### PR TITLE
Add headless mode configuration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,6 +23,32 @@ cd skills/dev-browser && bun run test
 cd skills/dev-browser && bun x tsc --noEmit
 ```
 
+## Headless Mode
+
+The dev-browser server can run in headless mode (no visible browser window) or headed mode (shows browser window).
+
+```bash
+# Headed mode (default, shows browser window for debugging)
+cd skills/dev-browser && bun run start-server
+
+# Headless mode via CLI flag (no visible browser)
+cd skills/dev-browser && bun run start-server -- --headless
+
+# Headless mode via environment variable (useful for CI/automation)
+DEV_BROWSER_HEADLESS=true cd skills/dev-browser && bun run start-server
+
+# CLI flags override environment variables
+DEV_BROWSER_HEADLESS=true cd skills/dev-browser && bun run start-server -- --no-headless  # Will be headed
+
+# Show available options
+cd skills/dev-browser && bun run start-server -- --help
+```
+
+**Use Cases:**
+
+- **Headed mode** (default): Best for development and debugging - you can see what the browser is doing
+- **Headless mode**: Best for CI/automation, background tasks, or when you don't need visual feedback
+
 ## Important: Before Completing Code Changes
 
 **Always run these checks before considering a task complete:**

--- a/skills/dev-browser/SKILL.md
+++ b/skills/dev-browser/SKILL.md
@@ -20,8 +20,20 @@ Browser automation that maintains page state across script executions. Write sma
 First, start the dev-browser server. It will automatically install Chromium on first run if needed:
 
 ```bash
+# Headed mode (default) - shows browser window
 cd skills/dev-browser && bun run start-server &
+
+# Headless mode - no visible browser window (useful for automation)
+cd skills/dev-browser && bun run start-server -- --headless &
+
+# Or using environment variable
+DEV_BROWSER_HEADLESS=true cd skills/dev-browser && bun run start-server &
 ```
+
+**Headless vs Headed Mode:**
+
+- **Headed** (default): Browser window is visible. Use when the user wants to see what's happening or for debugging.
+- **Headless**: No browser window. Use for automation tasks, when the user doesn't need visual feedback, or when running in CI/background.
 
 **Wait for the `Ready` message before running scripts.** On first run, the server will:
 

--- a/skills/dev-browser/scripts/start-server.ts
+++ b/skills/dev-browser/scripts/start-server.ts
@@ -1,4 +1,5 @@
 import { serve } from "@/index.js";
+import type { ServeOptions } from "@/types.js";
 import { execSync } from "child_process";
 import { mkdirSync, existsSync, readdirSync } from "fs";
 import { join, dirname } from "path";
@@ -7,6 +8,59 @@ import { fileURLToPath } from "url";
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const tmpDir = join(__dirname, "..", "tmp");
 const profileDir = join(__dirname, "..", "profiles");
+
+const HELP_TEXT = `
+dev-browser server
+
+Options:
+  --headless          Run browser in headless mode
+  --no-headless       Run browser in headed mode (default)
+  --port <number>     HTTP API port (default: 9222)
+  --cdp-port <number> CDP debugging port (default: 9223)
+  --help             Show this help message
+
+Environment Variables:
+  DEV_BROWSER_HEADLESS=true   Run in headless mode
+`;
+
+// Parse CLI arguments and environment variables
+function parseConfig(): Partial<ServeOptions> {
+  const args = process.argv.slice(2);
+  const config: Partial<ServeOptions> = {};
+
+  // Environment variable support
+  if (process.env.DEV_BROWSER_HEADLESS) {
+    config.headless = process.env.DEV_BROWSER_HEADLESS.toLowerCase() === "true";
+  }
+
+  // CLI arguments (override env vars)
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === "--headless") {
+      config.headless = true;
+    } else if (args[i] === "--no-headless") {
+      config.headless = false;
+    } else if (args[i] === "--port") {
+      const value = args[++i];
+      if (value === undefined) {
+        console.error("Error: --port requires a value");
+        process.exit(1);
+      }
+      config.port = parseInt(value, 10);
+    } else if (args[i] === "--cdp-port") {
+      const value = args[++i];
+      if (value === undefined) {
+        console.error("Error: --cdp-port requires a value");
+        process.exit(1);
+      }
+      config.cdpPort = parseInt(value, 10);
+    } else if (args[i] === "--help") {
+      console.log(HELP_TEXT);
+      process.exit(0);
+    }
+  }
+
+  return config;
+}
 
 // Create tmp and profile directories if they don't exist
 console.log("Creating tmp directory...");
@@ -93,13 +147,16 @@ try {
 }
 
 console.log("Starting dev browser server...");
+const config = parseConfig();
 const server = await serve({
-  port: 9222,
-  headless: false,
+  port: config.port ?? 9222,
+  headless: config.headless ?? false,
+  cdpPort: config.cdpPort ?? 9223,
   profileDir,
 });
 
 console.log(`Dev browser server started`);
+console.log(`  Mode: ${(config.headless ?? false) ? "headless" : "headed"}`);
 console.log(`  WebSocket: ${server.wsEndpoint}`);
 console.log(`  Tmp directory: ${tmpDir}`);
 console.log(`  Profile directory: ${profileDir}`);


### PR DESCRIPTION
## Summary

Adds headless mode configuration to the dev-browser server via CLI flags and environment variables. This allows users to run the browser in headless mode (no visible window) for automation tasks, CI environments, or when visual feedback isn't needed.

## Changes

- **CLI flags**: `--headless`, `--no-headless`, `--port`, `--cdp-port`, `--help`
- **Environment variable**: `DEV_BROWSER_HEADLESS=true`
- **Configuration priority**: CLI args > env vars > default (headed mode)
- **Documentation**: Updated CLAUDE.md and SKILL.md with usage examples and guidance

## Usage

```bash
# Headed mode (default)
bun run start-server

# Headless via CLI
bun run start-server -- --headless

# Headless via environment variable
DEV_BROWSER_HEADLESS=true bun run start-server
```

## Testing

- ✅ TypeScript check passes
- ✅ All tests pass (9/9)
- ✅ Backward compatible (default behavior unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)