### PR TITLE
feat: add multi-port support for parallel server instances

### DIFF
--- a/skills/dev-browser/server.sh
+++ b/skills/dev-browser/server.sh
@@ -8,9 +8,14 @@ cd "$SCRIPT_DIR"
 
 # Parse command line arguments
 HEADLESS=false
+PORT=9222
+CDP_PORT=""
+
 while [[ "$#" -gt 0 ]]; do
     case $1 in
         --headless) HEADLESS=true ;;
+        --port) PORT="$2"; shift ;;
+        --cdp-port) CDP_PORT="$2"; shift ;;
         *) echo "Unknown parameter: $1"; exit 1 ;;
     esac
     shift
@@ -19,6 +24,8 @@ done
 echo "Installing dependencies..."
 npm install
 
-echo "Starting dev-browser server..."
+echo "Starting dev-browser server on port $PORT..."
 export HEADLESS=$HEADLESS
+export PORT=$PORT
+export CDP_PORT=$CDP_PORT
 npx tsx scripts/start-server.ts


### PR DESCRIPTION
Add --port and --cdp-port CLI flags to server.sh to enable running multiple dev-browser instances in parallel. This allows different subagents to each control their own browser instance.

Usage:
  ./server.sh --port 9222  # instance 1
  ./server.sh --port 9224  # instance 2 (parallel)

CDP port defaults to port + 1 unless explicitly set via --cdp-port.