### PR TITLE
Add "Run in Smithery" badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,9 @@ A browser automation plugin for [Claude Code](https://docs.anthropic.com/en/docs
 
 ## Prerequisites
 
+[![Run in Smithery](https://smithery.ai/badge/skills/sawyerhood)](https://smithery.ai/skills?ns=sawyerhood&utm_source=github&utm_medium=badge)
+
+
 - [Claude Code](https://docs.anthropic.com/en/docs/claude-code) CLI installed
 - [Node.js](https://nodejs.org) (v18 or later) with npm
 


### PR DESCRIPTION
## Add skill discoverability badge

Your 1 Claude skill is already indexed on [Smithery](https://smithery.ai), a directory of Agent Skills and MCP servers. This badge links users directly to your skills.

### Badge Preview
[![Run in Smithery](https://smithery.ai/badge/skills/SawyerHood)](https://smithery.ai/skills?ns=SawyerHood&utm_source=github&utm_medium=badge)

### Why add this?
- Users browsing your repo can discover and install your skills with one click
- No additional setup required - your skills are already listed

---

This is optional. Feel free to close if you prefer not to add external badges.