### PR TITLE
fix: add --input-type=module to heredoc examples

### DIFF
--- a/skills/dev-browser/SKILL.md
+++ b/skills/dev-browser/SKILL.md
@@ -58,7 +58,7 @@ If the extension hasn't connected yet, tell the user to launch and activate it. 
 Execute scripts inline using heredocs:
 
 ```bash
-cd skills/dev-browser && npx tsx <<'EOF'
+cd skills/dev-browser && npx tsx --input-type=module <<'EOF'
 import { connect, waitForPageLoad } from "@/client.js";
 
 const client = await connect();
@@ -190,7 +190,7 @@ await element.click();
 Page state persists after failures. Debug with:
 
 ```bash
-cd skills/dev-browser && npx tsx <<'EOF'
+cd skills/dev-browser && npx tsx --input-type=module <<'EOF'
 import { connect } from "@/client.js";
 
 const client = await connect();


### PR DESCRIPTION
## Problem

The heredoc examples in SKILL.md fail with:
```
SyntaxError: Cannot use import statement outside a module
```

This happens because `tsx` reading from stdin doesn't know to treat the input as an ES module (no file extension to indicate module type).

I'll note the agent was able to find alternative approaches to this failure but it took a couple minutes and slowed down this part of the workflow.

## Solution

Add `--input-type=module` flag to all `npx tsx` heredoc commands:
```bash
# Before
npx tsx <<'EOF'

# After
npx tsx --input-type=module <<'EOF'
```

## Testing

Verified the fix works with Node.js v18.20.8 and tsx.

## Changes

- Updated heredoc example in 'Writing Scripts' section (line 61)
- Updated heredoc example in 'Error Recovery' section (line 193)