### PR TITLE
Add remote access support with WebSocket proxy and lazy launch

### DIFF
--- a/skills/dev-browser/package.json
+++ b/skills/dev-browser/package.json
@@ -13,10 +13,12 @@
   },
   "dependencies": {
     "express": "^4.21.0",
-    "playwright": "^1.49.0"
+    "playwright": "^1.49.0",
+    "ws": "^8.18.0"
   },
   "devDependencies": {
     "@types/express": "^5.0.0",
+    "@types/ws": "^8.5.13",
     "tsx": "^4.21.0",
     "vitest": "^2.1.0"
   }

--- a/skills/dev-browser/scripts/start-server.ts
+++ b/skills/dev-browser/scripts/start-server.ts
@@ -100,14 +100,22 @@ try {
 
 console.log("Starting dev browser server...");
 const headless = process.env.HEADLESS === "true";
+const host = process.env.HOST ?? "localhost";
+const lazy = process.env.LAZY === "true";
 const server = await serve({
   port: 9222,
+  host,
   headless,
+  lazy,
   profileDir,
 });
 
 console.log(`Dev browser server started`);
-console.log(`  WebSocket: ${server.wsEndpoint}`);
+if (lazy) {
+  console.log(`  Mode: lazy (browser launches on first request)`);
+} else {
+  console.log(`  WebSocket: ${server.wsEndpoint}`);
+}
 console.log(`  Tmp directory: ${tmpDir}`);
 console.log(`  Profile directory: ${profileDir}`);
 console.log(`\nReady`);

--- a/skills/dev-browser/src/types.ts
+++ b/skills/dev-browser/src/types.ts
@@ -2,10 +2,14 @@
 
 export interface ServeOptions {
   port?: number;
+  /** Host to bind the server to. Defaults to "localhost". Use "0.0.0.0" for remote access. */
+  host?: string;
   headless?: boolean;
   cdpPort?: number;
   /** Directory to store persistent browser profiles (cookies, localStorage, etc.) */
   profileDir?: string;
+  /** If true, Chrome is not launched until first client request. Defaults to false. */
+  lazy?: boolean;
 }
 
 export interface GetPageRequest {


### PR DESCRIPTION
Adds support for running the dev-browser server remotely over a network.

## Features

- **host option**: Bind server to custom address (use `0.0.0.0` for remote access)
- **WebSocket proxy**: Routes CDP connections through the HTTP server, working around Chrome ignoring `--remote-debugging-address` on macOS
- **lazy option**: Delay browser launch until first client request

## Environment Variables

- `HOST`: Server bind address (default: `localhost`)
- `LAZY`: Set to `true` for lazy browser launch

## Usage

```bash
HOST=0.0.0.0 bun run scripts/start-server.ts
```

## Why WebSocket Proxy?

On macOS, Chrome ignores the `--remote-debugging-address` flag and always binds the CDP WebSocket to localhost. This proxy routes WebSocket connections from the HTTP server port to Chrome's internal CDP port, enabling remote connections.

## Tested

- Remote connections from Linux server to macOS (both Intel and Apple Silicon)
- Lazy mode startup and immediate mode
- WebSocket proxy with Playwright CDP connections