### PR TITLE
`DEV_BROWSER_EXECUTABLE_PATH` for custom chromium binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,10 @@ The Chrome extension allows Dev Browser to control your existing Chrome browser 
 
 When active, Claude can control your existing Chrome tabs with all your logged-in sessions, cookies, and extensions intact.
 
+## Configuration
+
+Optionally set `DEV_BROWSER_EXECUTABLE_PATH` to use a custom Chromium binary.
+
 ## Permissions
 
 To skip permission prompts, add to `~/.claude/settings.json`:

--- a/skills/dev-browser/src/index.ts
+++ b/skills/dev-browser/src/index.ts
@@ -82,6 +82,7 @@ export async function serve(options: ServeOptions = {}): Promise<DevBrowserServe
   // Launch persistent context - this persists cookies, localStorage, cache, etc.
   const context: BrowserContext = await chromium.launchPersistentContext(userDataDir, {
     headless,
+    executablePath: process.env.DEV_BROWSER_EXECUTABLE_PATH || undefined,
     args: [`--remote-debugging-port=${cdpPort}`],
   });
   console.log("Browser launched with persistent profile...");


### PR DESCRIPTION
Hi Sawyer, great skill, also a big fan of Terragon :+1: 

I run NixOS where Playwright's bundled Chromium doesn't work out of the box (it's a whole thing!) - this is a minimal change to allow passing a preinstalled chromium path.