### PR TITLE
fix: add files field to skill package.json to exclude unnecessary files

### DIFF
--- a/skills/dev-browser/package.json
+++ b/skills/dev-browser/package.json
@@ -1,6 +1,13 @@
 {
   "name": "dev-browser",
   "version": "0.0.1",
+  "files": [
+    "src/",
+    "references/",
+    "SKILL.md",
+    "server.sh",
+    "package.json"
+  ],
   "type": "module",
   "imports": {
     "@/*": "./src/*"


### PR DESCRIPTION
## Summary

Fixes #47

When the dev-browser skill is installed in Amp/other agents, it includes unnecessary files that waste context tokens and slow down skill loading.

## Problem

The skill directory currently includes:
- `tmp/*.png` (accumulated screenshots)
- `tsconfig.json`
- `vitest.config.ts`
- `bun.lock`
- `scripts/`

## Solution

Add explicit `files` field to `skills/dev-browser/package.json`:

```json
"files": [
  "src/",
  "references/",
  "SKILL.md",
  "server.sh",
  "package.json"
]
```

## Result

- **Before**: All files in directory
- **After**: Only 12 production files (27.8 kB total)

Verified with `npm pack --dry-run`:
```
npm notice total files: 12
npm notice package size: 27.8 kB
```