### PR TITLE
Add OpenPackage manifest

### DIFF
--- a/openpackage.yml
+++ b/openpackage.yml
@@ -1,0 +1,8 @@
+name: dev-browser
+version: 1.0.0
+description: Browser automation for Claude Code. Control your browser to test and verify your work as you develop.
+author: Sawyer Hood
+license: MIT
+
+includes:
+  - skills/dev-browser/**/*


### PR DESCRIPTION
Enables installation via opkg install dev-browser

Adds openpackage.yml manifest for opkg compatibility.