### PR TITLE
Add Claude Code SDK to Related Projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,10 @@ Pages are full [Playwright Page objects](https://playwright.dev/docs/api/class-p
 
 _See [dev-browser-eval](https://github.com/SawyerHood/dev-browser-eval) for methodology._
 
+## Related Projects
+
+- [Claude Code SDK](https://github.com/SeifBenayed/claude-code-sdk) — Open-source, provider-agnostic SDK (Node.js, Python, Go, Rust) implementing the Claude Code tool loop. Run skills and browser automation on any LLM backend.
+
 ## License
 
 MIT


### PR DESCRIPTION
## Summary

Adds a Related Projects section with [Claude Code SDK](https://github.com/SeifBenayed/claude-code-sdk).

**What it is:** An open-source, provider-agnostic SDK (Node.js, Python, Go, Rust) implementing the Claude Code tool loop. Enables running dev-browser and other skills on any LLM backend — Anthropic, OpenAI, Ollama, LM Studio, and more. Fully open source, zero dependencies.