### PR TITLE
fix: bound listPages title lookup

### DIFF
--- a/daemon/src/browser-manager-title-timeout.test.ts
+++ b/daemon/src/browser-manager-title-timeout.test.ts
@@ -1,0 +1,83 @@
+import type { Browser, BrowserContext, Page } from "playwright";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { BrowserManager, type BrowserEntry } from "./browser-manager.js";
+
+const browserName = "browser-manager-title-timeout";
+
+type BrowserManagerInternals = {
+  browsers: Map<string, BrowserEntry>;
+  getPageTargetId: (context: BrowserContext, page: Page) => Promise<string | null>;
+};
+
+function createMockEntry(page: Page): BrowserEntry {
+  const context = {
+    pages: () => [page],
+  } as unknown as BrowserContext;
+
+  const browser = {
+    contexts: () => [context],
+    isConnected: () => true,
+  } as unknown as Browser;
+
+  return {
+    name: browserName,
+    type: "connected",
+    browser,
+    context,
+    pages: new Map(),
+    endpoint: "ws://127.0.0.1:9222/devtools/browser/test",
+    headless: false,
+  };
+}
+
+describe("BrowserManager listPages title handling", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("falls back to an empty title when page.title never resolves", async () => {
+    vi.useFakeTimers();
+
+    const page = {
+      isClosed: () => false,
+      on: () => undefined,
+      title: () => new Promise<string>(() => {}),
+      url: () => "chrome://blank",
+    } as unknown as Page;
+
+    const manager = new BrowserManager("/tmp/dev-browser-title-timeout");
+    const internals = manager as unknown as BrowserManagerInternals;
+    internals.browsers.set(browserName, createMockEntry(page));
+    vi.spyOn(internals, "getPageTargetId").mockResolvedValue("target-1");
+
+    const pagesPromise = manager.listPages(browserName);
+    await vi.advanceTimersByTimeAsync(1_500);
+
+    await expect(pagesPromise).resolves.toEqual([
+      {
+        id: "target-1",
+        name: null,
+        title: "",
+        url: "chrome://blank",
+      },
+    ]);
+  });
+
+  it("still surfaces page.title errors when the page remains open", async () => {
+    const page = {
+      isClosed: () => false,
+      on: () => undefined,
+      title: () => Promise.reject(new Error("title failed")),
+      url: () => "chrome://broken",
+    } as unknown as Page;
+
+    const manager = new BrowserManager("/tmp/dev-browser-title-errors");
+    const internals = manager as unknown as BrowserManagerInternals;
+    internals.browsers.set(browserName, createMockEntry(page));
+    vi.spyOn(internals, "getPageTargetId").mockResolvedValue("target-2");
+
+    await expect(manager.listPages(browserName)).rejects.toThrow("title failed");
+  });
+});

--- a/daemon/src/browser-manager.ts
+++ b/daemon/src/browser-manager.ts
@@ -50,6 +50,7 @@ type DebuggerWebSocketLookupResult =
 const DISCOVERY_PORTS = [9222, 9223, 9224, 9225, 9226, 9227, 9228, 9229];
 const PROBE_TIMEOUT_MS = 750;
 const MANUAL_CONNECT_TIMEOUT_MS = 5_000;
+const PAGE_TITLE_TIMEOUT_MS = 1_500;
 const TARGET_ID_PATTERN = /^[a-f0-9]{16,}$/i;
 
 function isIgnorableFileError(error: unknown): boolean {
@@ -237,7 +238,7 @@ export class BrowserManager {
 
       let title = "";
       try {
-        title = await page.title();
+        title = await this.getPageTitle(page);
       } catch (error) {
         if (page.isClosed()) {
           continue;
@@ -790,6 +791,23 @@ export class BrowserManager {
     }
 
     return pages;
+  }
+
+  private async getPageTitle(page: Page): Promise<string> {
+    let timeoutId: ReturnType<typeof setTimeout> | undefined;
+
+    try {
+      return await Promise.race([
+        page.title(),
+        new Promise<string>((resolve) => {
+          timeoutId = setTimeout(() => resolve(""), PAGE_TITLE_TIMEOUT_MS);
+        }),
+      ]);
+    } finally {
+      if (timeoutId !== undefined) {
+        clearTimeout(timeoutId);
+      }
+    }
   }
 
   private async findPageByTargetId(entry: BrowserEntry, targetId: string): Promise<Page | null> {


### PR DESCRIPTION
Closes #71.

## Summary

`browser.listPages()` can hang indefinitely when one attached target never resolves `page.title()`.

This changes `BrowserManager.listPages()` to bound title lookup with a short timeout and fall back to an empty title for that target, while preserving the existing behavior for real `page.title()` errors when the page is still open.

## Why this change

In a live Chrome session connected over CDP, I hit blank targets with `url: ""` where Playwright's `page.title()` never settled. Because `listPages()` awaited every title serially with no timeout, one bad target blocked discovery for the entire browser session.

## What changed

- add a bounded `getPageTitle()` helper in `daemon/src/browser-manager.ts`
- use that helper from `listPages()` instead of awaiting `page.title()` directly
- add a deterministic regression test for a target whose `title()` promise never resolves
- add a regression test to ensure real `page.title()` errors still propagate

## Validation

Ran locally in `daemon/`:

- `pnpm exec tsc --noEmit`
- `pnpm run format:check`
- `pnpm run bundle`
- `pnpm run bundle:sandbox-client`
- `pnpm vitest run src/browser-manager-title-timeout.test.ts`
- `pnpm exec playwright install chromium`
- `pnpm vitest run`
