### PR TITLE
fix: add install lock to prevent concurrent npm install corruption

### DIFF
--- a/daemon/src/daemon.ts
+++ b/daemon/src/daemon.ts
@@ -3,6 +3,7 @@ import { mkdir, unlink, writeFile } from "node:fs/promises";
 import net from "node:net";
 import path from "node:path";
 import { BrowserManager } from "./browser-manager.js";
+import { createKeyedLock, createMutex } from "./lock.js";
 import {
   getBrowsersDir,
   getDaemonEndpoint,
@@ -33,7 +34,8 @@ const EMBEDDED_PACKAGE_JSON = JSON.stringify({
 
 const manager = new BrowserManager(BROWSERS_DIR);
 const startedAt = Date.now();
-const browserLocks = new Map<string, Promise<void>>();
+const withBrowserLock = createKeyedLock<string>();
+const withInstallLock = createMutex();
 const clients = new Set<net.Socket>();
 
 let server: net.Server | null = null;
@@ -110,27 +112,6 @@ async function closeClientSocket(socket: net.Socket): Promise<void> {
   });
 }
 
-async function withBrowserLock<T>(browserName: string, action: () => Promise<T>): Promise<T> {
-  const previous = browserLocks.get(browserName) ?? Promise.resolve();
-  let release!: () => void;
-  const current = new Promise<void>((resolve) => {
-    release = resolve;
-  });
-  const tail = previous.catch(() => undefined).then(() => current);
-  browserLocks.set(browserName, tail);
-
-  await previous.catch(() => undefined);
-
-  try {
-    return await action();
-  } finally {
-    release();
-    if (browserLocks.get(browserName) === tail) {
-      browserLocks.delete(browserName);
-    }
-  }
-}
-
 function createMessageQueue(socket: net.Socket) {
   let queue = Promise.resolve();
 
@@ -204,33 +185,35 @@ async function handleExecute(socket: net.Socket, request: ExecuteRequest): Promi
 }
 
 async function handleInstall(socket: net.Socket, request: { id: string }): Promise<void> {
-  const output = createMessageQueue(socket);
-  try {
-    await mkdir(BASE_DIR, { recursive: true });
-    await writeFile(path.join(BASE_DIR, "package.json"), EMBEDDED_PACKAGE_JSON);
-    const npmProgram = process.platform === "win32" ? "npm.cmd" : "npm";
-    await runInstallCommand(output, request.id, npmProgram, ["install"], BASE_DIR, "npm install");
-    await runInstallCommand(
-      output,
-      request.id,
-      npmProgram,
-      ["exec", "--", "playwright", "install", "chromium"],
-      BASE_DIR,
-      "Playwright install"
-    );
-    await writeMessage(socket, {
-      id: request.id,
-      type: "complete",
-      success: true,
-    });
-  } catch (error) {
-    await output.drain().catch(() => undefined);
-    await writeMessage(socket, {
-      id: request.id,
-      type: "error",
-      message: formatError(error),
-    });
-  }
+  await withInstallLock(async () => {
+    const output = createMessageQueue(socket);
+    try {
+      await mkdir(BASE_DIR, { recursive: true });
+      await writeFile(path.join(BASE_DIR, "package.json"), EMBEDDED_PACKAGE_JSON);
+      const npmProgram = process.platform === "win32" ? "npm.cmd" : "npm";
+      await runInstallCommand(output, request.id, npmProgram, ["install"], BASE_DIR, "npm install");
+      await runInstallCommand(
+        output,
+        request.id,
+        npmProgram,
+        ["exec", "--", "playwright", "install", "chromium"],
+        BASE_DIR,
+        "Playwright install"
+      );
+      await writeMessage(socket, {
+        id: request.id,
+        type: "complete",
+        success: true,
+      });
+    } catch (error) {
+      await output.drain().catch(() => undefined);
+      await writeMessage(socket, {
+        id: request.id,
+        type: "error",
+        message: formatError(error),
+      });
+    }
+  });
 }
 
 async function runInstallCommand(

--- a/daemon/src/lock.test.ts
+++ b/daemon/src/lock.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+
+import { createKeyedLock, createMutex } from "./lock.js";
+
+function createDeferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  const promise = new Promise<T>((innerResolve) => {
+    resolve = innerResolve;
+  });
+
+  return { promise, resolve };
+}
+
+describe("createKeyedLock", () => {
+  it("serializes actions with the same key", async () => {
+    const withLock = createKeyedLock<string>();
+    const firstGate = createDeferred<void>();
+    const secondGate = createDeferred<void>();
+    const events: string[] = [];
+
+    const first = withLock("chromium", async () => {
+      events.push("first:start");
+      await firstGate.promise;
+      events.push("first:end");
+    });
+
+    await Promise.resolve();
+
+    const second = withLock("chromium", async () => {
+      events.push("second:start");
+      secondGate.resolve();
+      events.push("second:end");
+    });
+
+    await Promise.resolve();
+    expect(events).toEqual(["first:start"]);
+
+    firstGate.resolve();
+    await first;
+    await secondGate.promise;
+    await second;
+
+    expect(events).toEqual(["first:start", "first:end", "second:start", "second:end"]);
+  });
+});
+
+describe("createMutex", () => {
+  it("serializes all actions through a single lock", async () => {
+    const withMutex = createMutex();
+    const firstGate = createDeferred<void>();
+    const secondStarted = createDeferred<void>();
+    const events: string[] = [];
+
+    const first = withMutex(async () => {
+      events.push("first:start");
+      await firstGate.promise;
+      events.push("first:end");
+    });
+
+    await Promise.resolve();
+
+    const second = withMutex(async () => {
+      events.push("second:start");
+      secondStarted.resolve();
+      events.push("second:end");
+    });
+
+    await Promise.resolve();
+    expect(events).toEqual(["first:start"]);
+
+    firstGate.resolve();
+    await first;
+    await secondStarted.promise;
+    await second;
+
+    expect(events).toEqual(["first:start", "first:end", "second:start", "second:end"]);
+  });
+});

--- a/daemon/src/lock.ts
+++ b/daemon/src/lock.ts
@@ -1,0 +1,35 @@
+type AsyncAction<T> = () => Promise<T>;
+
+export function createKeyedLock<K>() {
+  const locks = new Map<K, Promise<void>>();
+
+  return async function withLock<T>(key: K, action: AsyncAction<T>): Promise<T> {
+    const previous = locks.get(key) ?? Promise.resolve();
+    let release!: () => void;
+    const current = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const tail = previous.catch(() => undefined).then(() => current);
+    locks.set(key, tail);
+
+    await previous.catch(() => undefined);
+
+    try {
+      return await action();
+    } finally {
+      release();
+      if (locks.get(key) === tail) {
+        locks.delete(key);
+      }
+    }
+  };
+}
+
+export function createMutex() {
+  const withLock = createKeyedLock<symbol>();
+  const lockKey = Symbol("mutex");
+
+  return function withMutex<T>(action: AsyncAction<T>): Promise<T> {
+    return withLock(lockKey, action);
+  };
+}


### PR DESCRIPTION
Serializes concurrent `install` requests to the daemon so two simultaneous `npm install` runs can't corrupt `node_modules`.

- Extracted reusable promise-queue lock into `daemon/src/lock.ts`
- Wrapped `handleInstall` with dedicated mutex
- Added regression tests in `daemon/src/lock.test.ts`

Addresses I5 from #73.