### PR TITLE
Fix Playwright compatibility in embedded daemon

### DIFF
--- a/daemon/src/sandbox/forked-client/src/client/connection.ts
+++ b/daemon/src/sandbox/forked-client/src/client/connection.ts
@@ -38,6 +38,7 @@ import { LocalUtils } from "./localUtils";
 import { Request, Response, Route, WebSocket, WebSocketRoute } from "./network";
 import { BindingCall, Page } from "./page";
 import { Playwright } from "./playwright";
+import { SelectorsOwner } from "./selectors";
 import { Stream } from "./stream";
 import { Tracing } from "./tracing";
 import { Worker } from "./worker";
@@ -359,6 +360,9 @@ export class Connection extends EventEmitter {
         break;
       case "Stream":
         result = new Stream(parent, type, guid, initializer);
+        break;
+      case "Selectors":
+        result = new SelectorsOwner(parent, type, guid, initializer);
         break;
       case "SocksSupport":
         result = new DummyChannelOwner(parent, type, guid, initializer);

--- a/daemon/src/sandbox/forked-client/src/client/playwright.ts
+++ b/daemon/src/sandbox/forked-client/src/client/playwright.ts
@@ -22,7 +22,7 @@ import { ChannelOwner } from "./channelOwner";
 import { Electron } from "./electron";
 import { TimeoutError } from "./errors";
 import { APIRequest } from "./fetch";
-import { Selectors } from "./selectors";
+import { Selectors, SelectorsOwner } from "./selectors";
 
 import type * as channels from "../protocol/channels";
 import type { LaunchOptions } from "../../types/types";
@@ -63,6 +63,13 @@ export class Playwright extends ChannelOwner<channels.PlaywrightChannel> {
     this._electron._playwright = this;
     this.devices = this._connection.localUtils()?.devices ?? {};
     this.selectors = new Selectors(this._connection._platform);
+    if (initializer.selectors) {
+      const selectorsOwner = SelectorsOwner.from(initializer.selectors);
+      this.selectors._addChannel(selectorsOwner);
+      this._connection.on("close", () => {
+        this.selectors._removeChannel(selectorsOwner);
+      });
+    }
     this.errors = { TimeoutError };
   }
 

--- a/daemon/src/sandbox/forked-client/src/client/selectors.ts
+++ b/daemon/src/sandbox/forked-client/src/client/selectors.ts
@@ -16,6 +16,7 @@
  */
 
 import { evaluationScript } from "./clientHelper";
+import { ChannelOwner } from "./channelOwner";
 import { setTestIdAttribute } from "./locator";
 
 import type { SelectorEngine } from "./types";
@@ -28,6 +29,7 @@ export class Selectors implements api.Selectors {
   private _platform: Platform;
   private _selectorEngines: channels.SelectorEngine[] = [];
   private _testIdAttributeName: string | undefined;
+  readonly _channels = new Set<SelectorsOwner>();
   readonly _contextsForSelectors = new Set<BrowserContext>();
 
   constructor(platform: Platform) {
@@ -44,6 +46,9 @@ export class Selectors implements api.Selectors {
 
     const source = await evaluationScript(this._platform, script, undefined, false);
     const selectorEngine: channels.SelectorEngine = { ...options, name, source };
+    for (const channel of this._channels) {
+      await channel._channel.register(selectorEngine);
+    }
     for (const context of this._contextsForSelectors)
       await context._channel.registerSelectorEngine({ selectorEngine });
     this._selectorEngines.push(selectorEngine);
@@ -52,6 +57,11 @@ export class Selectors implements api.Selectors {
   setTestIdAttribute(attributeName: string) {
     this._testIdAttributeName = attributeName;
     setTestIdAttribute(attributeName);
+    for (const channel of this._channels) {
+      channel._channel
+        .setTestIdAttributeName({ testIdAttributeName: attributeName })
+        .catch(() => {});
+    }
     for (const context of this._contextsForSelectors) {
       context._options.testIdAttributeName = attributeName;
       context._channel
@@ -66,5 +76,27 @@ export class Selectors implements api.Selectors {
       selectorEngines: this._selectorEngines,
       testIdAttributeName: this._testIdAttributeName,
     };
+  }
+
+  _addChannel(channel: SelectorsOwner) {
+    this._channels.add(channel);
+    for (const selectorEngine of this._selectorEngines) {
+      channel._channel.register(selectorEngine).catch(() => {});
+    }
+    if (this._testIdAttributeName) {
+      channel._channel
+        .setTestIdAttributeName({ testIdAttributeName: this._testIdAttributeName })
+        .catch(() => {});
+    }
+  }
+
+  _removeChannel(channel: SelectorsOwner) {
+    this._channels.delete(channel);
+  }
+}
+
+export class SelectorsOwner extends ChannelOwner<channels.SelectorsChannel> {
+  static from(channel: channels.SelectorsChannel): SelectorsOwner {
+    return (channel as any)._object;
   }
 }

--- a/daemon/src/sandbox/forked-client/src/protocol/validator.ts
+++ b/daemon/src/sandbox/forked-client/src/protocol/validator.ts
@@ -410,6 +410,7 @@ scheme.PlaywrightInitializer = tObject({
   android: tChannel(["Android"]),
   electron: tChannel(["Electron"]),
   utils: tOptional(tChannel(["LocalUtils"])),
+  selectors: tOptional(tChannel(["Selectors"])),
   preLaunchedBrowser: tOptional(tChannel(["Browser"])),
   preConnectedAndroidDevice: tOptional(tChannel(["AndroidDevice"])),
   socksSupport: tOptional(tChannel(["SocksSupport"])),
@@ -559,6 +560,17 @@ scheme.SocksSupportSocksEndParams = tObject({
   uid: tString,
 });
 scheme.SocksSupportSocksEndResult = tOptional(tObject({}));
+scheme.SelectorsInitializer = tOptional(tObject({}));
+scheme.SelectorsRegisterParams = tObject({
+  name: tString,
+  source: tString,
+  contentScript: tOptional(tBoolean),
+});
+scheme.SelectorsRegisterResult = tOptional(tObject({}));
+scheme.SelectorsSetTestIdAttributeNameParams = tObject({
+  testIdAttributeName: tString,
+});
+scheme.SelectorsSetTestIdAttributeNameResult = tOptional(tObject({}));
 scheme.BrowserTypeInitializer = tObject({
   executablePath: tString,
   name: tString,

--- a/daemon/src/sandbox/host-bridge.ts
+++ b/daemon/src/sandbox/host-bridge.ts
@@ -2,6 +2,7 @@ import {
   DispatcherConnection,
   type DispatcherConnectionLike,
   PlaywrightDispatcher,
+  type PlaywrightDispatcherCtorArgs,
   type PlaywrightDispatcherLike,
   RootDispatcher,
   type RootDispatcherLike,
@@ -26,6 +27,23 @@ export class HostBridge {
   private playwrightDispatcher?: PlaywrightDispatcherLike;
   private disposed = false;
 
+  private createPlaywrightDispatcher(rootScope: unknown): PlaywrightDispatcherLike {
+    const dispatcherArgs: PlaywrightDispatcherCtorArgs =
+      PlaywrightDispatcher.length >= 4
+        ? [rootScope, this.playwright, undefined, this.options.preLaunchedBrowser, undefined]
+        : [
+            rootScope,
+            this.playwright,
+            {
+              preLaunchedBrowser: this.options.preLaunchedBrowser,
+              sharedBrowser: this.options.sharedBrowser,
+              denyLaunch: this.options.denyLaunch,
+            },
+          ];
+
+    return new PlaywrightDispatcher(...dispatcherArgs);
+  }
+
   constructor(options: HostBridgeOptions) {
     this.sendToSandbox = options.sendToSandbox;
     this.options = {
@@ -42,11 +60,7 @@ export class HostBridge {
       this.sendToSandbox(JSON.stringify(message));
     };
     this.rootDispatcher = new RootDispatcher(this.dispatcherConnection, async (rootScope) => {
-      this.playwrightDispatcher = new PlaywrightDispatcher(rootScope, this.playwright, {
-        preLaunchedBrowser: this.options.preLaunchedBrowser,
-        sharedBrowser: this.options.sharedBrowser,
-        denyLaunch: this.options.denyLaunch,
-      });
+      this.playwrightDispatcher = this.createPlaywrightDispatcher(rootScope);
       return this.playwrightDispatcher;
     });
   }

--- a/daemon/src/sandbox/playwright-internals.ts
+++ b/daemon/src/sandbox/playwright-internals.ts
@@ -45,6 +45,16 @@ export interface HostBridgeDispatcherOptions {
   denyLaunch?: boolean;
 }
 
+export type PlaywrightDispatcherCtorArgs =
+  | [scope: unknown, playwright: unknown, options?: HostBridgeDispatcherOptions]
+  | [
+      scope: unknown,
+      playwright: unknown,
+      socksProxy?: unknown,
+      preLaunchedBrowser?: unknown,
+      prelaunchedAndroidDevice?: unknown,
+    ];
+
 function resolvePlaywrightInternal(modulePath: string): string {
   const candidates = [
     path.resolve(currentDir, "../../node_modules/playwright-core", modulePath),
@@ -70,11 +80,7 @@ const serverInternals = require(
     connection: DispatcherConnectionLike,
     createPlaywright?: (scope: unknown, params: RootInitializeParams) => Promise<unknown>
   ) => RootDispatcherLike;
-  PlaywrightDispatcher: new (
-    scope: unknown,
-    playwright: unknown,
-    options?: HostBridgeDispatcherOptions
-  ) => PlaywrightDispatcherLike;
+  PlaywrightDispatcher: new (...args: PlaywrightDispatcherCtorArgs) => PlaywrightDispatcherLike;
 };
 
 const clientInternals = require(


### PR DESCRIPTION
Fix Playwright compatibility in the embedded daemon

Fixes #90
Refs #89

Summary

- Fix the host bridge to support both the legacy object-style `PlaywrightDispatcher` constructor and the newer positional constructor used by current Playwright internals.
- Add `Selectors` channel support to the forked sandbox client so the embedded client can deserialize current Playwright root objects without failing during initialization.

Problem

- With current `playwright` / `playwright-core` versions, the embedded daemon passes an options object into `PlaywrightDispatcher` where newer Playwright expects a `socksProxy` event emitter in that argument slot.
- The forked sandbox client also lacks `Selectors` protocol support, which causes initialization to fail with:
  `ValidationError: Unknown scheme for Initializer: Selectors.`

Root causes

1. `daemon/src/sandbox/host-bridge.ts` assumes an older `PlaywrightDispatcher` constructor shape.
2. The forked client protocol/client sources do not include the `Selectors` channel that current Playwright roots now expose.

What changed

- `daemon/src/sandbox/host-bridge.ts`
  - Add an adaptive `createPlaywrightDispatcher` helper that switches on constructor arity.
- `daemon/src/sandbox/playwright-internals.ts`
  - Widen the internal `PlaywrightDispatcher` constructor typing to support both signatures.
- `daemon/src/sandbox/forked-client/src/protocol/validator.ts`
  - Add `selectors` to `PlaywrightInitializer`.
  - Add `SelectorsInitializer`, `SelectorsRegister*`, and `SelectorsSetTestIdAttributeName*` schemas.
- `daemon/src/sandbox/forked-client/src/client/selectors.ts`
  - Add `SelectorsOwner` plus channel replay helpers.
- `daemon/src/sandbox/forked-client/src/client/playwright.ts`
  - Attach the selectors channel to the local selectors helper when present.
- `daemon/src/sandbox/forked-client/src/client/connection.ts`
  - Create `SelectorsOwner` instances when the wire protocol sends `type: "Selectors"`.

Verification

- `pnpm install` in `daemon/`
- `pnpm run build`
- `pnpm run bundle`
- `pnpm run bundle:sandbox-client`
- Runtime validation through the stock CLI using the source daemon override:
  - `DEV_BROWSER_DAEMON=/path/to/daemon/src/daemon.ts dev-browser --connect http://127.0.0.1:9222 <<'EOF' ...`
  - Minimal script now succeeds and prints `hi`.
  - A real-world navigation workflow now boots correctly instead of failing during daemon/sandbox initialization.
