### PR TITLE
fix: pin playwright to 1.58.2 to match forked sandbox client

### DIFF
--- a/daemon/package.json
+++ b/daemon/package.json
@@ -13,8 +13,8 @@
     "format:check": "prettier --check \"**/*.{ts,json,md}\""
   },
   "dependencies": {
-    "playwright": "^1.52.0",
-    "playwright-core": "^1.52.0",
+    "playwright": "1.58.2",
+    "playwright-core": "1.58.2",
     "quickjs-emscripten": "^0.32.0",
     "zod": "^3.25.76"
   },

--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
     "LICENSE"
   ],
   "dependencies": {
-    "playwright": "^1.52.0",
-    "playwright-core": "^1.52.0",
+    "playwright": "1.58.2",
+    "playwright-core": "1.58.2",
     "quickjs-emscripten": "^0.32.0"
   },
   "keywords": [


### PR DESCRIPTION
## Summary

Fixes #93

Pin `playwright` and `playwright-core` to `1.58.2` (exact version) in both `package.json` and `daemon/package.json` to match the wire protocol version the forked sandbox client was built against.

## Problem

The caret range `^1.52.0` resolves to `1.59.0` as of today. The Playwright wire protocol changed between 1.58.x and 1.59.0, causing a `ValidationError` during sandbox initialization — every script fails before any user code runs.

## Changes

- `package.json`: `^1.52.0` → `1.58.2` for playwright and playwright-core
- `daemon/package.json`: same change

## Testing

Before fix:
```
$ dev-browser --headless <<< 'console.log("hello")'
    at ValidationError (<input>:306:3)
    at dispatch (<input>:12346:45)
    at value (sandbox-init.js:35:36)
```

After fix:
```
$ dev-browser --headless <<< 'console.log("hello")'
hello
```

Also verified: `page.goto()`, `page.snapshotForAI()`, `page.screenshot()`, form interactions all work correctly after the fix.