### PR TITLE
docs: recommend domcontentloaded for dev server navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ dev-browser install    # installs Playwright + Chromium
 # Launch a headless browser and run a script
 dev-browser --headless <<'EOF'
 const page = await browser.getPage("main");
-await page.goto("https://example.com");
+await page.goto("https://example.com", { waitUntil: "domcontentloaded" });
 console.log(await page.title());
 EOF
 
@@ -42,7 +42,7 @@ EOF
 ```powershell
 @"
 const page = await browser.getPage("main");
-await page.goto("https://example.com");
+await page.goto("https://example.com", { waitUntil: "domcontentloaded" });
 console.log(await page.title());
 "@ | dev-browser
 ```

--- a/cli/llm-guide.txt
+++ b/cli/llm-guide.txt
@@ -60,6 +60,12 @@ LLM USAGE GUIDE:
     }, null, 2));
     EOF
 
+  Dev server navigation:
+    For local dev servers (Next.js, Vite, etc.), prefer:
+      await page.goto(url, { waitUntil: "domcontentloaded" });
+    The default "load" wait can hang on HMR, streaming, or other long-lived dev-server connections.
+    Use "load" only when you specifically need every subresource to finish loading.
+
   Error recovery:
     If a script fails, the page usually stays where it stopped.
     Reconnect to the same page name, take a screenshot, and log the URL/title:
@@ -74,7 +80,8 @@ LLM USAGE GUIDE:
     EOF
 
   Common Playwright Page methods:
-    page.goto(url)                         Navigate to a URL
+    page.goto(url, { waitUntil: "domcontentloaded" })
+                                           Navigate to a URL; prefer this on dev servers
     page.title()                           Get the current page title
     page.url()                             Get the current URL
     page.snapshotForAI(options)            Get an AI-optimized snapshot; returns { full, incremental? }


### PR DESCRIPTION
## Summary
- recommend `waitUntil: "domcontentloaded"` in the LLM guide for dev servers such as Next.js and Vite
- update all existing `page.goto()` examples in `cli/llm-guide.txt` to use the `domcontentloaded` pattern
- update `README.md` `page.goto()` examples to match

Refs #97