### PR TITLE
fix(daemon): Support live CDP Chrome attach

### DIFF
--- a/daemon/src/browser-manager.ts
+++ b/daemon/src/browser-manager.ts
@@ -534,7 +534,7 @@ export class BrowserManager {
     if (result.status === "ok") {
       return {
         endpoint: result.webSocketDebuggerUrl,
-        backend: "playwright",
+        backend: "live-cdp",
       };
     }
 
@@ -757,7 +757,7 @@ export class BrowserManager {
     if (result.status === "ok") {
       return {
         endpoint: result.webSocketDebuggerUrl,
-        backend: "playwright",
+        backend: "live-cdp",
       };
     }
 

--- a/daemon/src/browser-manager.ts
+++ b/daemon/src/browser-manager.ts
@@ -2,13 +2,26 @@ import { mkdir, readFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { chromium, type Browser, type BrowserContext, type Page } from "playwright";
+import {
+  createLiveCdpBrowser,
+  getLiveCdpPageTargetId,
+  isLiveCdpBrowser,
+  type LiveCdpBrowser,
+  type LiveCdpBrowserContext,
+  type LiveCdpPage,
+} from "./live-cdp-browser.js";
+
+type BrowserHandle = Browser | LiveCdpBrowser;
+type BrowserContextHandle = BrowserContext | LiveCdpBrowserContext;
+type BrowserPageHandle = Page | LiveCdpPage;
+export type BrowserPage = BrowserPageHandle;
 
 export interface BrowserEntry {
   name: string;
   type: "launched" | "connected";
-  browser: Browser;
-  context: BrowserContext;
-  pages: Map<string, Page>;
+  browser: BrowserHandle;
+  context: BrowserContextHandle;
+  pages: Map<string, BrowserPageHandle>;
   profileDir?: string;
   endpoint?: string;
   headless: boolean;
@@ -31,6 +44,7 @@ interface BrowserPageSummary {
 
 type BrowserManagerDependencies = {
   connectOverCDP: typeof chromium.connectOverCDP;
+  createLiveCdpBrowser: typeof createLiveCdpBrowser;
   fetch: typeof globalThis.fetch;
   homedir: () => string;
   launchPersistentContext: typeof chromium.launchPersistentContext;
@@ -48,6 +62,11 @@ type DebuggerWebSocketLookupResult =
       status: "not-found" | "unavailable";
     };
 
+type ConnectedEndpoint = {
+  endpoint: string;
+  backend: "playwright" | "live-cdp";
+};
+
 const DISCOVERY_PORTS = [9222, 9223, 9224, 9225, 9226, 9227, 9228, 9229];
 const PROBE_TIMEOUT_MS = 750;
 const MANUAL_CONNECT_TIMEOUT_MS = 5_000;
@@ -63,6 +82,18 @@ function isHttpEndpoint(endpoint: string): boolean {
   return endpoint.startsWith("http://") || endpoint.startsWith("https://");
 }
 
+function isWebSocketEndpoint(endpoint: string): boolean {
+  let url: URL;
+
+  try {
+    url = new URL(endpoint);
+  } catch {
+    return false;
+  }
+
+  return url.protocol === "ws:" || url.protocol === "wss:";
+}
+
 export class BrowserManager {
   private readonly browsers = new Map<string, BrowserEntry>();
   private readonly baseDir: string;
@@ -75,6 +106,7 @@ export class BrowserManager {
     this.baseDir = baseDir;
     this.dependencies = {
       connectOverCDP: chromium.connectOverCDP.bind(chromium) as typeof chromium.connectOverCDP,
+      createLiveCdpBrowser,
       fetch: globalThis.fetch,
       homedir: os.homedir,
       launchPersistentContext: chromium.launchPersistentContext.bind(
@@ -133,12 +165,12 @@ export class BrowserManager {
     const attemptedEndpoints = new Set<string>();
     let lastError: unknown;
 
-    const tryEndpoint = async (endpoint: string | null): Promise<BrowserEntry | null> => {
-      if (!endpoint || attemptedEndpoints.has(endpoint)) {
+    const tryEndpoint = async (endpoint: ConnectedEndpoint | null): Promise<BrowserEntry | null> => {
+      if (!endpoint || attemptedEndpoints.has(endpoint.endpoint)) {
         return null;
       }
 
-      attemptedEndpoints.add(endpoint);
+      attemptedEndpoints.add(endpoint.endpoint);
 
       try {
         return await this.openConnectedBrowser(name, endpoint);
@@ -148,7 +180,13 @@ export class BrowserManager {
       }
     };
 
-    const devToolsEndpoint = await this.readDevToolsActivePort();
+    const devToolsActivePortEndpoint = await this.readDevToolsActivePort();
+    const devToolsEndpoint = devToolsActivePortEndpoint
+      ? {
+          endpoint: devToolsActivePortEndpoint,
+          backend: "live-cdp" as const,
+        }
+      : null;
     const devToolsBrowser = await tryEndpoint(devToolsEndpoint);
     if (devToolsBrowser) {
       return devToolsBrowser;
@@ -177,7 +215,7 @@ export class BrowserManager {
     if (existing) {
       const isSameConnection =
         existing.type === "connected" &&
-        existing.endpoint === resolvedEndpoint &&
+        existing.endpoint === resolvedEndpoint.endpoint &&
         existing.browser.isConnected();
 
       if (isSameConnection) {
@@ -204,7 +242,7 @@ export class BrowserManager {
     const existingPage = entry.pages.get(pageNameOrId);
 
     if (existingPage && !existingPage.isClosed()) {
-      return existingPage;
+      return existingPage as Page;
     }
 
     entry.pages.delete(pageNameOrId);
@@ -212,24 +250,28 @@ export class BrowserManager {
     if (TARGET_ID_PATTERN.test(pageNameOrId)) {
       const page = await this.findPageByTargetId(entry, pageNameOrId);
       if (page) {
-        return page;
+        return page as Page;
       }
     }
 
     const page = await entry.context.newPage();
     this.registerNamedPage(entry, pageNameOrId, page);
-    return page;
+    return page as Page;
   }
 
   async newPage(browserName: string): Promise<Page> {
     const entry = this.getBrowserEntry(browserName);
-    return entry.context.newPage();
+    return (await entry.context.newPage()) as Page;
   }
 
   async listPages(browserName: string): Promise<BrowserPageSummary[]> {
     const entry = this.browsers.get(browserName);
     if (!entry || !entry.browser.isConnected()) {
       return [];
+    }
+
+    if (isLiveCdpBrowser(entry.browser)) {
+      await entry.browser.refreshPages();
     }
 
     this.pruneClosedPages(entry);
@@ -385,8 +427,14 @@ export class BrowserManager {
     return entry;
   }
 
-  private async openConnectedBrowser(name: string, endpoint: string): Promise<BrowserEntry> {
-    const browser = await this.dependencies.connectOverCDP(endpoint);
+  private async openConnectedBrowser(
+    name: string,
+    resolved: ConnectedEndpoint
+  ): Promise<BrowserEntry> {
+    const browser =
+      resolved.backend === "live-cdp"
+        ? await this.dependencies.createLiveCdpBrowser(resolved.endpoint)
+        : await this.dependencies.connectOverCDP(resolved.endpoint);
     const contexts = browser.contexts();
 
     // Enumerate existing tabs for connected browsers, but leave them unnamed so getPage(name)
@@ -403,7 +451,7 @@ export class BrowserManager {
       browser,
       context,
       pages: new Map(),
-      endpoint,
+      endpoint: resolved.endpoint,
       headless: false,
       ignoreHTTPSErrors: false,
     };
@@ -437,10 +485,13 @@ export class BrowserManager {
     }
   }
 
-  private async discoverChrome(): Promise<string | null> {
+  private async discoverChrome(): Promise<ConnectedEndpoint | null> {
     const devToolsEndpoint = await this.readDevToolsActivePort();
     if (devToolsEndpoint) {
-      return devToolsEndpoint;
+      return {
+        endpoint: devToolsEndpoint,
+        backend: "live-cdp",
+      };
     }
 
     for (const port of DISCOVERY_PORTS) {
@@ -476,16 +527,25 @@ export class BrowserManager {
     return null;
   }
 
-  private async probePort(port: number): Promise<string | null> {
+  private async probePort(port: number): Promise<ConnectedEndpoint | null> {
     const endpoint = `http://127.0.0.1:${port}`;
     const result = await this.fetchDebuggerWebSocketUrl(endpoint, PROBE_TIMEOUT_MS);
 
     if (result.status === "ok") {
-      return result.webSocketDebuggerUrl;
+      return {
+        endpoint: result.webSocketDebuggerUrl,
+        backend: "playwright",
+      };
     }
 
     if (result.status === "not-found") {
-      return this.readDevToolsActivePort(port);
+      const activePortEndpoint = await this.readDevToolsActivePort(port);
+      return activePortEndpoint
+        ? {
+            endpoint: activePortEndpoint,
+            backend: "live-cdp",
+          }
+        : null;
     }
 
     return null;
@@ -576,7 +636,7 @@ export class BrowserManager {
     }
   }
 
-  private async resolveEndpoint(endpoint: string): Promise<string> {
+  private async resolveEndpoint(endpoint: string): Promise<ConnectedEndpoint> {
     if (endpoint === "auto") {
       const discoveredEndpoint = await this.discoverChrome();
       if (discoveredEndpoint) {
@@ -599,7 +659,10 @@ export class BrowserManager {
       return discoveredEndpoint;
     }
 
-    return endpoint;
+    return {
+      endpoint,
+      backend: isWebSocketEndpoint(endpoint) ? "live-cdp" : "playwright",
+    };
   }
 
   private async fetchDebuggerWebSocketUrl(
@@ -686,16 +749,28 @@ export class BrowserManager {
     return details.join("\n");
   }
 
-  private async resolveHttpEndpoint(endpoint: string, timeoutMs: number): Promise<string | null> {
+  private async resolveHttpEndpoint(
+    endpoint: string,
+    timeoutMs: number
+  ): Promise<ConnectedEndpoint | null> {
     const result = await this.fetchDebuggerWebSocketUrl(endpoint, timeoutMs);
     if (result.status === "ok") {
-      return result.webSocketDebuggerUrl;
+      return {
+        endpoint: result.webSocketDebuggerUrl,
+        backend: "playwright",
+      };
     }
 
     if (result.status === "not-found") {
       const port = this.getEndpointPort(endpoint);
       if (port !== null) {
-        return this.readDevToolsActivePort(port);
+        const activePortEndpoint = await this.readDevToolsActivePort(port);
+        return activePortEndpoint
+          ? {
+              endpoint: activePortEndpoint,
+              backend: "live-cdp",
+            }
+          : null;
       }
     }
 
@@ -749,7 +824,7 @@ export class BrowserManager {
     ].join("\n");
   }
 
-  private registerNamedPage(entry: BrowserEntry, pageName: string, page: Page): void {
+  private registerNamedPage(entry: BrowserEntry, pageName: string, page: BrowserPageHandle): void {
     entry.pages.set(pageName, page);
 
     page.on("close", () => {
@@ -777,8 +852,8 @@ export class BrowserManager {
       .sort((left, right) => left.localeCompare(right));
   }
 
-  private getNamedPagesByPage(entry: BrowserEntry): Map<Page, string> {
-    const namesByPage = new Map<Page, string>();
+  private getNamedPagesByPage(entry: BrowserEntry): Map<BrowserPageHandle, string> {
+    const namesByPage = new Map<BrowserPageHandle, string>();
 
     for (const [name, page] of entry.pages.entries()) {
       if (!page.isClosed() && !namesByPage.has(page)) {
@@ -789,12 +864,14 @@ export class BrowserManager {
     return namesByPage;
   }
 
-  private getBrowserContexts(entry: BrowserEntry): BrowserContext[] {
+  private getBrowserContexts(entry: BrowserEntry): BrowserContextHandle[] {
     return [...new Set([entry.context, ...entry.browser.contexts()])];
   }
 
-  private getContextPages(entry: BrowserEntry): Array<{ context: BrowserContext; page: Page }> {
-    const pages: Array<{ context: BrowserContext; page: Page }> = [];
+  private getContextPages(
+    entry: BrowserEntry
+  ): Array<{ context: BrowserContextHandle; page: BrowserPageHandle }> {
+    const pages: Array<{ context: BrowserContextHandle; page: BrowserPageHandle }> = [];
 
     for (const context of this.getBrowserContexts(entry)) {
       for (const page of context.pages()) {
@@ -807,7 +884,7 @@ export class BrowserManager {
     return pages;
   }
 
-  private async getPageTitle(page: Page): Promise<string> {
+  private async getPageTitle(page: BrowserPageHandle): Promise<string> {
     let timeoutId: ReturnType<typeof setTimeout> | undefined;
 
     try {
@@ -824,7 +901,14 @@ export class BrowserManager {
     }
   }
 
-  private async findPageByTargetId(entry: BrowserEntry, targetId: string): Promise<Page | null> {
+  private async findPageByTargetId(
+    entry: BrowserEntry,
+    targetId: string
+  ): Promise<BrowserPageHandle | null> {
+    if (isLiveCdpBrowser(entry.browser)) {
+      await entry.browser.refreshPages();
+    }
+
     for (const { context, page } of this.getContextPages(entry)) {
       const pageTargetId = await this.getPageTargetId(context, page);
       if (pageTargetId === targetId) {
@@ -835,11 +919,19 @@ export class BrowserManager {
     return null;
   }
 
-  private async getPageTargetId(context: BrowserContext, page: Page): Promise<string | null> {
+  private async getPageTargetId(
+    context: BrowserContextHandle,
+    page: BrowserPageHandle
+  ): Promise<string | null> {
+    const liveCdpTargetId = getLiveCdpPageTargetId(page);
+    if (liveCdpTargetId) {
+      return liveCdpTargetId;
+    }
+
     let session: Awaited<ReturnType<BrowserContext["newCDPSession"]>> | undefined;
 
     try {
-      session = await context.newCDPSession(page);
+      session = await (context as BrowserContext).newCDPSession(page as Page);
       const result = await session.send("Target.getTargetInfo");
       const targetId =
         typeof result === "object" &&

--- a/daemon/src/live-cdp-browser.test.ts
+++ b/daemon/src/live-cdp-browser.test.ts
@@ -12,6 +12,14 @@ type CdpMessage = {
 class MockLiveCdpTransport implements LiveCdpTransport {
   readonly sent: CdpMessage[] = [];
   readonly hangingMethods = new Set<string>();
+  targetInfos = [
+    {
+      targetId: "target-1",
+      type: "page",
+      url: "https://example.com/",
+      title: "Existing",
+    },
+  ];
 
   #closed = false;
   #messageListeners = new Set<(message: string) => void>();
@@ -65,14 +73,7 @@ class MockLiveCdpTransport implements LiveCdpTransport {
         this.emit({
           id: request.id,
           result: {
-            targetInfos: [
-              {
-                targetId: "target-1",
-                type: "page",
-                url: "https://example.com/",
-                title: "Existing",
-              },
-            ],
+            targetInfos: this.targetInfos,
           },
         });
         return;
@@ -90,14 +91,35 @@ class MockLiveCdpTransport implements LiveCdpTransport {
       case "Network.enable":
         this.emit({ id: request.id, result: {} });
         return;
+      case "Page.getFrameTree":
+        this.emit({
+          id: request.id,
+          result: {
+            frameTree: {
+              frame: {
+                id: "frame-1",
+              },
+            },
+          },
+        });
+        return;
       case "Target.createTarget":
         this.emit({ id: request.id, result: { targetId: "target-2" } });
         return;
       case "Runtime.evaluate":
-        this.emit({ id: request.id, result: { result: { type: "string", value: "Live Title" } } });
+        this.emit({
+          id: request.id,
+          result: {
+            result:
+              request.params?.expression === "document.title"
+                ? { type: "string", value: "Live Title" }
+                : { type: "number", value: 42 },
+          },
+        });
         return;
-      case "Runtime.callFunctionOn":
-        this.emit({ id: request.id, result: { result: { type: "number", value: 42 } } });
+      case "Input.dispatchKeyEvent":
+      case "Target.detachFromTarget":
+        this.emit({ id: request.id, result: {} });
         return;
       case "Page.navigate":
         this.emit({ id: request.id, result: { frameId: "frame-1" } });
@@ -179,6 +201,7 @@ describe("live-CDP browser adapter", () => {
       ])
     );
     expect(transport.sent.map((message) => message.method)).not.toContain("Target.setAutoAttach");
+    expect(transport.sent.map((message) => message.method)).not.toContain("Runtime.callFunctionOn");
     expect(
       transport.sent.find((message) => message.method === "Target.attachToTarget")?.params
     ).toEqual({
@@ -225,5 +248,94 @@ describe("live-CDP browser adapter", () => {
     });
 
     expect(context?.pages()).toHaveLength(0);
+  });
+
+  it("tracks same-document navigation for synchronous url reads", async () => {
+    const transport = new MockLiveCdpTransport();
+    const browser = await createLiveCdpBrowser("ws://127.0.0.1/devtools/browser/test", {
+      transportFactory: async () => transport,
+    });
+    const page = browser.contexts()[0]?.pages()[0];
+    expect(page?.url()).toBe("https://example.com/");
+
+    transport.emit({
+      method: "Page.navigatedWithinDocument",
+      sessionId: "session-1",
+      params: {
+        frameId: "frame-1",
+        url: "https://example.com/chat/c/123",
+      },
+    });
+
+    expect(page?.url()).toBe("https://example.com/chat/c/123");
+  });
+
+  it("types text as per-character key events", async () => {
+    const transport = new MockLiveCdpTransport();
+    const browser = await createLiveCdpBrowser("ws://127.0.0.1/devtools/browser/test", {
+      transportFactory: async () => transport,
+    });
+    const page = browser.contexts()[0]?.pages()[0];
+
+    await page?.keyboard.type("ab");
+
+    const keyEvents = transport.sent.filter((message) => message.method === "Input.dispatchKeyEvent");
+    expect(keyEvents).toHaveLength(6);
+    expect(keyEvents.map((message) => message.params?.type)).toEqual([
+      "keyDown",
+      "char",
+      "keyUp",
+      "keyDown",
+      "char",
+      "keyUp",
+    ]);
+    expect(transport.sent.map((message) => message.method)).not.toContain("Input.insertText");
+  });
+
+  it("ignores same-document navigation from subframes", async () => {
+    const transport = new MockLiveCdpTransport();
+    const browser = await createLiveCdpBrowser("ws://127.0.0.1/devtools/browser/test", {
+      transportFactory: async () => transport,
+    });
+    const page = browser.contexts()[0]?.pages()[0];
+    expect(page?.url()).toBe("https://example.com/");
+
+    transport.emit({
+      method: "Page.navigatedWithinDocument",
+      sessionId: "session-1",
+      params: {
+        frameId: "subframe-1",
+        url: "https://embedded.example/path",
+      },
+    });
+
+    expect(page?.url()).toBe("https://example.com/");
+  });
+
+  it("prioritizes yoetz-owned targets before pre-existing tabs", async () => {
+    const transport = new MockLiveCdpTransport();
+    transport.targetInfos = [
+      {
+        targetId: "target-existing",
+        type: "page",
+        url: "https://example.com/",
+        title: "Existing",
+      },
+      {
+        targetId: "target-yoetz",
+        type: "page",
+        url: "https://chatgpt.com/?_yoetz=run-1",
+        title: "Yoetz",
+      },
+    ];
+
+    await createLiveCdpBrowser("ws://127.0.0.1/devtools/browser/test", {
+      transportFactory: async () => transport,
+    });
+
+    const attachedTargets = transport.sent
+      .filter((message) => message.method === "Target.attachToTarget")
+      .map((message) => message.params?.targetId);
+    expect(attachedTargets).toEqual(["target-yoetz"]);
   });
 });

--- a/daemon/src/live-cdp-browser.test.ts
+++ b/daemon/src/live-cdp-browser.test.ts
@@ -1,0 +1,229 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { createLiveCdpBrowser, type LiveCdpTransport } from "./live-cdp-browser.js";
+
+type CdpMessage = {
+  id: number;
+  method: string;
+  params?: Record<string, unknown>;
+  sessionId?: string;
+};
+
+class MockLiveCdpTransport implements LiveCdpTransport {
+  readonly sent: CdpMessage[] = [];
+  readonly hangingMethods = new Set<string>();
+
+  #closed = false;
+  #messageListeners = new Set<(message: string) => void>();
+  #closeListeners = new Set<(reason?: string) => void>();
+
+  send(message: string): void {
+    const request = JSON.parse(message) as CdpMessage;
+    this.sent.push(request);
+    queueMicrotask(() => {
+      this.respond(request);
+    });
+  }
+
+  close(): void {
+    this.#closed = true;
+    for (const listener of this.#closeListeners) {
+      listener("closed by test");
+    }
+  }
+
+  onMessage(listener: (message: string) => void): () => void {
+    this.#messageListeners.add(listener);
+    return () => this.#messageListeners.delete(listener);
+  }
+
+  onClose(listener: (reason?: string) => void): () => void {
+    this.#closeListeners.add(listener);
+    return () => this.#closeListeners.delete(listener);
+  }
+
+  emit(payload: unknown): void {
+    for (const listener of this.#messageListeners) {
+      listener(JSON.stringify(payload));
+    }
+  }
+
+  private respond(request: CdpMessage): void {
+    if (this.#closed) {
+      return;
+    }
+
+    if (this.hangingMethods.has(request.method)) {
+      return;
+    }
+
+    switch (request.method) {
+      case "Browser.getVersion":
+        this.emit({ id: request.id, result: { product: "Chrome/147.0.0.0" } });
+        return;
+      case "Target.getTargets":
+        this.emit({
+          id: request.id,
+          result: {
+            targetInfos: [
+              {
+                targetId: "target-1",
+                type: "page",
+                url: "https://example.com/",
+                title: "Existing",
+              },
+            ],
+          },
+        });
+        return;
+      case "Target.attachToTarget":
+        this.emit({
+          id: request.id,
+          result: {
+            sessionId: request.params?.targetId === "target-2" ? "session-2" : "session-1",
+          },
+        });
+        return;
+      case "Page.enable":
+      case "Runtime.enable":
+      case "Runtime.runIfWaitingForDebugger":
+      case "Network.enable":
+        this.emit({ id: request.id, result: {} });
+        return;
+      case "Target.createTarget":
+        this.emit({ id: request.id, result: { targetId: "target-2" } });
+        return;
+      case "Runtime.evaluate":
+        this.emit({ id: request.id, result: { result: { type: "string", value: "Live Title" } } });
+        return;
+      case "Runtime.callFunctionOn":
+        this.emit({ id: request.id, result: { result: { type: "number", value: 42 } } });
+        return;
+      case "Page.navigate":
+        this.emit({ id: request.id, result: { frameId: "frame-1" } });
+        this.emit({ method: "Page.loadEventFired", sessionId: request.sessionId, params: {} });
+        return;
+      case "Target.closeTarget":
+        this.emit({ id: request.id, result: { success: true } });
+        return;
+      default:
+        this.emit({
+          id: request.id,
+          error: { message: `Unexpected method ${request.method}` },
+        });
+    }
+  }
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("live-CDP browser adapter", () => {
+  it("times out a hung Browser.getVersion handshake with a named step error", async () => {
+    vi.useFakeTimers();
+    const transport = new MockLiveCdpTransport();
+    transport.hangingMethods.add("Browser.getVersion");
+
+    const connectPromise = createLiveCdpBrowser("ws://127.0.0.1/devtools/browser/test", {
+      transportFactory: async () => transport,
+    });
+    const assertion = expect(connectPromise).rejects.toThrow(
+      /Timed out after 5000ms initializing live CDP browser during Browser\.getVersion/
+    );
+
+    await vi.advanceTimersByTimeAsync(5_000);
+
+    await assertion;
+  });
+
+  it("times out a hung Target.getTargets refresh with a named step error", async () => {
+    vi.useFakeTimers();
+    const transport = new MockLiveCdpTransport();
+    const browser = await createLiveCdpBrowser("ws://127.0.0.1/devtools/browser/test", {
+      transportFactory: async () => transport,
+    });
+    transport.hangingMethods.add("Target.getTargets");
+
+    const refreshPromise = browser.refreshPages();
+    const assertion = expect(refreshPromise).rejects.toThrow(
+      /Timed out after 5000ms initializing live CDP browser during Target\.getTargets/
+    );
+    await vi.advanceTimersByTimeAsync(5_000);
+
+    await assertion;
+  });
+
+  it("attaches to page targets without root Target.setAutoAttach", async () => {
+    const transport = new MockLiveCdpTransport();
+    const browser = await createLiveCdpBrowser("ws://127.0.0.1/devtools/browser/test", {
+      transportFactory: async () => transport,
+    });
+
+    const context = browser.contexts()[0];
+    expect(context).toBeDefined();
+    const page = context!.pages()[0];
+
+    expect(page?.url()).toBe("https://example.com/");
+    await expect(page?.title()).resolves.toBe("Live Title");
+    await expect(page?.evaluate(() => 42)).resolves.toBe(42);
+
+    expect(transport.sent.map((message) => message.method)).toEqual(
+      expect.arrayContaining([
+        "Browser.getVersion",
+        "Target.getTargets",
+        "Target.attachToTarget",
+        "Page.enable",
+        "Runtime.enable",
+        "Network.enable",
+      ])
+    );
+    expect(transport.sent.map((message) => message.method)).not.toContain("Target.setAutoAttach");
+    expect(
+      transport.sent.find((message) => message.method === "Target.attachToTarget")?.params
+    ).toEqual({
+      targetId: "target-1",
+      flatten: true,
+    });
+  });
+
+  it("creates new targets and drives basic navigation over the page session", async () => {
+    const transport = new MockLiveCdpTransport();
+    const browser = await createLiveCdpBrowser("ws://127.0.0.1/devtools/browser/test", {
+      transportFactory: async () => transport,
+    });
+    const context = browser.contexts()[0];
+    expect(context).toBeDefined();
+    const page = await context!.newPage();
+
+    await page.goto("https://example.test/");
+
+    expect(transport.sent.map((message) => message.method)).toEqual(
+      expect.arrayContaining(["Target.createTarget", "Target.attachToTarget", "Page.navigate"])
+    );
+    expect(transport.sent.find((message) => message.method === "Page.navigate")).toMatchObject({
+      sessionId: "session-2",
+      params: {
+        url: "https://example.test/",
+      },
+    });
+  });
+
+  it("removes pages when Chrome detaches their target session", async () => {
+    const transport = new MockLiveCdpTransport();
+    const browser = await createLiveCdpBrowser("ws://127.0.0.1/devtools/browser/test", {
+      transportFactory: async () => transport,
+    });
+    const context = browser.contexts()[0];
+    expect(context?.pages()).toHaveLength(1);
+
+    transport.emit({
+      method: "Target.detachedFromTarget",
+      params: {
+        sessionId: "session-1",
+      },
+    });
+
+    expect(context?.pages()).toHaveLength(0);
+  });
+});

--- a/daemon/src/live-cdp-browser.ts
+++ b/daemon/src/live-cdp-browser.ts
@@ -395,17 +395,22 @@ export class LiveCdpBrowser extends EventEmitter {
   ): Promise<LiveCdpBrowser> {
     const connection = await CdpConnection.connect(endpoint, options.transportFactory);
 
-    await sendLiveCdpInitCommand(
-      connection,
-      "Browser.getVersion",
-      {},
-      undefined,
-      "Browser.getVersion"
-    );
+    try {
+      await sendLiveCdpInitCommand(
+        connection,
+        "Browser.getVersion",
+        {},
+        undefined,
+        "Browser.getVersion"
+      );
 
-    const browser = new LiveCdpBrowser(connection);
-    await browser.refreshPages();
-    return browser;
+      const browser = new LiveCdpBrowser(connection);
+      await browser.refreshPages();
+      return browser;
+    } catch (error) {
+      connection.close("live-CDP initialization failed");
+      throw error;
+    }
   }
 
   private constructor(connection: CdpConnection) {
@@ -484,29 +489,55 @@ export class LiveCdpBrowserContext {
       undefined,
       "Target.getTargets"
     );
-    const targetInfos = Array.isArray(result.targetInfos) ? result.targetInfos : [];
+    const targetInfos = Array.isArray(result.targetInfos)
+      ? result.targetInfos
+          .map((rawInfo) => normalizeTargetInfo(rawInfo))
+          .filter((targetInfo): targetInfo is TargetInfo =>
+            Boolean(targetInfo && isPageLikeTarget(targetInfo))
+          )
+      : [];
+    const hasYoetzTarget = targetInfos.some(isYoetzTarget);
+    const targetInfosToAttach = targetInfos
+      .filter(
+        (targetInfo) =>
+          !hasYoetzTarget ||
+          isYoetzTarget(targetInfo) ||
+          this.#pagesByTargetId.has(targetInfo.targetId)
+      )
+      .sort(compareTargetAttachPriority);
     const liveTargetIds = new Set<string>();
+    const attachErrors: Error[] = [];
 
-    for (const rawInfo of targetInfos) {
-      const targetInfo = normalizeTargetInfo(rawInfo);
-      if (!targetInfo || !isPageLikeTarget(targetInfo)) {
-        continue;
-      }
-
-      liveTargetIds.add(targetInfo.targetId);
+    for (const targetInfo of targetInfosToAttach) {
       const existingPage = this.#pagesByTargetId.get(targetInfo.targetId);
       if (existingPage) {
+        liveTargetIds.add(targetInfo.targetId);
         existingPage.updateTargetInfo(targetInfo);
         continue;
       }
 
-      await this.attachToTarget(targetInfo).catch(() => undefined);
+      try {
+        await this.attachToTarget(targetInfo);
+        liveTargetIds.add(targetInfo.targetId);
+      } catch (error) {
+        attachErrors.push(
+          new Error(
+            `Failed to attach live-CDP target ${targetInfo.targetId}: ${
+              error instanceof Error ? error.message : String(error)
+            }`
+          )
+        );
+      }
     }
 
     for (const [targetId, page] of this.#pagesByTargetId.entries()) {
       if (!liveTargetIds.has(targetId)) {
         this.markPageClosed(page);
       }
+    }
+
+    if (this.#pagesByTargetId.size === 0 && attachErrors.length > 0) {
+      throw attachErrors[0]!;
     }
   }
 
@@ -535,45 +566,76 @@ export class LiveCdpBrowserContext {
       );
     }
 
-    await sendLiveCdpInitCommand(
-      this.connection,
-      "Page.enable",
-      {},
-      sessionId,
-      `Page.enable(${targetInfo.targetId})`,
-      LIVE_CDP_TARGET_INIT_TIMEOUT_MS
-    );
-    await sendLiveCdpInitCommand(
-      this.connection,
-      "Runtime.enable",
-      {},
-      sessionId,
-      `Runtime.enable(${targetInfo.targetId})`,
-      LIVE_CDP_TARGET_INIT_TIMEOUT_MS
-    );
-    await sendLiveCdpInitCommand(
-      this.connection,
-      "Runtime.runIfWaitingForDebugger",
-      {},
-      sessionId,
-      `Runtime.runIfWaitingForDebugger(${targetInfo.targetId})`,
-      LIVE_CDP_TARGET_INIT_TIMEOUT_MS
-    ).catch(() => {});
-    await sendLiveCdpInitCommand(
-      this.connection,
-      "Network.enable",
-      {},
-      sessionId,
-      `Network.enable(${targetInfo.targetId})`,
-      LIVE_CDP_TARGET_INIT_TIMEOUT_MS
-    );
+    try {
+      await sendLiveCdpInitCommand(
+        this.connection,
+        "Page.enable",
+        {},
+        sessionId,
+        `Page.enable(${targetInfo.targetId})`,
+        LIVE_CDP_TARGET_INIT_TIMEOUT_MS
+      );
+      const mainFrameId = await this.readMainFrameId(sessionId, targetInfo.targetId);
+      await sendLiveCdpInitCommand(
+        this.connection,
+        "Runtime.enable",
+        {},
+        sessionId,
+        `Runtime.enable(${targetInfo.targetId})`,
+        LIVE_CDP_TARGET_INIT_TIMEOUT_MS
+      );
+      await sendLiveCdpInitCommand(
+        this.connection,
+        "Runtime.runIfWaitingForDebugger",
+        {},
+        sessionId,
+        `Runtime.runIfWaitingForDebugger(${targetInfo.targetId})`,
+        LIVE_CDP_TARGET_INIT_TIMEOUT_MS
+      ).catch(() => {});
+      await sendLiveCdpInitCommand(
+        this.connection,
+        "Network.enable",
+        {},
+        sessionId,
+        `Network.enable(${targetInfo.targetId})`,
+        LIVE_CDP_TARGET_INIT_TIMEOUT_MS
+      );
 
-    const page = new LiveCdpPage(this.connection, targetInfo, sessionId, () => {
-      this.markPageClosed(page);
-    });
-    this.#pagesByTargetId.set(targetInfo.targetId, page);
-    this.#pagesBySessionId.set(sessionId, page);
-    return page;
+      const page = new LiveCdpPage(this.connection, targetInfo, sessionId, mainFrameId, () => {
+        this.markPageClosed(page);
+      });
+      this.#pagesByTargetId.set(targetInfo.targetId, page);
+      this.#pagesBySessionId.set(sessionId, page);
+      return page;
+    } catch (error) {
+      await this.connection
+        .send("Target.detachFromTarget", { sessionId }, undefined, 1_000)
+        .catch(() => undefined);
+      throw error;
+    }
+  }
+
+  private async readMainFrameId(
+    sessionId: string,
+    targetId: string
+  ): Promise<string | undefined> {
+    const result = await sendLiveCdpInitCommand(
+      this.connection,
+      "Page.getFrameTree",
+      {},
+      sessionId,
+      `Page.getFrameTree(${targetId})`,
+      LIVE_CDP_TARGET_INIT_TIMEOUT_MS
+    ).catch(() => undefined);
+    const frameTree =
+      result && typeof result.frameTree === "object" && result.frameTree !== null
+        ? (result.frameTree as { frame?: unknown })
+        : undefined;
+    const frame =
+      typeof frameTree?.frame === "object" && frameTree.frame !== null
+        ? (frameTree.frame as { id?: unknown })
+        : undefined;
+    return typeof frame?.id === "string" ? frame.id : undefined;
   }
 
   private handleEvent(event: CdpEvent): void {
@@ -617,7 +679,9 @@ export class LiveCdpKeyboard {
   constructor(private readonly page: LiveCdpPage) {}
 
   async type(text: string): Promise<void> {
-    await this.page.sendSession("Input.insertText", { text });
+    for (const char of Array.from(text)) {
+      await this.press(char);
+    }
   }
 
   async down(key: string): Promise<void> {
@@ -643,11 +707,14 @@ export class LiveCdpKeyboard {
     const activeModifiers = this.#modifiers | modifiers;
 
     await this.dispatchKeyEvent("keyDown", definition, activeModifiers);
+    if (definition.text && activeModifiers === 0) {
+      await this.dispatchKeyEvent("char", definition, activeModifiers);
+    }
     await this.dispatchKeyEvent("keyUp", definition, activeModifiers);
   }
 
   private async dispatchKeyEvent(
-    type: "keyDown" | "keyUp",
+    type: "keyDown" | "char" | "keyUp",
     definition: KeyDefinition,
     modifiers: number
   ): Promise<void> {
@@ -657,7 +724,7 @@ export class LiveCdpKeyboard {
       code: definition.code,
       windowsVirtualKeyCode: definition.windowsVirtualKeyCode,
       nativeVirtualKeyCode: definition.windowsVirtualKeyCode,
-      text: type === "keyDown" && modifiers === 0 ? definition.text : undefined,
+      text: type === "char" ? definition.text : undefined,
       unmodifiedText: definition.text,
       modifiers,
     });
@@ -677,6 +744,7 @@ export class LiveCdpPage extends EventEmitter {
   readonly mouse = new LiveCdpMouse(this);
 
   #closed = false;
+  #mainFrameId: string | undefined;
   #url: string;
   #title: string;
 
@@ -684,10 +752,12 @@ export class LiveCdpPage extends EventEmitter {
     private readonly connection: CdpConnection,
     targetInfo: TargetInfo,
     readonly sessionId: string,
+    mainFrameId: string | undefined,
     private readonly onClose: () => void
   ) {
     super();
     this.targetId = targetInfo.targetId;
+    this.#mainFrameId = mainFrameId;
     this.#url = targetInfo.url ?? "about:blank";
     this.#title = targetInfo.title ?? "";
   }
@@ -811,14 +881,12 @@ export class LiveCdpPage extends EventEmitter {
     }
 
     const args = payload.args ?? (payload.hasArg ? [payload.arg] : []);
-    const result = (await this.sendSession("Runtime.callFunctionOn", {
-      functionDeclaration: `function(...args) {
+    const result = (await this.sendSession("Runtime.evaluate", {
+      expression: `(() => {
         const fn = (${payload.source});
+        const args = [${args.map((value) => serializeRuntimeArgument(value)).join(",")}];
         return fn(...args);
-      }`,
-      arguments: args.map((value) => ({
-        value,
-      })),
+      })()`,
       awaitPromise: true,
       returnByValue: true,
     })) as RuntimeEvaluationResult;
@@ -1086,11 +1154,22 @@ export class LiveCdpPage extends EventEmitter {
     if (event.method === "Page.frameNavigated") {
       const frame =
         typeof event.params.frame === "object" && event.params.frame !== null
-          ? (event.params.frame as { parentId?: unknown; url?: unknown })
+          ? (event.params.frame as { id?: unknown; parentId?: unknown; url?: unknown })
           : undefined;
       if (frame && frame.parentId === undefined && typeof frame.url === "string") {
+        if (typeof frame.id === "string") {
+          this.#mainFrameId = frame.id;
+        }
         this.#url = frame.url;
       }
+    }
+
+    if (
+      event.method === "Page.navigatedWithinDocument" &&
+      typeof event.params.url === "string" &&
+      (typeof event.params.frameId !== "string" || event.params.frameId === this.#mainFrameId)
+    ) {
+      this.#url = event.params.url;
     }
 
     this.emit(`cdp:${event.method}`, event.params);
@@ -1112,6 +1191,11 @@ export class LiveCdpPage extends EventEmitter {
 
   private waitForSessionEvent(method: string, timeout: number): Promise<void> {
     return new Promise<void>((resolve, reject) => {
+      if (this.#closed) {
+        reject(new Error(`Page target ${this.targetId} is closed while waiting for ${method}`));
+        return;
+      }
+
       const timeoutId = setTimeout(() => {
         cleanup();
         reject(new Error(`Timed out waiting for ${method}`));
@@ -1120,12 +1204,18 @@ export class LiveCdpPage extends EventEmitter {
         cleanup();
         resolve();
       };
+      const handleClose = () => {
+        cleanup();
+        reject(new Error(`Page target ${this.targetId} closed while waiting for ${method}`));
+      };
       const cleanup = () => {
         clearTimeout(timeoutId);
         this.off(`cdp:${method}`, handleEvent);
+        this.off("close", handleClose);
       };
 
       this.on(`cdp:${method}`, handleEvent);
+      this.on("close", handleClose);
     });
   }
 }
@@ -1424,6 +1514,55 @@ function normalizeLocatorDescriptor(
     index: descriptor.index ?? null,
     hasText: descriptor.hasText ?? null,
   };
+}
+
+function compareTargetAttachPriority(left: TargetInfo, right: TargetInfo): number {
+  const leftIsYoetz = isYoetzTarget(left);
+  const rightIsYoetz = isYoetzTarget(right);
+
+  if (leftIsYoetz !== rightIsYoetz) {
+    return leftIsYoetz ? -1 : 1;
+  }
+
+  return 0;
+}
+
+function isYoetzTarget(targetInfo: TargetInfo): boolean {
+  const url = targetInfo.url ?? "";
+  if (url.length === 0) {
+    return false;
+  }
+
+  try {
+    return new URL(url).searchParams.has("_yoetz");
+  } catch {
+    return /[?&]_yoetz(?:=|&|$)/.test(url);
+  }
+}
+
+function serializeRuntimeArgument(value: unknown): string {
+  if (value === undefined) {
+    return "undefined";
+  }
+
+  if (typeof value === "number") {
+    if (Number.isNaN(value)) {
+      return "NaN";
+    }
+    if (value === Infinity) {
+      return "Infinity";
+    }
+    if (value === -Infinity) {
+      return "-Infinity";
+    }
+  }
+
+  const serialized = JSON.stringify(value);
+  if (serialized === undefined) {
+    throw new Error(`Cannot pass ${typeof value} to live-CDP evaluation`);
+  }
+
+  return serialized;
 }
 
 function readRuntimeResult(result: RuntimeEvaluationResult): unknown {

--- a/daemon/src/live-cdp-browser.ts
+++ b/daemon/src/live-cdp-browser.ts
@@ -1,0 +1,1576 @@
+import { EventEmitter } from "node:events";
+
+type CdpParams = Record<string, unknown>;
+type CdpResult = Record<string, unknown>;
+
+interface CdpRequest {
+  id: number;
+  method: string;
+  params?: CdpParams;
+  sessionId?: string;
+}
+
+interface CdpResponse {
+  id?: number;
+  result?: CdpResult;
+  error?: {
+    code?: number;
+    message?: string;
+    data?: string;
+  };
+  method?: string;
+  params?: CdpParams;
+  sessionId?: string;
+}
+
+interface CdpEvent {
+  method: string;
+  params: CdpParams;
+  sessionId?: string;
+}
+
+interface PendingCdpCommand {
+  resolve: (value: CdpResult) => void;
+  reject: (error: Error) => void;
+  timeout: ReturnType<typeof setTimeout>;
+}
+
+interface TargetInfo {
+  targetId: string;
+  type: string;
+  url?: string;
+  title?: string;
+}
+
+interface RemoteObject {
+  type?: string;
+  subtype?: string;
+  value?: unknown;
+  unserializableValue?: string;
+  description?: string;
+  objectId?: string;
+}
+
+interface RuntimeEvaluationResult extends CdpResult {
+  result?: RemoteObject;
+  exceptionDetails?: {
+    text?: string;
+    exception?: RemoteObject;
+  };
+}
+
+interface Point {
+  x: number;
+  y: number;
+}
+
+interface KeyDefinition {
+  key: string;
+  code: string;
+  windowsVirtualKeyCode: number;
+  text?: string;
+}
+
+const LIVE_CDP_BROWSER_INIT_TIMEOUT_MS = 5_000;
+const LIVE_CDP_TARGET_INIT_TIMEOUT_MS = 5_000;
+
+export interface LiveCdpTransport {
+  send(message: string): void;
+  close(): void;
+  onMessage(listener: (message: string) => void): () => void;
+  onClose(listener: (reason?: string) => void): () => void;
+}
+
+export type LiveCdpTransportFactory = (endpoint: string) => Promise<LiveCdpTransport>;
+
+export interface LiveCdpBrowserOptions {
+  transportFactory?: LiveCdpTransportFactory;
+}
+
+export interface LiveCdpLocatorDescriptor {
+  selector: string;
+  index?: number | null;
+  hasText?: string | null;
+}
+
+export type SerializedEvaluation =
+  | {
+      kind: "expression";
+      source: string;
+    }
+  | {
+      kind: "function";
+      source: string;
+      hasArg?: boolean;
+      arg?: unknown;
+      args?: unknown[];
+    };
+
+interface WebSocketLike {
+  readonly readyState: number;
+  send(message: string): void;
+  close(): void;
+  addEventListener(
+    type: string,
+    listener: (event: unknown) => void,
+    options?: { once?: boolean }
+  ): void;
+  removeEventListener(type: string, listener: (event: unknown) => void): void;
+}
+
+class WebSocketLiveCdpTransport implements LiveCdpTransport {
+  static async connect(endpoint: string): Promise<WebSocketLiveCdpTransport> {
+    const WebSocketConstructor = (
+      globalThis as typeof globalThis & {
+        WebSocket?: new (url: string) => WebSocketLike;
+      }
+    ).WebSocket;
+
+    if (!WebSocketConstructor) {
+      throw new Error("This Node.js runtime does not expose a global WebSocket implementation");
+    }
+
+    const socket = new WebSocketConstructor(endpoint);
+
+    return await new Promise<WebSocketLiveCdpTransport>((resolve, reject) => {
+      let settled = false;
+      const timeoutId = setTimeout(() => {
+        rejectWith(new Error(`Timed out connecting to CDP endpoint ${endpoint}`));
+      }, 5_000);
+
+      const cleanup = () => {
+        clearTimeout(timeoutId);
+        socket.removeEventListener("open", handleOpen);
+        socket.removeEventListener("error", handleError);
+        socket.removeEventListener("close", handleClose);
+      };
+      const rejectWith = (error: Error) => {
+        if (settled) {
+          return;
+        }
+
+        settled = true;
+        cleanup();
+        try {
+          socket.close();
+        } catch {
+          // Best effort while rejecting the failed connection attempt.
+        }
+        reject(error);
+      };
+      const handleOpen = () => {
+        if (settled) {
+          return;
+        }
+
+        settled = true;
+        cleanup();
+        resolve(new WebSocketLiveCdpTransport(socket));
+      };
+      const handleError = (event: unknown) => {
+        rejectWith(new Error(`Failed to connect to CDP endpoint ${endpoint}: ${String(event)}`));
+      };
+      const handleClose = () => {
+        rejectWith(new Error(`CDP endpoint closed before connection opened: ${endpoint}`));
+      };
+
+      socket.addEventListener("open", handleOpen);
+      socket.addEventListener("error", handleError);
+      socket.addEventListener("close", handleClose, { once: true });
+    });
+  }
+
+  private readonly messageListeners = new Set<(message: string) => void>();
+  private readonly closeListeners = new Set<(reason?: string) => void>();
+
+  private constructor(private readonly socket: WebSocketLike) {
+    this.socket.addEventListener("message", (event) => {
+      const data = (event as { data?: unknown }).data;
+      if (typeof data === "string") {
+        this.emitMessage(data);
+        return;
+      }
+
+      if (data instanceof ArrayBuffer) {
+        this.emitMessage(Buffer.from(data).toString("utf8"));
+        return;
+      }
+
+      if (ArrayBuffer.isView(data)) {
+        this.emitMessage(
+          Buffer.from(data.buffer, data.byteOffset, data.byteLength).toString("utf8")
+        );
+      }
+    });
+    this.socket.addEventListener("close", (event) => {
+      const reason = (event as { reason?: unknown }).reason;
+      this.emitClose(typeof reason === "string" && reason.length > 0 ? reason : undefined);
+    });
+  }
+
+  send(message: string): void {
+    this.socket.send(message);
+  }
+
+  close(): void {
+    this.socket.close();
+  }
+
+  onMessage(listener: (message: string) => void): () => void {
+    this.messageListeners.add(listener);
+    return () => {
+      this.messageListeners.delete(listener);
+    };
+  }
+
+  onClose(listener: (reason?: string) => void): () => void {
+    this.closeListeners.add(listener);
+    return () => {
+      this.closeListeners.delete(listener);
+    };
+  }
+
+  private emitMessage(message: string): void {
+    for (const listener of this.messageListeners) {
+      listener(message);
+    }
+  }
+
+  private emitClose(reason?: string): void {
+    for (const listener of this.closeListeners) {
+      listener(reason);
+    }
+  }
+}
+
+class CdpConnection {
+  static async connect(
+    endpoint: string,
+    transportFactory: LiveCdpTransportFactory = (url) => WebSocketLiveCdpTransport.connect(url)
+  ): Promise<CdpConnection> {
+    return new CdpConnection(await transportFactory(endpoint));
+  }
+
+  private readonly pending = new Map<number, PendingCdpCommand>();
+  private readonly eventListeners = new Set<(event: CdpEvent) => void>();
+  private nextId = 1;
+  private closed = false;
+
+  private constructor(private readonly transport: LiveCdpTransport) {
+    this.transport.onMessage((message) => {
+      this.handleMessage(message);
+    });
+    this.transport.onClose((reason) => {
+      this.markClosed(reason);
+    });
+  }
+
+  isConnected(): boolean {
+    return !this.closed;
+  }
+
+  send(
+    method: string,
+    params: CdpParams = {},
+    sessionId?: string,
+    timeoutMs = 30_000
+  ): Promise<CdpResult> {
+    if (this.closed) {
+      return Promise.reject(new Error("CDP connection is closed"));
+    }
+
+    const id = this.nextId++;
+    const request: CdpRequest = { id, method };
+    if (Object.keys(params).length > 0) {
+      request.params = params;
+    }
+    if (sessionId) {
+      request.sessionId = sessionId;
+    }
+
+    const promise = new Promise<CdpResult>((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        this.pending.delete(id);
+        reject(new Error(`CDP command timed out after ${timeoutMs}ms: ${method}`));
+      }, timeoutMs);
+      this.pending.set(id, { resolve, reject, timeout });
+    });
+
+    try {
+      this.transport.send(JSON.stringify(request));
+    } catch (error) {
+      const pending = this.pending.get(id);
+      this.pending.delete(id);
+      if (pending) {
+        clearTimeout(pending.timeout);
+      }
+      throw error;
+    }
+
+    return promise;
+  }
+
+  onEvent(listener: (event: CdpEvent) => void): () => void {
+    this.eventListeners.add(listener);
+    return () => {
+      this.eventListeners.delete(listener);
+    };
+  }
+
+  close(reason?: string): void {
+    if (this.closed) {
+      return;
+    }
+
+    this.markClosed(reason);
+    this.transport.close();
+  }
+
+  private handleMessage(message: string): void {
+    let payload: CdpResponse;
+
+    try {
+      payload = JSON.parse(message) as CdpResponse;
+    } catch {
+      return;
+    }
+
+    if (typeof payload.id === "number") {
+      const pending = this.pending.get(payload.id);
+      if (!pending) {
+        return;
+      }
+
+      this.pending.delete(payload.id);
+      clearTimeout(pending.timeout);
+      if (payload.error) {
+        pending.reject(
+          new Error(
+            payload.error.data
+              ? `${payload.error.message ?? "CDP command failed"}: ${payload.error.data}`
+              : (payload.error.message ?? "CDP command failed")
+          )
+        );
+        return;
+      }
+
+      pending.resolve(payload.result ?? {});
+      return;
+    }
+
+    if (typeof payload.method === "string") {
+      const event: CdpEvent = {
+        method: payload.method,
+        params: payload.params ?? {},
+        sessionId: payload.sessionId,
+      };
+      for (const listener of this.eventListeners) {
+        listener(event);
+      }
+    }
+  }
+
+  private markClosed(reason?: string): void {
+    if (this.closed) {
+      return;
+    }
+
+    this.closed = true;
+    const error = new Error(reason ? `CDP connection closed: ${reason}` : "CDP connection closed");
+    for (const pending of this.pending.values()) {
+      clearTimeout(pending.timeout);
+      pending.reject(error);
+    }
+    this.pending.clear();
+  }
+}
+
+export class LiveCdpBrowser extends EventEmitter {
+  readonly #connection: CdpConnection;
+  readonly #context: LiveCdpBrowserContext;
+
+  static async connect(
+    endpoint: string,
+    options: LiveCdpBrowserOptions = {}
+  ): Promise<LiveCdpBrowser> {
+    const connection = await CdpConnection.connect(endpoint, options.transportFactory);
+
+    await sendLiveCdpInitCommand(
+      connection,
+      "Browser.getVersion",
+      {},
+      undefined,
+      "Browser.getVersion"
+    );
+
+    const browser = new LiveCdpBrowser(connection);
+    await browser.refreshPages();
+    return browser;
+  }
+
+  private constructor(connection: CdpConnection) {
+    super();
+    this.#connection = connection;
+    this.#context = new LiveCdpBrowserContext(connection);
+  }
+
+  contexts(): LiveCdpBrowserContext[] {
+    return [this.#context];
+  }
+
+  async newContext(): Promise<LiveCdpBrowserContext> {
+    return this.#context;
+  }
+
+  isConnected(): boolean {
+    return this.#connection.isConnected();
+  }
+
+  async close(): Promise<void> {
+    this.#connection.close("dev-browser detached");
+    await Promise.resolve();
+    this.emit("disconnected");
+  }
+
+  async refreshPages(): Promise<void> {
+    await this.#context.refreshPages();
+  }
+}
+
+export class LiveCdpBrowserContext {
+  readonly #pagesByTargetId = new Map<string, LiveCdpPage>();
+  readonly #pagesBySessionId = new Map<string, LiveCdpPage>();
+
+  constructor(private readonly connection: CdpConnection) {
+    this.connection.onEvent((event) => {
+      this.handleEvent(event);
+    });
+  }
+
+  pages(): LiveCdpPage[] {
+    return Array.from(this.#pagesByTargetId.values()).filter((page) => !page.isClosed());
+  }
+
+  async newPage(): Promise<LiveCdpPage> {
+    const result = await sendLiveCdpInitCommand(
+      this.connection,
+      "Target.createTarget",
+      { url: "about:blank" },
+      undefined,
+      "Target.createTarget"
+    );
+    const targetId = typeof result.targetId === "string" ? result.targetId : undefined;
+    if (!targetId) {
+      throw new Error("Target.createTarget did not return a targetId");
+    }
+
+    return await this.attachToTarget({
+      targetId,
+      type: "page",
+      url: "about:blank",
+      title: "",
+    });
+  }
+
+  async close(): Promise<void> {
+    await Promise.allSettled(this.pages().map(async (page) => page.close()));
+  }
+
+  async refreshPages(): Promise<void> {
+    const result = await sendLiveCdpInitCommand(
+      this.connection,
+      "Target.getTargets",
+      {},
+      undefined,
+      "Target.getTargets"
+    );
+    const targetInfos = Array.isArray(result.targetInfos) ? result.targetInfos : [];
+    const liveTargetIds = new Set<string>();
+
+    for (const rawInfo of targetInfos) {
+      const targetInfo = normalizeTargetInfo(rawInfo);
+      if (!targetInfo || !isPageLikeTarget(targetInfo)) {
+        continue;
+      }
+
+      liveTargetIds.add(targetInfo.targetId);
+      const existingPage = this.#pagesByTargetId.get(targetInfo.targetId);
+      if (existingPage) {
+        existingPage.updateTargetInfo(targetInfo);
+        continue;
+      }
+
+      await this.attachToTarget(targetInfo).catch(() => undefined);
+    }
+
+    for (const [targetId, page] of this.#pagesByTargetId.entries()) {
+      if (!liveTargetIds.has(targetId)) {
+        this.markPageClosed(page);
+      }
+    }
+  }
+
+  private async attachToTarget(targetInfo: TargetInfo): Promise<LiveCdpPage> {
+    const existingPage = this.#pagesByTargetId.get(targetInfo.targetId);
+    if (existingPage && !existingPage.isClosed()) {
+      return existingPage;
+    }
+
+    const attachResult = await sendLiveCdpInitCommand(
+      this.connection,
+      "Target.attachToTarget",
+      {
+        targetId: targetInfo.targetId,
+        flatten: true,
+      },
+      undefined,
+      `Target.attachToTarget(${targetInfo.targetId})`,
+      LIVE_CDP_TARGET_INIT_TIMEOUT_MS
+    );
+    const sessionId =
+      typeof attachResult.sessionId === "string" ? attachResult.sessionId : undefined;
+    if (!sessionId) {
+      throw new Error(
+        `Target.attachToTarget did not return a sessionId for ${targetInfo.targetId}`
+      );
+    }
+
+    await sendLiveCdpInitCommand(
+      this.connection,
+      "Page.enable",
+      {},
+      sessionId,
+      `Page.enable(${targetInfo.targetId})`,
+      LIVE_CDP_TARGET_INIT_TIMEOUT_MS
+    );
+    await sendLiveCdpInitCommand(
+      this.connection,
+      "Runtime.enable",
+      {},
+      sessionId,
+      `Runtime.enable(${targetInfo.targetId})`,
+      LIVE_CDP_TARGET_INIT_TIMEOUT_MS
+    );
+    await sendLiveCdpInitCommand(
+      this.connection,
+      "Runtime.runIfWaitingForDebugger",
+      {},
+      sessionId,
+      `Runtime.runIfWaitingForDebugger(${targetInfo.targetId})`,
+      LIVE_CDP_TARGET_INIT_TIMEOUT_MS
+    ).catch(() => {});
+    await sendLiveCdpInitCommand(
+      this.connection,
+      "Network.enable",
+      {},
+      sessionId,
+      `Network.enable(${targetInfo.targetId})`,
+      LIVE_CDP_TARGET_INIT_TIMEOUT_MS
+    );
+
+    const page = new LiveCdpPage(this.connection, targetInfo, sessionId, () => {
+      this.markPageClosed(page);
+    });
+    this.#pagesByTargetId.set(targetInfo.targetId, page);
+    this.#pagesBySessionId.set(sessionId, page);
+    return page;
+  }
+
+  private handleEvent(event: CdpEvent): void {
+    if (event.method === "Target.targetDestroyed") {
+      const targetId =
+        typeof event.params.targetId === "string" ? event.params.targetId : undefined;
+      const page = targetId ? this.#pagesByTargetId.get(targetId) : undefined;
+      if (page) {
+        this.markPageClosed(page);
+      }
+      return;
+    }
+
+    if (event.method === "Target.detachedFromTarget") {
+      const sessionId =
+        typeof event.params.sessionId === "string" ? event.params.sessionId : event.sessionId;
+      const page = sessionId ? this.#pagesBySessionId.get(sessionId) : undefined;
+      if (page) {
+        this.markPageClosed(page);
+      }
+      return;
+    }
+
+    if (!event.sessionId) {
+      return;
+    }
+
+    this.#pagesBySessionId.get(event.sessionId)?.handleSessionEvent(event);
+  }
+
+  private markPageClosed(page: LiveCdpPage): void {
+    this.#pagesByTargetId.delete(page.targetId);
+    this.#pagesBySessionId.delete(page.sessionId);
+    page.markClosed();
+  }
+}
+
+export class LiveCdpKeyboard {
+  #modifiers = 0;
+
+  constructor(private readonly page: LiveCdpPage) {}
+
+  async type(text: string): Promise<void> {
+    await this.page.sendSession("Input.insertText", { text });
+  }
+
+  async down(key: string): Promise<void> {
+    const { definition, modifiers } = parseKeyChord(key);
+    const keyModifier = modifierMaskForKey(definition.key);
+    const activeModifiers = this.#modifiers | modifiers | keyModifier;
+
+    await this.dispatchKeyEvent("keyDown", definition, activeModifiers);
+    this.#modifiers = activeModifiers;
+  }
+
+  async up(key: string): Promise<void> {
+    const { definition, modifiers } = parseKeyChord(key);
+    const keyModifier = modifierMaskForKey(definition.key);
+    const activeModifiers = (this.#modifiers | modifiers) & ~keyModifier;
+
+    await this.dispatchKeyEvent("keyUp", definition, activeModifiers);
+    this.#modifiers = activeModifiers;
+  }
+
+  async press(key: string): Promise<void> {
+    const { definition, modifiers } = parseKeyChord(key);
+    const activeModifiers = this.#modifiers | modifiers;
+
+    await this.dispatchKeyEvent("keyDown", definition, activeModifiers);
+    await this.dispatchKeyEvent("keyUp", definition, activeModifiers);
+  }
+
+  private async dispatchKeyEvent(
+    type: "keyDown" | "keyUp",
+    definition: KeyDefinition,
+    modifiers: number
+  ): Promise<void> {
+    await this.page.sendSession("Input.dispatchKeyEvent", {
+      type,
+      key: definition.key,
+      code: definition.code,
+      windowsVirtualKeyCode: definition.windowsVirtualKeyCode,
+      nativeVirtualKeyCode: definition.windowsVirtualKeyCode,
+      text: type === "keyDown" && modifiers === 0 ? definition.text : undefined,
+      unmodifiedText: definition.text,
+      modifiers,
+    });
+  }
+}
+
+export class LiveCdpMouse {
+  constructor(private readonly page: LiveCdpPage) {}
+
+  async click(x: number, y: number): Promise<void> {
+    await this.page.clickPoint({ x, y });
+  }
+}
+
+export class LiveCdpPage extends EventEmitter {
+  readonly keyboard = new LiveCdpKeyboard(this);
+  readonly mouse = new LiveCdpMouse(this);
+
+  #closed = false;
+  #url: string;
+  #title: string;
+
+  constructor(
+    private readonly connection: CdpConnection,
+    targetInfo: TargetInfo,
+    readonly sessionId: string,
+    private readonly onClose: () => void
+  ) {
+    super();
+    this.targetId = targetInfo.targetId;
+    this.#url = targetInfo.url ?? "about:blank";
+    this.#title = targetInfo.title ?? "";
+  }
+
+  readonly targetId: string;
+
+  isClosed(): boolean {
+    return this.#closed;
+  }
+
+  url(): string {
+    return this.#url;
+  }
+
+  async title(): Promise<string> {
+    const title = await this.evaluateSerialized({
+      kind: "expression",
+      source: "document.title",
+    });
+    return typeof title === "string" ? title : "";
+  }
+
+  async goto(
+    url: string,
+    options: {
+      waitUntil?: "commit" | "domcontentloaded" | "load" | "networkidle";
+      timeout?: number;
+    } = {}
+  ): Promise<null> {
+    const waitUntil = options.waitUntil ?? "load";
+    const timeout = options.timeout ?? 30_000;
+    const waitForNavigation =
+      waitUntil === "commit"
+        ? Promise.resolve()
+        : this.waitForSessionEvent(
+            waitUntil === "domcontentloaded" ? "Page.domContentEventFired" : "Page.loadEventFired",
+            timeout
+          );
+
+    const result = await this.sendSession("Page.navigate", { url });
+    const errorText = typeof result.errorText === "string" ? result.errorText : undefined;
+    if (errorText) {
+      throw new Error(`Navigation to ${url} failed: ${errorText}`);
+    }
+
+    this.#url = url;
+    await waitForNavigation;
+
+    if (waitUntil === "networkidle") {
+      await this.waitForTimeout(500);
+    }
+
+    return null;
+  }
+
+  async reload(
+    options: {
+      waitUntil?: "commit" | "domcontentloaded" | "load" | "networkidle";
+      timeout?: number;
+    } = {}
+  ): Promise<null> {
+    const waitUntil = options.waitUntil ?? "load";
+    const timeout = options.timeout ?? 30_000;
+    const waitForNavigation =
+      waitUntil === "commit"
+        ? Promise.resolve()
+        : this.waitForSessionEvent(
+            waitUntil === "domcontentloaded" ? "Page.domContentEventFired" : "Page.loadEventFired",
+            timeout
+          );
+
+    await this.sendSession("Page.reload", {});
+    await waitForNavigation;
+
+    if (waitUntil === "networkidle") {
+      await this.waitForTimeout(500);
+    }
+
+    return null;
+  }
+
+  async close(): Promise<void> {
+    if (this.#closed) {
+      return;
+    }
+
+    await this.connection
+      .send("Target.closeTarget", { targetId: this.targetId })
+      .catch(() => undefined);
+    this.onClose();
+  }
+
+  async evaluate<R = unknown>(
+    pageFunction: string | ((...args: unknown[]) => R),
+    ...args: unknown[]
+  ): Promise<R> {
+    if (typeof pageFunction === "string") {
+      return (await this.evaluateSerialized({
+        kind: "expression",
+        source: pageFunction,
+      })) as R;
+    }
+
+    return (await this.evaluateSerialized({
+      kind: "function",
+      source: pageFunction.toString(),
+      hasArg: args.length > 0,
+      arg: args[0],
+      args,
+    })) as R;
+  }
+
+  async evaluateSerialized(payload: SerializedEvaluation): Promise<unknown> {
+    if (payload.kind === "expression") {
+      const result = (await this.sendSession("Runtime.evaluate", {
+        expression: payload.source,
+        awaitPromise: true,
+        returnByValue: true,
+      })) as RuntimeEvaluationResult;
+      return readRuntimeResult(result);
+    }
+
+    const args = payload.args ?? (payload.hasArg ? [payload.arg] : []);
+    const result = (await this.sendSession("Runtime.callFunctionOn", {
+      functionDeclaration: `function(...args) {
+        const fn = (${payload.source});
+        return fn(...args);
+      }`,
+      arguments: args.map((value) => ({
+        value,
+      })),
+      awaitPromise: true,
+      returnByValue: true,
+    })) as RuntimeEvaluationResult;
+    return readRuntimeResult(result);
+  }
+
+  async waitForTimeout(timeout: number): Promise<void> {
+    await new Promise<void>((resolve) => {
+      setTimeout(resolve, Math.max(0, timeout));
+    });
+  }
+
+  async click(selector: string, options: { timeout?: number } = {}): Promise<void> {
+    await this.locator(selector).click(options);
+  }
+
+  async fill(selector: string, value: string): Promise<void> {
+    await this.locator(selector).fill(value);
+  }
+
+  async type(selector: string, text: string): Promise<void> {
+    await this.locator(selector).fill("");
+    await this.locator(selector).click();
+    await this.keyboard.type(text);
+  }
+
+  async press(selector: string, key: string): Promise<void> {
+    await this.locator(selector).click();
+    await this.keyboard.press(key);
+  }
+
+  async check(selector: string): Promise<void> {
+    await this.locator(selector).setChecked(true);
+  }
+
+  async uncheck(selector: string): Promise<void> {
+    await this.locator(selector).setChecked(false);
+  }
+
+  async selectOption(selector: string, value: string | string[]): Promise<string[]> {
+    return await this.locator(selector).selectOption(value);
+  }
+
+  async textContent(selector: string): Promise<string | null> {
+    return await this.locator(selector).textContent();
+  }
+
+  async innerText(selector: string): Promise<string> {
+    return await this.locator(selector).innerText();
+  }
+
+  async innerHTML(selector: string): Promise<string> {
+    return await this.locator(selector).innerHTML();
+  }
+
+  async getAttribute(selector: string, name: string): Promise<string | null> {
+    return await this.locator(selector).getAttribute(name);
+  }
+
+  async inputValue(selector: string): Promise<string> {
+    return await this.locator(selector).inputValue();
+  }
+
+  async isChecked(selector: string): Promise<boolean> {
+    return await this.locator(selector).isChecked();
+  }
+
+  async isVisible(selector: string): Promise<boolean> {
+    return await this.locator(selector).isVisible();
+  }
+
+  async isHidden(selector: string): Promise<boolean> {
+    return !(await this.isVisible(selector));
+  }
+
+  async isEnabled(selector: string): Promise<boolean> {
+    return await this.locator(selector).isEnabled();
+  }
+
+  async waitForSelector(
+    selector: string,
+    options: { state?: "attached" | "detached" | "hidden" | "visible"; timeout?: number } = {}
+  ): Promise<null> {
+    const state = options.state ?? "visible";
+    const deadline = Date.now() + (options.timeout ?? 30_000);
+
+    while (Date.now() <= deadline) {
+      const locator = this.locator(selector);
+      const count = await locator.count();
+      const visible = count > 0 ? await locator.isVisible().catch(() => false) : false;
+
+      if (
+        (state === "attached" && count > 0) ||
+        (state === "detached" && count === 0) ||
+        (state === "visible" && visible) ||
+        (state === "hidden" && !visible)
+      ) {
+        return null;
+      }
+
+      await this.waitForTimeout(100);
+    }
+
+    throw new Error(`Timed out waiting for selector "${selector}" to become ${state}`);
+  }
+
+  async waitForFunction(
+    pageFunction: string | ((arg?: unknown) => unknown),
+    arg?: unknown,
+    options: { timeout?: number } = {}
+  ): Promise<unknown> {
+    const deadline = Date.now() + (options.timeout ?? 30_000);
+    while (Date.now() <= deadline) {
+      const value =
+        typeof pageFunction === "string"
+          ? await this.evaluate(pageFunction)
+          : await this.evaluate(pageFunction, arg);
+      if (value) {
+        return value;
+      }
+      await this.waitForTimeout(100);
+    }
+
+    throw new Error("Timed out waiting for function");
+  }
+
+  locator(selectorOrDescriptor: string | LiveCdpLocatorDescriptor): LiveCdpLocator {
+    const descriptor =
+      typeof selectorOrDescriptor === "string"
+        ? { selector: selectorOrDescriptor, index: null, hasText: null }
+        : selectorOrDescriptor;
+    return new LiveCdpLocator(this, descriptor);
+  }
+
+  async content(): Promise<string> {
+    const content = await this.evaluateSerialized({
+      kind: "expression",
+      source: "document.documentElement.outerHTML",
+    });
+    return typeof content === "string" ? content : "";
+  }
+
+  async setContent(html: string): Promise<void> {
+    await this.evaluateSerialized({
+      kind: "function",
+      source: `(html) => {
+        document.open();
+        document.write(html);
+        document.close();
+      }`,
+      hasArg: true,
+      arg: html,
+    });
+  }
+
+  async setInputFiles(selector: string, files: string | string[]): Promise<void> {
+    const fileList = Array.isArray(files) ? files : [files];
+    await this.sendSession("DOM.enable", {}).catch(() => {});
+    const documentResult = await this.sendSession("DOM.getDocument", {
+      depth: -1,
+      pierce: true,
+    });
+    const root = documentResult.root as { nodeId?: unknown } | undefined;
+    const nodeId = typeof root?.nodeId === "number" ? root.nodeId : undefined;
+    if (nodeId === undefined) {
+      throw new Error("DOM.getDocument did not return a root node");
+    }
+
+    const queryResult = await this.sendSession("DOM.querySelector", {
+      nodeId,
+      selector,
+    });
+    const inputNodeId = typeof queryResult.nodeId === "number" ? queryResult.nodeId : undefined;
+    if (!inputNodeId) {
+      throw new Error(`No file input found for selector "${selector}"`);
+    }
+
+    await this.sendSession("DOM.setFileInputFiles", {
+      nodeId: inputNodeId,
+      files: fileList,
+    });
+  }
+
+  sendSession(method: string, params: CdpParams = {}): Promise<CdpResult> {
+    if (this.#closed) {
+      return Promise.reject(new Error(`Page target ${this.targetId} is closed`));
+    }
+
+    return this.connection.send(method, params, this.sessionId);
+  }
+
+  async clickPoint(point: Point): Promise<void> {
+    await this.sendSession("Input.dispatchMouseEvent", {
+      type: "mousePressed",
+      x: point.x,
+      y: point.y,
+      button: "left",
+      clickCount: 1,
+    });
+    await this.sendSession("Input.dispatchMouseEvent", {
+      type: "mouseReleased",
+      x: point.x,
+      y: point.y,
+      button: "left",
+      clickCount: 1,
+    });
+  }
+
+  async locatorCount(descriptor: LiveCdpLocatorDescriptor): Promise<number> {
+    const count = await this.evaluate((input) => {
+      const { selector, hasText } = input as { selector: string; hasText?: string | null };
+      const elements = Array.from(document.querySelectorAll(selector));
+      return hasText === null || hasText === undefined
+        ? elements.length
+        : elements.filter((element) => (element.textContent ?? "").includes(hasText)).length;
+    }, normalizeLocatorDescriptor(descriptor));
+    return typeof count === "number" ? count : 0;
+  }
+
+  async locatorAction<T>(
+    descriptor: LiveCdpLocatorDescriptor,
+    action: (element: Element, args: unknown[]) => T,
+    args: unknown[] = []
+  ): Promise<T> {
+    return (await this.evaluate(
+      (input) => {
+        const {
+          descriptor,
+          actionSource,
+          args: actionArgs,
+        } = input as {
+          descriptor: LiveCdpLocatorDescriptor;
+          actionSource: string;
+          args: unknown[];
+        };
+        const normalized = descriptor;
+        const elements = Array.from(document.querySelectorAll(normalized.selector));
+        const filtered =
+          normalized.hasText === null || normalized.hasText === undefined
+            ? elements
+            : elements.filter((element) =>
+                (element.textContent ?? "").includes(normalized.hasText ?? "")
+              );
+        const rawIndex =
+          normalized.index === null || normalized.index === undefined ? 0 : normalized.index;
+        const index = rawIndex < 0 ? filtered.length + rawIndex : rawIndex;
+        const element = filtered[index];
+
+        if (!element) {
+          throw new Error(`No element found for selector "${normalized.selector}"`);
+        }
+
+        const run = (0, eval)(`(${actionSource})`) as (element: Element, args: unknown[]) => T;
+        return run(element, actionArgs);
+      },
+      {
+        descriptor: normalizeLocatorDescriptor(descriptor),
+        actionSource: action.toString(),
+        args,
+      }
+    )) as T;
+  }
+
+  handleSessionEvent(event: CdpEvent): void {
+    if (event.method === "Page.frameNavigated") {
+      const frame =
+        typeof event.params.frame === "object" && event.params.frame !== null
+          ? (event.params.frame as { parentId?: unknown; url?: unknown })
+          : undefined;
+      if (frame && frame.parentId === undefined && typeof frame.url === "string") {
+        this.#url = frame.url;
+      }
+    }
+
+    this.emit(`cdp:${event.method}`, event.params);
+  }
+
+  updateTargetInfo(targetInfo: TargetInfo): void {
+    this.#url = targetInfo.url ?? this.#url;
+    this.#title = targetInfo.title ?? this.#title;
+  }
+
+  markClosed(): void {
+    if (this.#closed) {
+      return;
+    }
+
+    this.#closed = true;
+    this.emit("close");
+  }
+
+  private waitForSessionEvent(method: string, timeout: number): Promise<void> {
+    return new Promise<void>((resolve, reject) => {
+      const timeoutId = setTimeout(() => {
+        cleanup();
+        reject(new Error(`Timed out waiting for ${method}`));
+      }, timeout);
+      const handleEvent = () => {
+        cleanup();
+        resolve();
+      };
+      const cleanup = () => {
+        clearTimeout(timeoutId);
+        this.off(`cdp:${method}`, handleEvent);
+      };
+
+      this.on(`cdp:${method}`, handleEvent);
+    });
+  }
+}
+
+export class LiveCdpLocator {
+  constructor(
+    private readonly page: LiveCdpPage,
+    private readonly descriptor: LiveCdpLocatorDescriptor
+  ) {}
+
+  async click(options: { timeout?: number } = {}): Promise<void> {
+    await this.waitFor({ state: "visible", timeout: options.timeout });
+    const point = await this.page.locatorAction<Point>(this.descriptor, (element) => {
+      element.scrollIntoView({ block: "center", inline: "center" });
+      const rect = element.getBoundingClientRect();
+      return {
+        x: rect.left + rect.width / 2,
+        y: rect.top + rect.height / 2,
+      };
+    });
+    await this.page.clickPoint(point);
+  }
+
+  async waitFor(
+    options: { state?: "attached" | "detached" | "hidden" | "visible"; timeout?: number } = {}
+  ): Promise<void> {
+    const state = options.state ?? "visible";
+    const deadline = Date.now() + (options.timeout ?? 30_000);
+
+    while (Date.now() <= deadline) {
+      const count = await this.count();
+      const visible = count > 0 ? await this.isVisible().catch(() => false) : false;
+
+      if (
+        (state === "attached" && count > 0) ||
+        (state === "detached" && count === 0) ||
+        (state === "visible" && visible) ||
+        (state === "hidden" && !visible)
+      ) {
+        return;
+      }
+
+      await this.page.waitForTimeout(100);
+    }
+
+    throw new Error(`Timed out waiting for locator "${this.descriptor.selector}" to become ${state}`);
+  }
+
+  async pressSequentially(
+    text: string,
+    options: { delay?: number; timeout?: number } = {}
+  ): Promise<void> {
+    await this.waitFor({ state: "visible", timeout: options.timeout });
+    await this.click();
+
+    if (!options.delay) {
+      await this.page.keyboard.type(text);
+      return;
+    }
+
+    for (const char of text) {
+      await this.page.keyboard.type(char);
+      await this.page.waitForTimeout(options.delay);
+    }
+  }
+
+  async fill(value: string): Promise<void> {
+    await this.page.locatorAction<void>(
+      this.descriptor,
+      (element, [nextValue]) => {
+        const htmlElement = element as HTMLElement & {
+          value?: string;
+          checked?: boolean;
+          isContentEditable?: boolean;
+        };
+        htmlElement.focus();
+        if ("value" in htmlElement) {
+          htmlElement.value = String(nextValue);
+        } else if (htmlElement.isContentEditable) {
+          htmlElement.textContent = String(nextValue);
+        } else {
+          throw new Error("Element cannot be filled");
+        }
+        htmlElement.dispatchEvent(new Event("input", { bubbles: true }));
+        htmlElement.dispatchEvent(new Event("change", { bubbles: true }));
+      },
+      [value]
+    );
+  }
+
+  async textContent(): Promise<string | null> {
+    return await this.page.locatorAction<string | null>(
+      this.descriptor,
+      (element) => element.textContent
+    );
+  }
+
+  async innerText(): Promise<string> {
+    return await this.page.locatorAction<string>(
+      this.descriptor,
+      (element) => (element as HTMLElement).innerText ?? element.textContent ?? ""
+    );
+  }
+
+  async innerHTML(): Promise<string> {
+    return await this.page.locatorAction<string>(this.descriptor, (element) => element.innerHTML);
+  }
+
+  async getAttribute(name: string): Promise<string | null> {
+    return await this.page.locatorAction<string | null>(
+      this.descriptor,
+      (element, [attributeName]) => element.getAttribute(String(attributeName)),
+      [name]
+    );
+  }
+
+  async inputValue(): Promise<string> {
+    return await this.page.locatorAction<string>(
+      this.descriptor,
+      (element) =>
+        (element as HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement).value ?? ""
+    );
+  }
+
+  async isChecked(): Promise<boolean> {
+    return await this.page.locatorAction<boolean>(this.descriptor, (element) =>
+      Boolean((element as HTMLInputElement).checked)
+    );
+  }
+
+  async isVisible(): Promise<boolean> {
+    return await this.page.locatorAction<boolean>(this.descriptor, (element) => {
+      const style = window.getComputedStyle(element);
+      const rect = element.getBoundingClientRect();
+      return (
+        style.visibility !== "hidden" &&
+        style.display !== "none" &&
+        Number(style.opacity) !== 0 &&
+        rect.width > 0 &&
+        rect.height > 0
+      );
+    });
+  }
+
+  async isEnabled(): Promise<boolean> {
+    return await this.page.locatorAction<boolean>(
+      this.descriptor,
+      (element) => !(element as HTMLButtonElement | HTMLInputElement | HTMLSelectElement).disabled
+    );
+  }
+
+  async setChecked(checked: boolean): Promise<void> {
+    await this.page.locatorAction<void>(
+      this.descriptor,
+      (element, [nextChecked]) => {
+        const input = element as HTMLInputElement;
+        if (input.checked !== Boolean(nextChecked)) {
+          input.checked = Boolean(nextChecked);
+          input.dispatchEvent(new Event("input", { bubbles: true }));
+          input.dispatchEvent(new Event("change", { bubbles: true }));
+        }
+      },
+      [checked]
+    );
+  }
+
+  async selectOption(value: string | string[]): Promise<string[]> {
+    return await this.page.locatorAction<string[]>(
+      this.descriptor,
+      (element, [nextValue]) => {
+        const select = element as HTMLSelectElement;
+        const values = Array.isArray(nextValue) ? nextValue.map(String) : [String(nextValue)];
+        for (const option of Array.from(select.options)) {
+          option.selected = values.includes(option.value);
+        }
+        select.dispatchEvent(new Event("input", { bubbles: true }));
+        select.dispatchEvent(new Event("change", { bubbles: true }));
+        return Array.from(select.selectedOptions).map((option) => option.value);
+      },
+      [value]
+    );
+  }
+
+  async count(): Promise<number> {
+    return await this.page.locatorCount(this.descriptor);
+  }
+
+  locator(selector: string): LiveCdpLocator {
+    return new LiveCdpLocator(this.page, {
+      selector: `${this.descriptor.selector} ${selector}`,
+      index: null,
+      hasText: this.descriptor.hasText ?? null,
+    });
+  }
+
+  first(): LiveCdpLocator {
+    return this.nth(0);
+  }
+
+  last(): LiveCdpLocator {
+    return this.nth(-1);
+  }
+
+  nth(index: number): LiveCdpLocator {
+    return new LiveCdpLocator(this.page, {
+      ...normalizeLocatorDescriptor(this.descriptor),
+      index,
+    });
+  }
+
+  filter(options: { hasText?: string | RegExp } = {}): LiveCdpLocator {
+    return new LiveCdpLocator(this.page, {
+      ...normalizeLocatorDescriptor(this.descriptor),
+      hasText: options.hasText === undefined ? null : String(options.hasText),
+    });
+  }
+
+  async all(): Promise<LiveCdpLocator[]> {
+    const count = await this.count();
+    return Array.from({ length: count }, (_, index) => this.nth(index));
+  }
+}
+
+export async function createLiveCdpBrowser(
+  endpoint: string,
+  options: LiveCdpBrowserOptions = {}
+): Promise<LiveCdpBrowser> {
+  return await LiveCdpBrowser.connect(endpoint, options);
+}
+
+export function isLiveCdpBrowser(value: unknown): value is LiveCdpBrowser {
+  return value instanceof LiveCdpBrowser;
+}
+
+export function isLiveCdpPage(value: unknown): value is LiveCdpPage {
+  return value instanceof LiveCdpPage;
+}
+
+export function getLiveCdpPageTargetId(value: unknown): string | null {
+  return value instanceof LiveCdpPage ? value.targetId : null;
+}
+
+async function sendLiveCdpInitCommand(
+  connection: CdpConnection,
+  method: string,
+  params: CdpParams = {},
+  sessionId: string | undefined,
+  step: string,
+  timeoutMs = LIVE_CDP_BROWSER_INIT_TIMEOUT_MS
+): Promise<CdpResult> {
+  try {
+    return await connection.send(method, params, sessionId, timeoutMs);
+  } catch (error) {
+    if (isCdpCommandTimeout(error)) {
+      const message = error instanceof Error ? error.message : String(error);
+      throw new Error(
+        `Timed out after ${timeoutMs}ms initializing live CDP browser during ${step}. ` +
+          `Chrome may be waiting for remote-debugging consent or a target may be unresponsive. ` +
+          `Last error: ${message}`
+      );
+    }
+
+    throw error;
+  }
+}
+
+function isCdpCommandTimeout(error: unknown): boolean {
+  return error instanceof Error && error.message.startsWith("CDP command timed out after ");
+}
+
+function normalizeTargetInfo(value: unknown): TargetInfo | null {
+  if (typeof value !== "object" || value === null) {
+    return null;
+  }
+
+  const record = value as Record<string, unknown>;
+  const targetId = record.targetId;
+  const type = record.type;
+  if (typeof targetId !== "string" || typeof type !== "string") {
+    return null;
+  }
+
+  return {
+    targetId,
+    type,
+    url: typeof record.url === "string" ? record.url : undefined,
+    title: typeof record.title === "string" ? record.title : undefined,
+  };
+}
+
+function normalizeLocatorDescriptor(
+  descriptor: LiveCdpLocatorDescriptor
+): LiveCdpLocatorDescriptor {
+  return {
+    selector: descriptor.selector,
+    index: descriptor.index ?? null,
+    hasText: descriptor.hasText ?? null,
+  };
+}
+
+function readRuntimeResult(result: RuntimeEvaluationResult): unknown {
+  if (result.exceptionDetails) {
+    const exception = result.exceptionDetails.exception;
+    const message =
+      exception?.description ??
+      exception?.value ??
+      result.exceptionDetails.text ??
+      "Evaluation failed";
+    throw new Error(String(message));
+  }
+
+  return readRemoteObject(result.result);
+}
+
+function readRemoteObject(remoteObject: RemoteObject | undefined): unknown {
+  if (!remoteObject) {
+    return undefined;
+  }
+
+  if ("value" in remoteObject) {
+    return remoteObject.value;
+  }
+
+  switch (remoteObject.unserializableValue) {
+    case "NaN":
+      return Number.NaN;
+    case "Infinity":
+      return Infinity;
+    case "-Infinity":
+      return -Infinity;
+    case "-0":
+      return -0;
+    default:
+      break;
+  }
+
+  if (remoteObject.subtype === "null") {
+    return null;
+  }
+
+  return undefined;
+}
+
+const keyDefinitions = new Map<string, KeyDefinition>([
+  ["Enter", { key: "Enter", code: "Enter", windowsVirtualKeyCode: 13, text: "\r" }],
+  ["Escape", { key: "Escape", code: "Escape", windowsVirtualKeyCode: 27 }],
+  ["Tab", { key: "Tab", code: "Tab", windowsVirtualKeyCode: 9, text: "\t" }],
+  ["Backspace", { key: "Backspace", code: "Backspace", windowsVirtualKeyCode: 8 }],
+  ["Delete", { key: "Delete", code: "Delete", windowsVirtualKeyCode: 46 }],
+  ["Shift", { key: "Shift", code: "ShiftLeft", windowsVirtualKeyCode: 16 }],
+  ["Control", { key: "Control", code: "ControlLeft", windowsVirtualKeyCode: 17 }],
+  ["Ctrl", { key: "Control", code: "ControlLeft", windowsVirtualKeyCode: 17 }],
+  ["Alt", { key: "Alt", code: "AltLeft", windowsVirtualKeyCode: 18 }],
+  ["Option", { key: "Alt", code: "AltLeft", windowsVirtualKeyCode: 18 }],
+  ["Meta", { key: "Meta", code: "MetaLeft", windowsVirtualKeyCode: 91 }],
+  ["Cmd", { key: "Meta", code: "MetaLeft", windowsVirtualKeyCode: 91 }],
+  ["Command", { key: "Meta", code: "MetaLeft", windowsVirtualKeyCode: 91 }],
+  ["ArrowLeft", { key: "ArrowLeft", code: "ArrowLeft", windowsVirtualKeyCode: 37 }],
+  ["ArrowUp", { key: "ArrowUp", code: "ArrowUp", windowsVirtualKeyCode: 38 }],
+  ["ArrowRight", { key: "ArrowRight", code: "ArrowRight", windowsVirtualKeyCode: 39 }],
+  ["ArrowDown", { key: "ArrowDown", code: "ArrowDown", windowsVirtualKeyCode: 40 }],
+] as const);
+
+function isPageLikeTarget(targetInfo: TargetInfo): boolean {
+  if (targetInfo.type === "page") {
+    return true;
+  }
+
+  if (targetInfo.type !== "other") {
+    return false;
+  }
+
+  return /^(https?|about|chrome):/i.test(targetInfo.url ?? "");
+}
+
+function parseKeyChord(key: string): { definition: KeyDefinition; modifiers: number } {
+  const parts = key
+    .split("+")
+    .map((part) => part.trim())
+    .filter(Boolean);
+  const keyName = parts.pop() ?? key;
+  const modifiers = parts.reduce((mask, modifier) => {
+    switch (modifier.toLowerCase()) {
+      case "alt":
+      case "option":
+        return mask | 1;
+      case "control":
+      case "ctrl":
+        return mask | 2;
+      case "meta":
+      case "cmd":
+      case "command":
+        return mask | 4;
+      case "shift":
+        return mask | 8;
+      default:
+        return mask;
+    }
+  }, 0);
+
+  return {
+    definition: keyDefinitionFor(keyName),
+    modifiers,
+  };
+}
+
+function modifierMaskForKey(key: string): number {
+  switch (key.toLowerCase()) {
+    case "alt":
+    case "option":
+      return 1;
+    case "control":
+    case "ctrl":
+      return 2;
+    case "meta":
+    case "cmd":
+    case "command":
+      return 4;
+    case "shift":
+      return 8;
+    default:
+      return 0;
+  }
+}
+
+function keyDefinitionFor(key: string): KeyDefinition {
+  const existing = keyDefinitions.get(key);
+  if (existing) {
+    return existing;
+  }
+
+  if (/^[a-z]$/i.test(key)) {
+    const upper = key.toUpperCase();
+    return {
+      key: key.toLowerCase(),
+      code: `Key${upper}`,
+      windowsVirtualKeyCode: upper.charCodeAt(0),
+      text: key,
+    };
+  }
+
+  return {
+    key,
+    code: key,
+    windowsVirtualKeyCode: key.length === 1 ? key.toUpperCase().charCodeAt(0) : 0,
+    text: key.length === 1 ? key : undefined,
+  };
+}

--- a/daemon/src/sandbox/__tests__/auto-connect.test.ts
+++ b/daemon/src/sandbox/__tests__/auto-connect.test.ts
@@ -431,7 +431,7 @@ describe("BrowserManager auto-connect", () => {
 
       await expect(getInternals(manager).probePort(address.port)).resolves.toEqual({
         endpoint: websocketUrl,
-        backend: "playwright",
+        backend: "live-cdp",
       });
     } finally {
       await new Promise<void>((resolve, reject) => {
@@ -455,7 +455,8 @@ describe("BrowserManager auto-connect", () => {
     });
     const context = new MockContext([existingPage]);
     const browser = new MockBrowser([context]);
-    const connectOverCDP = vi.fn(async () => browser);
+    const connectOverCDP = vi.fn();
+    const createLiveCdpBrowser = vi.fn(async () => browser);
     const fetch = vi.fn(async (input: RequestInfo | URL) => {
       expect(String(input)).toBe("http://127.0.0.1:9222/json/version");
       return new Response(
@@ -472,15 +473,17 @@ describe("BrowserManager auto-connect", () => {
     }) as typeof globalThis.fetch;
     const { manager } = createManager({
       connectOverCDP,
+      createLiveCdpBrowser,
       fetch,
     });
 
     await manager.connectBrowser("attached", "http://127.0.0.1:9222");
     const namedPage = await manager.getPage("attached", "dashboard");
 
-    expect(connectOverCDP).toHaveBeenCalledWith(
+    expect(createLiveCdpBrowser).toHaveBeenCalledWith(
       "ws://127.0.0.1:9222/devtools/browser/connected-browser"
     );
+    expect(connectOverCDP).not.toHaveBeenCalled();
     expect(namedPage).not.toBe(existingPage);
     expect(context.newPageCalls).toBe(1);
     await expect(manager.listPages("attached")).resolves.toEqual([
@@ -645,7 +648,7 @@ describe("BrowserManager auto-connect", () => {
     const browser = new MockBrowser([new MockContext()]);
     const requests: string[] = [];
     const connectOverCDP = vi.fn(async () => browser);
-    const createLiveCdpBrowser = vi.fn();
+    const createLiveCdpBrowser = vi.fn(async () => browser);
     const fetch = vi.fn(async (input: RequestInfo | URL) => {
       const url = String(input);
       requests.push(url);
@@ -682,10 +685,10 @@ describe("BrowserManager auto-connect", () => {
       "http://127.0.0.1:9222/json/version",
       "http://127.0.0.1:9223/json/version",
     ]);
-    expect(connectOverCDP).toHaveBeenCalledWith(
+    expect(createLiveCdpBrowser).toHaveBeenCalledWith(
       "ws://127.0.0.1:9223/devtools/browser/discovered"
     );
-    expect(createLiveCdpBrowser).not.toHaveBeenCalled();
+    expect(connectOverCDP).not.toHaveBeenCalled();
     expect(manager.listBrowsers()).toEqual([
       {
         name: "auto-browser",
@@ -759,10 +762,10 @@ describe("BrowserManager auto-connect", () => {
 
     await manager.autoConnect("auto-browser");
 
-    expect(createLiveCdpBrowser).toHaveBeenCalledTimes(1);
-    expect(createLiveCdpBrowser).toHaveBeenCalledWith(staleEndpoint);
-    expect(connectOverCDP).toHaveBeenCalledTimes(1);
-    expect(connectOverCDP).toHaveBeenCalledWith(discoveredEndpoint);
+    expect(createLiveCdpBrowser).toHaveBeenCalledTimes(2);
+    expect(createLiveCdpBrowser).toHaveBeenNthCalledWith(1, staleEndpoint);
+    expect(createLiveCdpBrowser).toHaveBeenNthCalledWith(2, discoveredEndpoint);
+    expect(connectOverCDP).not.toHaveBeenCalled();
     expect(requests).toEqual([
       "http://127.0.0.1:9222/json/version",
       "http://127.0.0.1:9223/json/version",

--- a/daemon/src/sandbox/__tests__/auto-connect.test.ts
+++ b/daemon/src/sandbox/__tests__/auto-connect.test.ts
@@ -137,8 +137,8 @@ class MockBrowser extends EventEmitter {
 
 type BrowserManagerInternals = {
   readDevToolsActivePort(expectedPort?: number): Promise<string | null>;
-  discoverChrome(): Promise<string | null>;
-  probePort(port: number): Promise<string | null>;
+  discoverChrome(): Promise<{ endpoint: string; backend: string } | null>;
+  probePort(port: number): Promise<{ endpoint: string; backend: string } | null>;
 };
 
 function createEnoentError(filePath: string): NodeJS.ErrnoException {
@@ -152,6 +152,7 @@ function createEnoentError(filePath: string): NodeJS.ErrnoException {
 function createManager(
   options: {
     connectOverCDP?: ReturnType<typeof vi.fn>;
+    createLiveCdpBrowser?: ReturnType<typeof vi.fn>;
     fetch?: typeof globalThis.fetch;
     homedir?: () => string;
     launchPersistentContext?: ReturnType<typeof vi.fn>;
@@ -160,6 +161,7 @@ function createManager(
   } = {}
 ) {
   const connectOverCDP = options.connectOverCDP ?? vi.fn();
+  const createLiveCdpBrowser = options.createLiveCdpBrowser ?? vi.fn();
   const fetch =
     options.fetch ??
     (vi.fn(async () => {
@@ -175,6 +177,7 @@ function createManager(
 
   const manager = new BrowserManager(path.join("/tmp", "dev-browser-auto-connect-tests"), {
     connectOverCDP: connectOverCDP as never,
+    createLiveCdpBrowser: createLiveCdpBrowser as never,
     fetch,
     homedir: options.homedir ?? (() => "/Users/tester"),
     launchPersistentContext: launchPersistentContext as never,
@@ -186,6 +189,7 @@ function createManager(
   return {
     manager,
     connectOverCDP,
+    createLiveCdpBrowser,
     fetch,
     launchPersistentContext,
     readFile,
@@ -386,7 +390,10 @@ describe("BrowserManager auto-connect", () => {
     const fetch = vi.fn() as typeof globalThis.fetch;
     const { manager } = createManager({ fetch, homedir: () => homeDir, readFile });
 
-    await expect(getInternals(manager).discoverChrome()).resolves.toBe(websocketUrl);
+    await expect(getInternals(manager).discoverChrome()).resolves.toEqual({
+      endpoint: websocketUrl,
+      backend: "live-cdp",
+    });
     expect(requests).toEqual([]);
     expect(fetch).not.toHaveBeenCalled();
   });
@@ -422,7 +429,10 @@ describe("BrowserManager auto-connect", () => {
         fetch: globalThis.fetch,
       });
 
-      await expect(getInternals(manager).probePort(address.port)).resolves.toBe(websocketUrl);
+      await expect(getInternals(manager).probePort(address.port)).resolves.toEqual({
+        endpoint: websocketUrl,
+        backend: "playwright",
+      });
     } finally {
       await new Promise<void>((resolve, reject) => {
         server.close((error) => {
@@ -499,9 +509,9 @@ describe("BrowserManager auto-connect", () => {
 
   it("getBrowser returns connected entries without relaunching them", async () => {
     const browser = new MockBrowser([new MockContext()]);
-    const connectOverCDP = vi.fn(async () => browser);
+    const createLiveCdpBrowser = vi.fn(async () => browser);
     const { manager } = createManager({
-      connectOverCDP,
+      createLiveCdpBrowser,
     });
 
     await manager.connectBrowser(
@@ -516,11 +526,30 @@ describe("BrowserManager auto-connect", () => {
       type: "connected",
       browser,
     });
-    expect(connectOverCDP).toHaveBeenCalledTimes(1);
+    expect(createLiveCdpBrowser).toHaveBeenCalledTimes(1);
 
     browser.disconnect();
 
     expect(manager.getBrowser("attached")).toBeUndefined();
+  });
+
+  it("connectBrowser routes explicit websocket endpoints through the live-CDP adapter", async () => {
+    const tunneledEndpoint = "wss://chrome.example.test/devtools/browser/external-session";
+    const pageEndpoint = "ws://127.0.0.1:9222/devtools/page/page-id";
+    const browser = new MockBrowser([new MockContext()]);
+    const connectOverCDP = vi.fn();
+    const createLiveCdpBrowser = vi.fn(async () => browser);
+    const { manager } = createManager({
+      connectOverCDP,
+      createLiveCdpBrowser,
+    });
+
+    await manager.connectBrowser("attached", tunneledEndpoint);
+    await manager.connectBrowser("page-target", pageEndpoint);
+
+    expect(createLiveCdpBrowser).toHaveBeenNthCalledWith(1, tunneledEndpoint);
+    expect(createLiveCdpBrowser).toHaveBeenNthCalledWith(2, pageEndpoint);
+    expect(connectOverCDP).not.toHaveBeenCalled();
   });
 
   it("connectBrowser falls back to DevToolsActivePort when /json/version returns 404", async () => {
@@ -534,7 +563,8 @@ describe("BrowserManager auto-connect", () => {
       "DevToolsActivePort"
     );
     const browser = new MockBrowser([new MockContext()]);
-    const connectOverCDP = vi.fn(async () => browser);
+    const connectOverCDP = vi.fn();
+    const createLiveCdpBrowser = vi.fn(async () => browser);
     const fetch = vi.fn(async (input: RequestInfo | URL) => {
       expect(String(input)).toBe("http://127.0.0.1:9222/json/version");
       return new Response("not found", { status: 404 });
@@ -548,6 +578,7 @@ describe("BrowserManager auto-connect", () => {
     });
     const { manager } = createManager({
       connectOverCDP,
+      createLiveCdpBrowser,
       fetch,
       homedir: () => homeDir,
       readFile,
@@ -555,9 +586,10 @@ describe("BrowserManager auto-connect", () => {
 
     await manager.connectBrowser("attached", "http://127.0.0.1:9222");
 
-    expect(connectOverCDP).toHaveBeenCalledWith(
+    expect(createLiveCdpBrowser).toHaveBeenCalledWith(
       "ws://127.0.0.1:9222/devtools/browser/from-active-port"
     );
+    expect(connectOverCDP).not.toHaveBeenCalled();
   });
 
   it("reports a helpful error when /json/version returns 404 and no matching DevToolsActivePort exists", async () => {
@@ -593,9 +625,9 @@ describe("BrowserManager auto-connect", () => {
   it("keeps external browsers alive on stopAll by only closing the CDP connection", async () => {
     const context = new MockContext();
     const browser = new MockBrowser([context]);
-    const connectOverCDP = vi.fn(async () => browser);
+    const createLiveCdpBrowser = vi.fn(async () => browser);
     const { manager } = createManager({
-      connectOverCDP,
+      createLiveCdpBrowser,
     });
 
     await manager.connectBrowser(
@@ -613,6 +645,7 @@ describe("BrowserManager auto-connect", () => {
     const browser = new MockBrowser([new MockContext()]);
     const requests: string[] = [];
     const connectOverCDP = vi.fn(async () => browser);
+    const createLiveCdpBrowser = vi.fn();
     const fetch = vi.fn(async (input: RequestInfo | URL) => {
       const url = String(input);
       requests.push(url);
@@ -638,6 +671,7 @@ describe("BrowserManager auto-connect", () => {
     });
     const { manager } = createManager({
       connectOverCDP,
+      createLiveCdpBrowser,
       fetch,
       readFile,
     });
@@ -648,7 +682,10 @@ describe("BrowserManager auto-connect", () => {
       "http://127.0.0.1:9222/json/version",
       "http://127.0.0.1:9223/json/version",
     ]);
-    expect(connectOverCDP).toHaveBeenCalledWith("ws://127.0.0.1:9223/devtools/browser/discovered");
+    expect(connectOverCDP).toHaveBeenCalledWith(
+      "ws://127.0.0.1:9223/devtools/browser/discovered"
+    );
+    expect(createLiveCdpBrowser).not.toHaveBeenCalled();
     expect(manager.listBrowsers()).toEqual([
       {
         name: "auto-browser",
@@ -673,7 +710,8 @@ describe("BrowserManager auto-connect", () => {
     const discoveredEndpoint = "ws://127.0.0.1:9223/devtools/browser/discovered";
     const browser = new MockBrowser([new MockContext()]);
     const requests: string[] = [];
-    const connectOverCDP = vi.fn(async (endpoint: string) => {
+    const connectOverCDP = vi.fn(async () => browser);
+    const createLiveCdpBrowser = vi.fn(async (endpoint: string) => {
       if (endpoint === staleEndpoint) {
         throw new Error("stale DevToolsActivePort");
       }
@@ -713,6 +751,7 @@ describe("BrowserManager auto-connect", () => {
     });
     const { manager } = createManager({
       connectOverCDP,
+      createLiveCdpBrowser,
       fetch,
       homedir: () => homeDir,
       readFile,
@@ -720,9 +759,10 @@ describe("BrowserManager auto-connect", () => {
 
     await manager.autoConnect("auto-browser");
 
-    expect(connectOverCDP).toHaveBeenCalledTimes(2);
-    expect(connectOverCDP).toHaveBeenNthCalledWith(1, staleEndpoint);
-    expect(connectOverCDP).toHaveBeenNthCalledWith(2, discoveredEndpoint);
+    expect(createLiveCdpBrowser).toHaveBeenCalledTimes(1);
+    expect(createLiveCdpBrowser).toHaveBeenCalledWith(staleEndpoint);
+    expect(connectOverCDP).toHaveBeenCalledTimes(1);
+    expect(connectOverCDP).toHaveBeenCalledWith(discoveredEndpoint);
     expect(requests).toEqual([
       "http://127.0.0.1:9222/json/version",
       "http://127.0.0.1:9223/json/version",

--- a/daemon/src/sandbox/quickjs-sandbox.ts
+++ b/daemon/src/sandbox/quickjs-sandbox.ts
@@ -3,7 +3,14 @@ import util from "node:util";
 
 import type { Page } from "playwright";
 
-import type { BrowserManager } from "../browser-manager.js";
+import type { BrowserManager, BrowserPage } from "../browser-manager.js";
+import {
+  isLiveCdpBrowser,
+  isLiveCdpPage,
+  type LiveCdpLocatorDescriptor,
+  type LiveCdpPage,
+  type SerializedEvaluation,
+} from "../live-cdp-browser.js";
 import {
   ensureDevBrowserTempDir,
   readDevBrowserTempFile,
@@ -124,6 +131,69 @@ function requireString(value: unknown, label: string): string {
   return value;
 }
 
+function readNumber(value: unknown, label: string): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    throw new TypeError(`${label} must be a finite number`);
+  }
+
+  return value;
+}
+
+function readOptions(value: unknown): Record<string, unknown> {
+  return typeof value === "object" && value !== null ? (value as Record<string, unknown>) : {};
+}
+
+function readStringOrStringArray(value: unknown, label: string): string | string[] {
+  if (typeof value === "string") {
+    return value;
+  }
+
+  if (Array.isArray(value) && value.every((item) => typeof item === "string")) {
+    return value;
+  }
+
+  throw new TypeError(`${label} must be a string or string array`);
+}
+
+function readSerializedEvaluation(value: unknown): SerializedEvaluation {
+  if (typeof value !== "object" || value === null) {
+    throw new TypeError("Serialized evaluation must be an object");
+  }
+
+  const record = value as Record<string, unknown>;
+  if (record.kind === "expression" && typeof record.source === "string") {
+    return {
+      kind: "expression",
+      source: record.source,
+    };
+  }
+
+  if (record.kind === "function" && typeof record.source === "string") {
+    return {
+      kind: "function",
+      source: record.source,
+      hasArg: record.hasArg === true,
+      arg: record.arg,
+      args: Array.isArray(record.args) ? record.args : undefined,
+    };
+  }
+
+  throw new TypeError("Serialized evaluation has an unsupported shape");
+}
+
+function readLocatorDescriptor(value: unknown): LiveCdpLocatorDescriptor {
+  if (typeof value !== "object" || value === null) {
+    throw new TypeError("Locator descriptor must be an object");
+  }
+
+  const record = value as Record<string, unknown>;
+  return {
+    selector: requireString(record.selector, "Locator selector"),
+    index: typeof record.index === "number" ? record.index : null,
+    hasText: typeof record.hasText === "string" ? record.hasText : null,
+  };
+}
+
 function toServerImpl<T>(clientObject: unknown, label: string): T {
   const connection = (clientObject as { _connection?: { toImpl?: (value: unknown) => unknown } })
     ._connection;
@@ -178,7 +248,8 @@ interface QuickJSSandboxOptions {
 
 export class QuickJSSandbox {
   readonly #options: QuickJSSandboxOptions;
-  readonly #anonymousPages = new Set<Page>();
+  readonly #anonymousPages = new Set<BrowserPage>();
+  readonly #liveCdpPages = new Map<string, LiveCdpPage>();
   readonly #pendingHostOperations = new Set<Promise<void>>();
   readonly #transportInbox: string[] = [];
 
@@ -213,6 +284,11 @@ export class QuickJSSandbox {
           saveScreenshot: (name, data) => this.#writeTempFile(name, data),
           writeFile: (name, data) => this.#writeTempFile(name, data),
           readFile: (name) => this.#readTempFile(name),
+          liveCdpGetPage: (name) => this.#liveCdpGetPage(name),
+          liveCdpNewPage: () => this.#liveCdpNewPage(),
+          liveCdpPageCall: (pageId, method, args) => this.#liveCdpPageCall(pageId, method, args),
+          liveCdpLocatorCall: (pageId, descriptor, method, args) =>
+            this.#liveCdpLocatorCall(pageId, descriptor, method, args),
         },
         onConsole: (level, args) => {
           this.#routeConsole(level, args);
@@ -368,6 +444,13 @@ export class QuickJSSandbox {
           `Browser "${this.#options.browserName}" not found. It should have been created before script execution.`
         );
       }
+
+      if (isLiveCdpBrowser(browserEntry.browser)) {
+        await this.#installLiveCdpFacade();
+        this.#initialized = true;
+        return;
+      }
+
       this.#hostBridge = new HostBridge({
         sendToSandbox: (json) => {
           this.#transportInbox.push(json);
@@ -537,6 +620,267 @@ export class QuickJSSandbox {
     }
   }
 
+  async #installLiveCdpFacade(): Promise<void> {
+    await this.#host!.executeScript(
+      `
+        (() => {
+          const hostCall = globalThis.__hostCall;
+          if (typeof hostCall !== "function") {
+            throw new Error("Sandbox bridge did not expose a host-call function");
+          }
+
+          if (!delete globalThis.__hostCall) {
+            globalThis.__hostCall = undefined;
+          }
+          if (!delete globalThis.__transport_send) {
+            globalThis.__transport_send = undefined;
+          }
+          if (!delete globalThis.__createPlaywrightClient) {
+            globalThis.__createPlaywrightClient = undefined;
+          }
+
+          const callHost = async (name, args = []) => {
+            return await hostCall(name, JSON.stringify(args));
+          };
+
+          const serializeEvaluation = (pageFunction, args) => {
+            if (typeof pageFunction === "string") {
+              return {
+                kind: "expression",
+                source: pageFunction,
+              };
+            }
+            if (typeof pageFunction !== "function") {
+              throw new TypeError("Evaluation argument must be a function or expression string");
+            }
+            return {
+              kind: "function",
+              source: String(pageFunction),
+              hasArg: args.length > 0,
+              arg: args[0],
+              args,
+            };
+          };
+
+          const encodeHostFilePayload = (value) => {
+            if (typeof value === "string") {
+              return { encoding: "utf8", data: value };
+            }
+            if (value instanceof ArrayBuffer || ArrayBuffer.isView(value)) {
+              return { encoding: "base64", data: Buffer.from(value).toString("base64") };
+            }
+            throw new TypeError(
+              "File data must be a string, Buffer, Uint8Array, or ArrayBuffer",
+            );
+          };
+
+          class LiveCdpLocator {
+            constructor(page, descriptor) {
+              this.__page = page;
+              this.__pageId = page.__pageId;
+              this.__descriptor = {
+                selector: descriptor.selector,
+                index: descriptor.index ?? null,
+                hasText: descriptor.hasText ?? null,
+              };
+            }
+
+            async __call(method, args = []) {
+              return await callHost("liveCdpLocatorCall", [
+                this.__pageId,
+                this.__descriptor,
+                method,
+                args,
+              ]);
+            }
+
+            async click(options) {
+              const result = await this.__call("click", [options]);
+              await this.__page.__refreshUrl();
+              return result;
+            }
+            fill(value, options) { return this.__call("fill", [value, options]); }
+            waitFor(options) { return this.__call("waitFor", [options]); }
+            pressSequentially(text, options) { return this.__call("pressSequentially", [text, options]); }
+            textContent() { return this.__call("textContent"); }
+            innerText() { return this.__call("innerText"); }
+            innerHTML() { return this.__call("innerHTML"); }
+            getAttribute(name) { return this.__call("getAttribute", [name]); }
+            inputValue() { return this.__call("inputValue"); }
+            isChecked() { return this.__call("isChecked"); }
+            isVisible() { return this.__call("isVisible"); }
+            isEnabled() { return this.__call("isEnabled"); }
+            count() { return this.__call("count"); }
+            selectOption(value) { return this.__call("selectOption", [value]); }
+
+            locator(selector) {
+              return new LiveCdpLocator(this.__page, {
+                selector: this.__descriptor.selector + " " + selector,
+                index: null,
+                hasText: this.__descriptor.hasText,
+              });
+            }
+
+            first() { return this.nth(0); }
+            last() { return this.nth(-1); }
+
+            nth(index) {
+              return new LiveCdpLocator(this.__page, {
+                ...this.__descriptor,
+                index,
+              });
+            }
+
+            filter(options = {}) {
+              return new LiveCdpLocator(this.__page, {
+                ...this.__descriptor,
+                hasText: options.hasText == null ? null : String(options.hasText),
+              });
+            }
+
+            async all() {
+              const count = await this.count();
+              return Array.from({ length: count }, (_, index) => this.nth(index));
+            }
+          }
+
+          class LiveCdpPage {
+            constructor(pageInfo) {
+              this.__pageId = pageInfo.id;
+              this.__url = typeof pageInfo.url === "string" ? pageInfo.url : "about:blank";
+              this.keyboard = Object.freeze({
+                type: async (text) => await this.__call("keyboard.type", [text]),
+                press: async (key) => await this.__call("keyboard.press", [key]),
+                down: async (key) => await this.__call("keyboard.down", [key]),
+                up: async (key) => await this.__call("keyboard.up", [key]),
+              });
+              this.mouse = Object.freeze({
+                click: async (x, y) => await this.__call("mouse.click", [x, y]),
+              });
+            }
+
+            async __call(method, args = []) {
+              return await callHost("liveCdpPageCall", [this.__pageId, method, args]);
+            }
+
+            async __refreshUrl() {
+              const nextUrl = await this.__call("url");
+              if (typeof nextUrl === "string") {
+                this.__url = nextUrl;
+              }
+            }
+
+            async goto(url, options) {
+              await this.__call("goto", [url, options]);
+              await this.__refreshUrl();
+              return null;
+            }
+
+            async reload(options) {
+              await this.__call("reload", [options]);
+              await this.__refreshUrl();
+              return null;
+            }
+
+            url() { return this.__url; }
+            title() { return this.__call("title"); }
+            waitForTimeout(timeout) { return this.__call("waitForTimeout", [timeout]); }
+            async click(selector) {
+              const result = await this.__call("click", [selector]);
+              await this.__refreshUrl();
+              return result;
+            }
+            fill(selector, value) { return this.__call("fill", [selector, value]); }
+            type(selector, text) { return this.__call("type", [selector, text]); }
+            async press(selector, key) {
+              const result = await this.__call("press", [selector, key]);
+              await this.__refreshUrl();
+              return result;
+            }
+            check(selector) { return this.__call("check", [selector]); }
+            uncheck(selector) { return this.__call("uncheck", [selector]); }
+            selectOption(selector, value) { return this.__call("selectOption", [selector, value]); }
+            textContent(selector) { return this.__call("textContent", [selector]); }
+            innerText(selector) { return this.__call("innerText", [selector]); }
+            innerHTML(selector) { return this.__call("innerHTML", [selector]); }
+            getAttribute(selector, name) { return this.__call("getAttribute", [selector, name]); }
+            inputValue(selector) { return this.__call("inputValue", [selector]); }
+            isChecked(selector) { return this.__call("isChecked", [selector]); }
+            isVisible(selector) { return this.__call("isVisible", [selector]); }
+            isHidden(selector) { return this.__call("isHidden", [selector]); }
+            isEnabled(selector) { return this.__call("isEnabled", [selector]); }
+            waitForSelector(selector, options) { return this.__call("waitForSelector", [selector, options]); }
+            content() { return this.__call("content"); }
+            setContent(html) { return this.__call("setContent", [html]); }
+            setInputFiles(selector, files, options) { return this.__call("setInputFiles", [selector, files, options]); }
+            close() { return this.__call("close"); }
+
+            evaluate(pageFunction, ...args) {
+              return this.__call("evaluateSerialized", [serializeEvaluation(pageFunction, args)]);
+            }
+
+            waitForFunction(pageFunction, arg, options) {
+              return this.__call("waitForFunctionSerialized", [
+                serializeEvaluation(pageFunction, arguments.length >= 2 ? [arg] : []),
+                options,
+              ]);
+            }
+
+            locator(selector) {
+              return new LiveCdpLocator(this, {
+                selector,
+                index: null,
+                hasText: null,
+              });
+            }
+          }
+
+          const browserApi = Object.freeze({
+            getPage: async (name) => new LiveCdpPage(await callHost("liveCdpGetPage", [name])),
+            newPage: async () => new LiveCdpPage(await callHost("liveCdpNewPage")),
+            listPages: async () => await callHost("listPages"),
+            closePage: async (name) => await callHost("closePage", [name]),
+          });
+
+          Object.defineProperty(globalThis, "browser", {
+            value: browserApi,
+            configurable: false,
+            enumerable: true,
+            writable: false,
+          });
+
+          Object.defineProperties(globalThis, {
+            saveScreenshot: {
+              value: async (buffer, name) => {
+                return await callHost("saveScreenshot", [name, encodeHostFilePayload(buffer)]);
+              },
+              configurable: false,
+              enumerable: true,
+              writable: false,
+            },
+            writeFile: {
+              value: async (name, data) => {
+                return await callHost("writeFile", [name, encodeHostFilePayload(data)]);
+              },
+              configurable: false,
+              enumerable: true,
+              writable: false,
+            },
+            readFile: {
+              value: async (name) => await callHost("readFile", [name]),
+              configurable: false,
+              enumerable: true,
+              writable: false,
+            },
+          });
+        })()
+      `,
+      {
+        filename: "live-cdp-sandbox-init.js",
+      }
+    );
+  }
+
   async executeScript(script: string): Promise<void> {
     this.#assertInitialized();
     let executionError: unknown;
@@ -581,6 +925,7 @@ export class QuickJSSandbox {
 
     this.#transportInbox.length = 0;
     this.#pendingHostOperations.clear();
+    this.#liveCdpPages.clear();
 
     try {
       await this.#hostBridge?.dispose();
@@ -666,12 +1011,210 @@ export class QuickJSSandbox {
     await this.#flushPromise;
   }
 
+  #rememberLiveCdpPage(page: BrowserPage): { id: string; url: string } {
+    if (!isLiveCdpPage(page)) {
+      throw new Error("Connected Chrome page is not backed by the live-CDP adapter");
+    }
+
+    this.#liveCdpPages.set(page.targetId, page);
+    page.on("close", () => {
+      this.#liveCdpPages.delete(page.targetId);
+    });
+    return {
+      id: page.targetId,
+      url: page.url(),
+    };
+  }
+
+  #getLiveCdpPage(pageId: unknown): LiveCdpPage {
+    const page = this.#liveCdpPages.get(requireString(pageId, "Live-CDP page id"));
+    if (!page || page.isClosed()) {
+      throw new Error(`Live-CDP page "${String(pageId)}" is closed or unknown`);
+    }
+
+    return page;
+  }
+
+  async #liveCdpGetPage(name: unknown): Promise<{ id: string; url: string }> {
+    const page = await this.#options.manager.getPage(
+      this.#options.browserName,
+      requireString(name, "Page name or targetId")
+    );
+    return this.#rememberLiveCdpPage(page);
+  }
+
+  async #liveCdpNewPage(): Promise<{ id: string; url: string }> {
+    const page = await this.#options.manager.newPage(this.#options.browserName);
+    this.#anonymousPages.add(page);
+    page.on("close", () => {
+      this.#anonymousPages.delete(page);
+    });
+    return this.#rememberLiveCdpPage(page);
+  }
+
+  async #liveCdpPageCall(pageId: unknown, method: unknown, argsValue: unknown): Promise<unknown> {
+    const page = this.#getLiveCdpPage(pageId);
+    const args = Array.isArray(argsValue) ? argsValue : [];
+    const methodName = requireString(method, "Live-CDP page method");
+
+    switch (methodName) {
+      case "goto":
+        return await page.goto(requireString(args[0], "URL"), readOptions(args[1]));
+      case "reload":
+        return await page.reload(readOptions(args[0]));
+      case "url":
+        return page.url();
+      case "title":
+        return await page.title();
+      case "evaluateSerialized":
+        return await page.evaluateSerialized(readSerializedEvaluation(args[0]));
+      case "waitForFunctionSerialized":
+        return await this.#waitForLiveCdpFunction(
+          page,
+          readSerializedEvaluation(args[0]),
+          readOptions(args[1])
+        );
+      case "waitForTimeout":
+        return await page.waitForTimeout(readNumber(args[0], "Timeout"));
+      case "click":
+        return await page.click(requireString(args[0], "Selector"));
+      case "fill":
+        return await page.fill(requireString(args[0], "Selector"), String(args[1] ?? ""));
+      case "type":
+        return await page.type(requireString(args[0], "Selector"), String(args[1] ?? ""));
+      case "press":
+        return await page.press(requireString(args[0], "Selector"), requireString(args[1], "Key"));
+      case "check":
+        return await page.check(requireString(args[0], "Selector"));
+      case "uncheck":
+        return await page.uncheck(requireString(args[0], "Selector"));
+      case "selectOption":
+        return await page.selectOption(
+          requireString(args[0], "Selector"),
+          readStringOrStringArray(args[1], "Option value")
+        );
+      case "textContent":
+        return await page.textContent(requireString(args[0], "Selector"));
+      case "innerText":
+        return await page.innerText(requireString(args[0], "Selector"));
+      case "innerHTML":
+        return await page.innerHTML(requireString(args[0], "Selector"));
+      case "getAttribute":
+        return await page.getAttribute(
+          requireString(args[0], "Selector"),
+          requireString(args[1], "Attribute name")
+        );
+      case "inputValue":
+        return await page.inputValue(requireString(args[0], "Selector"));
+      case "isChecked":
+        return await page.isChecked(requireString(args[0], "Selector"));
+      case "isVisible":
+        return await page.isVisible(requireString(args[0], "Selector"));
+      case "isHidden":
+        return await page.isHidden(requireString(args[0], "Selector"));
+      case "isEnabled":
+        return await page.isEnabled(requireString(args[0], "Selector"));
+      case "waitForSelector":
+        return await page.waitForSelector(requireString(args[0], "Selector"), readOptions(args[1]));
+      case "content":
+        return await page.content();
+      case "setContent":
+        return await page.setContent(String(args[0] ?? ""));
+      case "setInputFiles":
+        return await page.setInputFiles(
+          requireString(args[0], "Selector"),
+          readStringOrStringArray(args[1], "Input file")
+        );
+      case "close":
+        return await page.close();
+      case "keyboard.type":
+        return await page.keyboard.type(String(args[0] ?? ""));
+      case "keyboard.press":
+        return await page.keyboard.press(requireString(args[0], "Key"));
+      case "keyboard.down":
+        return await page.keyboard.down(requireString(args[0], "Key"));
+      case "keyboard.up":
+        return await page.keyboard.up(requireString(args[0], "Key"));
+      case "mouse.click":
+        return await page.mouse.click(
+          readNumber(args[0], "X coordinate"),
+          readNumber(args[1], "Y coordinate")
+        );
+      default:
+        throw new Error(`Unsupported live-CDP page method "${methodName}"`);
+    }
+  }
+
+  async #liveCdpLocatorCall(
+    pageId: unknown,
+    descriptorValue: unknown,
+    method: unknown,
+    argsValue: unknown
+  ): Promise<unknown> {
+    const page = this.#getLiveCdpPage(pageId);
+    const locator = page.locator(readLocatorDescriptor(descriptorValue));
+    const args = Array.isArray(argsValue) ? argsValue : [];
+    const methodName = requireString(method, "Live-CDP locator method");
+
+    switch (methodName) {
+      case "click":
+        return await locator.click(readOptions(args[0]));
+      case "fill":
+        return await locator.fill(String(args[0] ?? ""));
+      case "waitFor":
+        return await locator.waitFor(readOptions(args[0]));
+      case "pressSequentially":
+        return await locator.pressSequentially(String(args[0] ?? ""), readOptions(args[1]));
+      case "textContent":
+        return await locator.textContent();
+      case "innerText":
+        return await locator.innerText();
+      case "innerHTML":
+        return await locator.innerHTML();
+      case "getAttribute":
+        return await locator.getAttribute(requireString(args[0], "Attribute name"));
+      case "inputValue":
+        return await locator.inputValue();
+      case "isChecked":
+        return await locator.isChecked();
+      case "isVisible":
+        return await locator.isVisible();
+      case "isEnabled":
+        return await locator.isEnabled();
+      case "count":
+        return await locator.count();
+      case "selectOption":
+        return await locator.selectOption(readStringOrStringArray(args[0], "Option value"));
+      default:
+        throw new Error(`Unsupported live-CDP locator method "${methodName}"`);
+    }
+  }
+
+  async #waitForLiveCdpFunction(
+    page: LiveCdpPage,
+    payload: SerializedEvaluation,
+    options: Record<string, unknown>
+  ): Promise<unknown> {
+    const timeout = typeof options.timeout === "number" ? options.timeout : 30_000;
+    const deadline = Date.now() + timeout;
+
+    while (Date.now() <= deadline) {
+      const value = await page.evaluateSerialized(payload);
+      if (value) {
+        return value;
+      }
+      await page.waitForTimeout(100);
+    }
+
+    throw new Error("Timed out waiting for function");
+  }
+
   async #getPage(name: unknown): Promise<string> {
     const page = await this.#options.manager.getPage(
       this.#options.browserName,
       requireString(name, "Page name or targetId")
     );
-    return extractGuid(page);
+    return extractGuid(page as Page);
   }
 
   async #newPage(): Promise<string> {
@@ -680,7 +1223,7 @@ export class QuickJSSandbox {
     page.on("close", () => {
       this.#anonymousPages.delete(page);
     });
-    return extractGuid(page);
+    return extractGuid(page as Page);
   }
 
   async #closePage(name: unknown): Promise<void> {


### PR DESCRIPTION
Add a live-CDP backend for explicit Chrome websocket attach flows, including Chrome 147 default-profile remote-debugging consent endpoints.

The existing Playwright CDP path enters Chrome through root target auto-attach, which can hang against the consent-based default-profile endpoint. This routes explicit ws/wss endpoints and HTTP-discovered browser websocket endpoints through a minimal raw-CDP adapter that never calls root Target.setAutoAttach.

The live path bounds browser and target initialization with named timeout errors, refreshes target lists before page lookup, prioritizes `_yoetz` targets over pre-existing tabs, tracks detached targets, and exposes the Playwright-like page methods current recipes rely on, including synchronous page.url(), same-document navigation updates scoped to the main frame, keyboard modifier holds, spec-compliant printable key dispatch, and file input upload.

Function evaluation now uses Runtime.evaluate rather than Runtime.callFunctionOn without a target object/context, so page.evaluate and locator actions work against real Chrome CDP sessions.

Known residuals: `networkidle` is approximated with a short quiet sleep rather than full Playwright network tracking; `setInputFiles` mirrors the existing Playwright capability and does not add a new path allowlist; file-input selector validation is intentionally minimal for the current recipe surface. These are not expected to affect the ChatGPT recipes, which use explicit selectors/waits and clipboard paste for macOS uploads.

Local validation covered daemon typechecking, focused live-CDP and auto-connect tests, daemon bundle generation, sandbox-client bundle generation, and the Rust CLI build. Full daemon vitest still needs an environment with the Playwright browser binary installed.