### PR TITLE
feat: stop a single browser by name

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -195,10 +195,16 @@ enum Command {
     )]
     Status,
     #[command(
-        about = "Stop the daemon and all browsers",
-        long_about = "Stop the daemon and all browsers.\n\nThis stops the background daemon process and closes every browser instance it currently manages."
+        about = "Stop the daemon, or a single managed browser",
+        long_about = "Stop the daemon and all browsers, or stop a single named browser.\n\nWithout an argument, stops the background daemon process and closes every browser instance it currently manages.\n\nWith a NAME argument, stops only that named browser instance while leaving the daemon and other browsers running. Use `dev-browser browsers` to find the name.\n\nStopping an unknown name is a no-op."
     )]
-    Stop,
+    Stop {
+        #[arg(
+            value_name = "NAME",
+            help = "Optional name of a managed browser to stop. Without this, stops the daemon and all browsers."
+        )]
+        name: Option<String>,
+    },
 }
 
 #[derive(Debug, Deserialize)]
@@ -277,10 +283,27 @@ fn run() -> Result<i32, Box<dyn Error>> {
                 ResultMode::Status,
             )
         }
-        Some(Command::Stop) => {
+        Some(Command::Stop { name }) => {
             if !is_daemon_running() {
                 println!("Daemon is not running.");
                 return Ok(0);
+            }
+
+            if let Some(name) = name {
+                let exit_code = send_request(
+                    json!({
+                        "id": request_id("browser-stop"),
+                        "type": "browser-stop",
+                        "browser": name,
+                    }),
+                    ResultMode::None,
+                )?;
+
+                if exit_code == 0 {
+                    println!("Stopped browser '{name}'.");
+                }
+
+                return Ok(exit_code);
             }
 
             let daemon_pid = current_daemon_pid();


### PR DESCRIPTION
Closes #107.

## Summary

Adds an optional `NAME` positional argument to `dev-browser stop`:

```
dev-browser stop          # daemon-wide stop (unchanged)
dev-browser stop <name>   # stop just that browser, leave the daemon up
```

The daemon already implements `browser-stop` (`protocol.ts`, `daemon.ts`, `browserManager.stopBrowser`); this just exposes it on the CLI. Stopping an unknown name is a silent no-op, matching the daemon's idempotent behavior.

## Why

Without this, any workflow that uses unique `--browser` names (e.g. timestamped names for test isolation) leaks an instance per run — there's no way to clean them up except `dev-browser stop`, which also kills every other browser. See #107 for a full reproducer.

## Diff

Single file, ~25 lines of Rust:

- `Command::Stop` → `Command::Stop { name: Option<String> }`
- Match arm branches on `name`:
  - `None` → existing `{type: "stop"}` flow (daemon kill)
  - `Some(name)` → new `{type: "browser-stop", browser: name}` flow
- Help text updated to describe both modes.

No daemon changes. No new dependencies.

## Verification

```bash
$ dev-browser browsers
NAME             TYPE      STATUS   PAGES
smoke-a          launched  running  login
smoke-b          launched  running  login
tabs-experiment  launched  running  page-a, page-b

$ dev-browser stop tabs-experiment
Stopped browser 'tabs-experiment'.

$ dev-browser browsers
NAME      TYPE      STATUS   PAGES
smoke-a   launched  running  login
smoke-b   launched  running  login

$ dev-browser stop unknown-name
Stopped browser 'unknown-name'.   # idempotent no-op, exit 0

$ dev-browser stop --help
Stop the daemon, or a single managed browser

Usage: dev-browser stop [NAME]

Arguments:
  [NAME]
          Optional name of a managed browser to stop. Without this, stops
          the daemon and all browsers.
```

Local CI checks pass: `cargo fmt -- --check`, `cargo check`, `cargo build`.

I left `CHANGELOG.md` alone since the maintainer manages versioning/release entries — happy to add an entry under an `Unreleased` heading if preferred.