### PR TITLE
fix(sandbox): deny host-path Playwright protocol params (#109)

### DIFF
--- a/daemon/src/sandbox/__tests__/sandbox-policy.test.ts
+++ b/daemon/src/sandbox/__tests__/sandbox-policy.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+
+import { checkProtocolMessage } from "../sandbox-policy.js";
+
+describe("sandbox protocol policy", () => {
+  it("rejects setInputFilePaths with localPaths", () => {
+    const violation = checkProtocolMessage({
+      id: 7,
+      guid: "element-handle@1",
+      method: "setInputFilePaths",
+      params: { localPaths: ["/etc/passwd"] },
+    });
+    expect(violation).toEqual({ method: "setInputFilePaths", param: "localPaths" });
+  });
+
+  it("rejects screenshot with a host path", () => {
+    expect(
+      checkProtocolMessage({
+        id: 1,
+        guid: "page@1",
+        method: "screenshot",
+        params: { path: "/tmp/leak.png" },
+      })
+    ).toEqual({ method: "screenshot", param: "path" });
+  });
+
+  it("rejects pdf, addScriptTag, addStyleTag, saveAs, storageState path/file params", () => {
+    const cases = [
+      ["pdf", "path"],
+      ["addScriptTag", "path"],
+      ["addStyleTag", "path"],
+      ["saveAs", "path"],
+      ["storageState", "path"],
+      ["harOpen", "file"],
+      ["tracingStop", "path"],
+    ] as const;
+    for (const [method, param] of cases) {
+      expect(
+        checkProtocolMessage({
+          id: 1,
+          guid: "x@1",
+          method,
+          params: { [param]: "/tmp/x" },
+        })
+      ).toEqual({ method, param });
+    }
+  });
+
+  it("allows screenshot without a path param", () => {
+    expect(
+      checkProtocolMessage({
+        id: 1,
+        guid: "page@1",
+        method: "screenshot",
+        params: { fullPage: true },
+      })
+    ).toBeNull();
+  });
+
+  it("allows unrelated methods to pass through", () => {
+    expect(
+      checkProtocolMessage({
+        id: 1,
+        guid: "page@1",
+        method: "goto",
+        params: { url: "https://example.com" },
+      })
+    ).toBeNull();
+  });
+
+  it("ignores null/undefined param values", () => {
+    expect(
+      checkProtocolMessage({
+        id: 1,
+        guid: "page@1",
+        method: "screenshot",
+        params: { path: null },
+      })
+    ).toBeNull();
+  });
+
+  it("returns null for messages without a method (e.g. responses)", () => {
+    expect(checkProtocolMessage({ id: 1, result: {} })).toBeNull();
+  });
+});

--- a/daemon/src/sandbox/__tests__/sandbox-policy.test.ts
+++ b/daemon/src/sandbox/__tests__/sandbox-policy.test.ts
@@ -1,58 +1,63 @@
 import { describe, expect, it } from "vitest";
 
+import { HostBridge } from "../host-bridge.js";
 import { checkProtocolMessage } from "../sandbox-policy.js";
 
-describe("sandbox protocol policy", () => {
-  it("rejects setInputFilePaths with localPaths", () => {
-    const violation = checkProtocolMessage({
-      id: 7,
-      guid: "element-handle@1",
-      method: "setInputFilePaths",
-      params: { localPaths: ["/etc/passwd"] },
-    });
-    expect(violation).toEqual({ method: "setInputFilePaths", param: "localPaths" });
-  });
-
-  it("rejects screenshot with a host path", () => {
+describe("sandbox protocol policy — unit", () => {
+  it("rejects setInputFiles with localPaths", () => {
     expect(
       checkProtocolMessage({
-        id: 1,
-        guid: "page@1",
-        method: "screenshot",
-        params: { path: "/tmp/leak.png" },
+        id: 7,
+        guid: "element-handle@1",
+        method: "setInputFiles",
+        params: { localPaths: ["/etc/passwd"] },
       })
-    ).toEqual({ method: "screenshot", param: "path" });
+    ).toEqual({ method: "setInputFiles", param: "localPaths" });
   });
 
-  it("rejects pdf, addScriptTag, addStyleTag, saveAs, storageState path/file params", () => {
-    const cases = [
-      ["pdf", "path"],
-      ["addScriptTag", "path"],
-      ["addStyleTag", "path"],
-      ["saveAs", "path"],
-      ["storageState", "path"],
-      ["harOpen", "file"],
-      ["tracingStop", "path"],
-    ] as const;
-    for (const [method, param] of cases) {
-      expect(
-        checkProtocolMessage({
-          id: 1,
-          guid: "x@1",
-          method,
-          params: { [param]: "/tmp/x" },
-        })
-      ).toEqual({ method, param });
-    }
+  it("rejects setInputFiles with localDirectory", () => {
+    expect(
+      checkProtocolMessage({
+        id: 7,
+        guid: "frame@1",
+        method: "setInputFiles",
+        params: { selector: "#f", localDirectory: "/etc" },
+      })
+    ).toEqual({ method: "setInputFiles", param: "localDirectory" });
   });
 
-  it("allows screenshot without a path param", () => {
+  it("rejects Artifact.saveAs with a host path", () => {
     expect(
       checkProtocolMessage({
         id: 1,
-        guid: "page@1",
-        method: "screenshot",
-        params: { fullPage: true },
+        guid: "artifact@1",
+        method: "saveAs",
+        params: { path: "/tmp/exfil.bin" },
+      })
+    ).toEqual({ method: "saveAs", param: "path" });
+  });
+
+  it("rejects LocalUtils.harOpen with a host file", () => {
+    expect(
+      checkProtocolMessage({
+        id: 1,
+        guid: "localUtils@1",
+        method: "harOpen",
+        params: { file: "/etc/passwd" },
+      })
+    ).toEqual({ method: "harOpen", param: "file" });
+  });
+
+  it("allows setInputFiles with payloads (no host path)", () => {
+    expect(
+      checkProtocolMessage({
+        id: 1,
+        guid: "frame@1",
+        method: "setInputFiles",
+        params: {
+          selector: "#f",
+          payloads: [{ name: "a.txt", mimeType: "text/plain", buffer: "" }],
+        },
       })
     ).toBeNull();
   });
@@ -72,14 +77,104 @@ describe("sandbox protocol policy", () => {
     expect(
       checkProtocolMessage({
         id: 1,
-        guid: "page@1",
-        method: "screenshot",
+        guid: "artifact@1",
+        method: "saveAs",
         params: { path: null },
       })
     ).toBeNull();
   });
 
-  it("returns null for messages without a method (e.g. responses)", () => {
+  it("returns null for response messages without a method", () => {
     expect(checkProtocolMessage({ id: 1, result: {} })).toBeNull();
+  });
+});
+
+describe("HostBridge.receiveFromSandbox — integration", () => {
+  function createBridge() {
+    const sent: string[] = [];
+    const bridge = new HostBridge({
+      sendToSandbox: (json) => sent.push(json),
+      denyLaunch: true,
+    });
+    return { bridge, sent };
+  }
+
+  it("returns a policy error for harOpen and never dispatches it", async () => {
+    const { bridge, sent } = createBridge();
+    try {
+      await bridge.receiveFromSandbox(
+        JSON.stringify({
+          id: 42,
+          guid: "localUtils@1",
+          method: "harOpen",
+          params: { file: "/etc/passwd" },
+        })
+      );
+
+      expect(sent).toHaveLength(1);
+      const response = JSON.parse(sent[0]!) as {
+        id: number;
+        error?: { error?: { message?: string; name?: string } };
+      };
+      expect(response.id).toBe(42);
+      expect(response.error?.error?.name).toBe("Error");
+      expect(response.error?.error?.message).toContain("Sandbox policy");
+      expect(response.error?.error?.message).toContain("harOpen");
+      expect(response.error?.error?.message).toContain("file");
+    } finally {
+      await bridge.dispose();
+    }
+  });
+
+  it("returns a policy error for setInputFiles localPaths", async () => {
+    const { bridge, sent } = createBridge();
+    try {
+      await bridge.receiveFromSandbox(
+        JSON.stringify({
+          id: 99,
+          guid: "element-handle@1",
+          method: "setInputFiles",
+          params: { localPaths: ["/etc/passwd"] },
+        })
+      );
+
+      const response = JSON.parse(sent[0]!) as {
+        error?: { error?: { message?: string } };
+      };
+      expect(response.error?.error?.message).toContain("setInputFiles");
+      expect(response.error?.error?.message).toContain("localPaths");
+    } finally {
+      await bridge.dispose();
+    }
+  });
+
+  it("forwards harmless messages to the dispatcher (different error shape)", async () => {
+    // Without the policy, the same harOpen message would reach the dispatcher
+    // and come back as a target/validation error from Playwright — NOT as a
+    // 'Sandbox policy' message. We assert that benign method names produce a
+    // non-policy response shape, proving the policy code path only fires for
+    // matches and that other messages still flow.
+    const { bridge, sent } = createBridge();
+    try {
+      await bridge.receiveFromSandbox(
+        JSON.stringify({
+          id: 1,
+          guid: "page@nonexistent",
+          method: "goto",
+          params: { url: "https://example.com" },
+        })
+      );
+
+      expect(sent.length).toBeGreaterThan(0);
+      const response = JSON.parse(sent[0]!) as {
+        error?: { error?: { message?: string } };
+      };
+      // Dispatcher will reject unknown guid with a TargetClosedError or
+      // similar — what matters here is that we did NOT short-circuit it with
+      // a policy error.
+      expect(response.error?.error?.message ?? "").not.toContain("Sandbox policy");
+    } finally {
+      await bridge.dispose();
+    }
   });
 });

--- a/daemon/src/sandbox/host-bridge.ts
+++ b/daemon/src/sandbox/host-bridge.ts
@@ -7,6 +7,7 @@ import {
   type RootDispatcherLike,
   createPlaywright,
 } from "./playwright-internals.js";
+import { checkProtocolMessage, formatPolicyError } from "./sandbox-policy.js";
 
 export interface HostBridgeOptions {
   sendToSandbox: (json: string) => void;
@@ -52,7 +53,25 @@ export class HostBridge {
   }
 
   async receiveFromSandbox(json: string): Promise<void> {
-    await this.dispatcherConnection.dispatch(JSON.parse(json) as Record<string, unknown>);
+    const message = JSON.parse(json) as Record<string, unknown>;
+    const violation = checkProtocolMessage(message);
+    if (violation) {
+      const id = typeof message.id === "number" ? message.id : 0;
+      this.sendToSandbox(
+        JSON.stringify({
+          id,
+          error: {
+            error: {
+              name: "Error",
+              message: formatPolicyError(violation),
+              stack: "",
+            },
+          },
+        })
+      );
+      return;
+    }
+    await this.dispatcherConnection.dispatch(message);
   }
 
   async dispose(): Promise<void> {

--- a/daemon/src/sandbox/sandbox-policy.ts
+++ b/daemon/src/sandbox/sandbox-policy.ts
@@ -1,21 +1,28 @@
 // Deny-list of Playwright protocol (method, top-level params key) pairs that
-// would let a sandboxed script reach the host filesystem. The QuickJS client
-// platform already throws on fs/path access, which blocks the friendly
-// JavaScript APIs that lower to these wire calls. This module is defense in
-// depth: it stops a script that crafts the raw protocol message directly from
-// reaching the host-side dispatcher.
+// let a sandboxed script reach the host filesystem at the *wire* level.
+//
+// Scope: the dev-browser QuickJS client platform already throws on `fs` and
+// `path` (forked-client/quickjs-platform.ts), which blocks the friendly
+// client-side APIs that resolve to host I/O before sending anything to the
+// server (page.screenshot({ path }), page.pdf({ path }), addScriptTag({ path }),
+// browserContext.storageState({ path }), tracing.start/stop({ path }), etc.
+// — none of those params exist in the wire schema; the client writes the file
+// itself via the platform fs adapter).
+//
+// What we have to block here are wire methods whose *server-side* implementation
+// reads or writes a host path passed in params. A sandboxed script that reaches
+// the underlying connection (e.g. via page._connection) can craft these
+// messages directly, bypassing the friendly API.
+//
+// Verified against playwright-core 1.58.2 protocol/validator.js.
 const DENIED_PARAMS: Record<string, readonly string[]> = {
-  screenshot: ["path"],
-  pdf: ["path"],
-  storageState: ["path"],
-  addScriptTag: ["path"],
-  addStyleTag: ["path"],
-  setInputFilePaths: ["localPaths"],
+  // Frame.setInputFiles / ElementHandle.setInputFiles — server reads the listed
+  // local paths and uploads them. `directoryStream` is a channel handle (server
+  // writes to a sandbox-supplied stream) and is intentionally not denied here.
+  setInputFiles: ["localPaths", "localDirectory"],
+  // Artifact.saveAs — server writes the artifact to a host-supplied path.
   saveAs: ["path"],
-  fulfill: ["path"],
-  tracingStart: ["tracesDir"],
-  tracingStop: ["path"],
-  tracingStopChunk: ["filePath"],
+  // LocalUtils.harOpen — server opens and reads a HAR file from disk.
   harOpen: ["file"],
 };
 

--- a/daemon/src/sandbox/sandbox-policy.ts
+++ b/daemon/src/sandbox/sandbox-policy.ts
@@ -1,0 +1,45 @@
+// Deny-list of Playwright protocol (method, top-level params key) pairs that
+// would let a sandboxed script reach the host filesystem. The QuickJS client
+// platform already throws on fs/path access, which blocks the friendly
+// JavaScript APIs that lower to these wire calls. This module is defense in
+// depth: it stops a script that crafts the raw protocol message directly from
+// reaching the host-side dispatcher.
+const DENIED_PARAMS: Record<string, readonly string[]> = {
+  screenshot: ["path"],
+  pdf: ["path"],
+  storageState: ["path"],
+  addScriptTag: ["path"],
+  addStyleTag: ["path"],
+  setInputFilePaths: ["localPaths"],
+  saveAs: ["path"],
+  fulfill: ["path"],
+  tracingStart: ["tracesDir"],
+  tracingStop: ["path"],
+  tracingStopChunk: ["filePath"],
+  harOpen: ["file"],
+};
+
+export interface PolicyViolation {
+  method: string;
+  param: string;
+}
+
+export function checkProtocolMessage(
+  message: Record<string, unknown>
+): PolicyViolation | null {
+  const method = typeof message.method === "string" ? message.method : "";
+  if (!method) return null;
+  const denied = DENIED_PARAMS[method];
+  if (!denied) return null;
+  const params = (message.params ?? {}) as Record<string, unknown>;
+  for (const key of denied) {
+    if (params[key] !== undefined && params[key] !== null) {
+      return { method, param: key };
+    }
+  }
+  return null;
+}
+
+export function formatPolicyError(violation: PolicyViolation): string {
+  return `Sandbox policy: parameter '${violation.param}' is not allowed on '${violation.method}' (host filesystem path access is denied).`;
+}


### PR DESCRIPTION
Fixes #109.

Deny three Playwright wire-level params at `HostBridge.receiveFromSandbox` — the only host-fs holes that aren't already blocked by the QuickJS client platform's `fs`/`path` throws or by `denyLaunch: true`. Verified against playwright-core 1.58.2.

| method | param(s) | direction |
|---|---|---|
| `setInputFiles` | `localPaths`, `localDirectory` | server reads |
| `saveAs` | `path` | server writes |
| `harOpen` | `file` | server reads |

The screenshot/pdf/storageState/addScriptTag/addStyleTag/fulfill/tracing scenarios in #109 are already non-exploitable — those path params don't exist in the wire schema; the client writes/reads via its platform fs adapter, which throws in QuickJS. This PR blocks the remaining path: a script that reaches the underlying connection (e.g. `page._connection`) and crafts the raw message itself.

## Attestation

Identical test file on both commits; only `host-bridge.ts` differs.

| state | commit | result |
|---|---|---|
| before | [`c58b79a`](https://github.com/kimjune01/dev-browser/commit/c58b79ac8143224d8bd3a2fcfad5e5c1f6afe7ff) ([`attest/before-fix`](https://github.com/kimjune01/dev-browser/tree/attest/before-fix)) | 2 failed, 9 passed |
| after | [`6c004d3`](https://github.com/kimjune01/dev-browser/commit/6c004d3df8f5f640e669a5ae2509e89aef986661) (this PR) | 11 passed |

Full suite on the fix commit (after `pnpm bundle:sandbox-client`): **15/15 files, 98/98 tests pass** — including the live-browser integration tests, confirming legitimate Playwright flows are unaffected.

```bash
git remote add kimjune01 https://github.com/kimjune01/dev-browser.git && git fetch kimjune01
git checkout c58b79a && (cd daemon && pnpm install && pnpm vitest run src/sandbox/__tests__/sandbox-policy.test.ts)
git checkout 6c004d3 && (cd daemon && pnpm vitest run src/sandbox/__tests__/sandbox-policy.test.ts)
```

Before-fail output (the proof — message reaches the dispatcher):

```
AssertionError: expected 'TargetClosedError' to be 'Error'
```

## Notes

- Deny-list, not allow-list — small and reversible, but brittle against future protocol additions.
- `daemon/dist/*` bundles not regenerated; left for release tooling.
- The integration test hits the wire-level chokepoint directly, not via a guest script. Auditing every way a sandbox script can reach `ChannelOwner._channel` is a separate, larger attack-surface question and out of scope here.

Found by Codex (GPT-5.5) via [`/bug-hunt`](https://github.com/SawyerHood/dev-browser).