### PR TITLE
feat: add page.cua (vision) and page.domCua (DOM-id) toolsets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+- Added the `page.cua.*` pixel/vision toolset: coordinate-based `click`, `doubleClick`, `drag`, `move`, `scroll`, `keypress`, and `type`, plus a JPEG `screenshot()` whose pixels map 1:1 onto click coordinates at any DPR.
+- Added the `page.domCua.*` DOM-id toolset: `getVisibleDom()` snapshots visible interactive elements as `node_id=N` lines, with `click`, `doubleClick`, `scroll`, `type`, and `keypress` acting against the latest snapshot's ids.
+- Fixed script error messages being dropped from CLI output; thrown errors now report their name and message alongside the stack.
+- Documented the vision and DOM-id workflows in the `--help` LLM usage guide.
+
 ## [0.2.7] - 2026-04-09
 
 - Updated documentation to recommend `domcontentloaded` for dev server navigation.

--- a/README.md
+++ b/README.md
@@ -180,6 +180,11 @@ console.log/warn/error/info       // Routed to CLI stdout/stderr
 
 Pages are full [Playwright Page objects](https://playwright.dev/docs/api/class-page) — `goto`, `click`, `fill`, `locator`, `evaluate`, `screenshot`, and everything else, including `page.snapshotForAI({ track?, depth?, timeout? })`, which returns `{ full, incremental? }` for AI-friendly page snapshots.
 
+Every page also exposes two computer-use toolsets:
+
+- `page.cua.*` — pixel/vision tier: `screenshot()` saves a JPEG whose pixels map 1:1 onto CSS coordinates at any DPR and returns `{ path, width, height }`; `click`, `doubleClick`, `drag`, `move`, `scroll`, `keypress`, and `type` act at those coordinates.
+- `page.domCua.*` — DOM-id tier: `getVisibleDom()` snapshots visible interactive elements as pseudo-HTML lines with `node_id=N`; `click`, `doubleClick`, and `scroll` act by node id (ids are only valid against the latest snapshot of the current document), plus `type` and `keypress` for the focused element.
+
 ## Benchmarks
 
 | Method                  | Time    | Cost  | Turns | Success |

--- a/cli/llm-guide.txt
+++ b/cli/llm-guide.txt
@@ -40,6 +40,54 @@ LLM USAGE GUIDE:
   Choosing your approach:
     Unknown pages: use page.snapshotForAI() first to discover the page, then interact based on what you find.
     Known pages/selectors: skip the snapshot and use direct Playwright selectors like page.click(), page.fill(), or page.locator() for faster, more reliable automation.
+    Prefer locators/snapshotForAI first; switch to page.domCua node ids when a unique stable locator can't be built or after 2 failed locator attempts on the same target; switch to page.cua coordinates when the visual structure is clearer than the DOM.
+    After acting, collect the cheapest state check; don't take both a snapshot and a screenshot by default.
+
+  Vision workflow (page.cua):
+    Coordinate-based control across two scripts on a named page.
+    Script 1 - look: take a screenshot, then read the saved image to pick coordinates.
+    dev-browser <<'EOF'
+    const page = await browser.getPage("checkout");
+    const shot = await page.cua.screenshot();
+    console.log(JSON.stringify(shot));
+    // {"path":"/Users/you/.dev-browser/tmp/cua-page_abc123.jpeg","width":1280,"height":720}
+    EOF
+    Script 2 - act: click at the coordinates measured on the image.
+    dev-browser <<'EOF'
+    const page = await browser.getPage("checkout");
+    await page.cua.click({ x: 412, y: 233 });
+    console.log(page.url());
+    EOF
+    Pixel coordinates measured on the saved image map 1:1 onto page.cua coordinates (any display, any DPR).
+    Always use a named page so coordinates stay valid between scripts.
+    This holds for viewport and clip screenshots only — never derive click coordinates from a fullPage capture; scroll, then re-screenshot.
+    Also available: cua.doubleClick({x, y}), cua.drag({path: [{x, y}, ...]}), cua.move({x, y}),
+    cua.scroll({x, y, scrollX, scrollY}) (positive scrollY scrolls content down),
+    cua.keypress({keys: ["ctrl", "a"]}), cua.type({text}).
+    cua.click and domCua.click wait ~1s for a click-triggered navigation (then up to 10s for the load);
+    pass waitForNavigation: false to skip that grace wait in tight loops.
+
+  DOM-id workflow (page.domCua):
+    Snapshot the visible interactive elements, then act on them by node id.
+    dev-browser <<'EOF'
+    const page = await browser.getPage("checkout");
+    console.log(await page.domCua.getVisibleDom());
+    // <input node_id=1 type="text" placeholder="name here" />
+    // <button node_id=2>Submit</button>
+    // <a node_id=3 href="https://example.com">Example link</a>
+    EOF
+    dev-browser <<'EOF'
+    const page = await browser.getPage("checkout");
+    await page.domCua.click({ nodeId: 2 });
+    console.log(page.url());
+    EOF
+    Ids are only valid against the latest snapshot of the current document.
+    A "DOM node N is stale or missing — re-run getVisibleDom()" error means the id predates the latest snapshot or the document changed; re-run getVisibleDom() and use the fresh ids.
+    Re-snapshot after every navigation - ids from the old document never act on the new one.
+    The snapshot only includes elements visible in the viewport; scroll and re-snapshot to see more.
+    A truncation marker line appears when the snapshot budget is hit.
+    Also available: domCua.doubleClick({nodeId}), domCua.scroll({scrollX, scrollY, nodeId?}),
+    domCua.type({text}) and domCua.keypress({keys}) (both act on the focused element - click first).
 
   Screenshots for visual state:
     dev-browser <<'EOF'
@@ -96,6 +144,11 @@ LLM USAGE GUIDE:
     page.waitForSelector(selector)         Wait for an element to appear
     page.waitForURL(url)                   Wait for navigation to a URL
     page.screenshot()                      Capture a screenshot buffer; save it with saveScreenshot(...)
+    page.cua.screenshot(options)           Save a JPEG for the vision workflow; returns { path, width, height }
+                                           Options: { name?: string, fullPage?: boolean, clip? }
+    page.cua.click({ x, y })               Click at viewport coordinates measured on a cua screenshot
+    page.domCua.getVisibleDom()            Snapshot visible interactive elements as node_id=N lines
+    page.domCua.click({ nodeId })          Click an element by node id from the latest snapshot
     page.$$eval(selector, fn)              Run a function on all matching elements
     page.$eval(selector, fn)               Run a function on the first matching element
     page.evaluate(fn)                      Run JavaScript in the page context (plain JS only)

--- a/daemon/scripts/bundle-sandbox-client.ts
+++ b/daemon/scripts/bundle-sandbox-client.ts
@@ -9,6 +9,10 @@ const outfile = resolve(daemonDir, "dist/sandbox-client.js");
 
 await mkdir(dirname(outfile), { recursive: true });
 
+// WARNING: src/sandbox/forked-client/src/client/domCuaInjected.ts exports
+// functions that are serialized with String(fn) and re-evaluated inside the
+// page. Do not add flags that rewrite function bodies (minify, keepNames) —
+// they would corrupt the serialized source.
 await build({
   entryPoints: [entryPoint],
   bundle: true,

--- a/daemon/src/daemon.ts
+++ b/daemon/src/daemon.ts
@@ -3,6 +3,7 @@ import { mkdir, unlink, writeFile } from "node:fs/promises";
 import net from "node:net";
 import path from "node:path";
 import { BrowserManager } from "./browser-manager.js";
+import { formatError } from "./format-error.js";
 import { createKeyedLock, createMutex } from "./lock.js";
 import {
   getBrowsersDir,
@@ -40,17 +41,6 @@ const clients = new Set<net.Socket>();
 
 let server: net.Server | null = null;
 let shuttingDown: Promise<void> | null = null;
-
-function formatError(error: unknown): string {
-  if (error instanceof Error) {
-    if (error.name === "ScriptTimeoutError") {
-      return error.message;
-    }
-    return error.stack ?? error.message;
-  }
-
-  return String(error);
-}
 
 async function writeMessage(socket: net.Socket, message: Response): Promise<void> {
   if (socket.destroyed) {

--- a/daemon/src/format-error.test.ts
+++ b/daemon/src/format-error.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+
+import { formatError } from "./format-error.js";
+
+describe("formatError", () => {
+  it("composes a name/message header when the stack has none", () => {
+    const error = new Error("QuickJS promise rejected: boom message");
+    error.stack = "    at <anonymous> (user-script.js:2:15)";
+
+    const formatted = formatError(error);
+
+    expect(formatted).toContain("Error: QuickJS promise rejected: boom message");
+    expect(formatted).toContain("at <anonymous> (user-script.js:2:15)");
+  });
+
+  it("does not duplicate the header when the stack already has one", () => {
+    const error = new Error("native failure");
+
+    const formatted = formatError(error);
+
+    expect(formatted).toBe(error.stack);
+    expect(formatted.indexOf("Error: native failure")).toBe(
+      formatted.lastIndexOf("Error: native failure")
+    );
+  });
+
+  it("falls back to the header when there is no stack", () => {
+    const error = new Error("no stack here");
+    error.stack = undefined;
+
+    expect(formatError(error)).toBe("Error: no stack here");
+  });
+
+  it("returns only the message for script timeouts", () => {
+    const error = new Error("Script timed out after 30000ms");
+    error.name = "ScriptTimeoutError";
+
+    expect(formatError(error)).toBe("Script timed out after 30000ms");
+  });
+
+  it("stringifies non-error values", () => {
+    expect(formatError("plain failure")).toBe("plain failure");
+  });
+});

--- a/daemon/src/format-error.ts
+++ b/daemon/src/format-error.ts
@@ -1,0 +1,14 @@
+export function formatError(error: unknown): string {
+  if (error instanceof Error) {
+    if (error.name === "ScriptTimeoutError") {
+      return error.message;
+    }
+    const header = `${error.name}: ${error.message}`;
+    if (!error.stack) {
+      return header;
+    }
+    return error.stack.startsWith(header) ? error.stack : `${header}\n${error.stack}`;
+  }
+
+  return String(error);
+}

--- a/daemon/src/sandbox/__tests__/cua.test.ts
+++ b/daemon/src/sandbox/__tests__/cua.test.ts
@@ -461,6 +461,58 @@ describe.sequential("QuickJS page.cua toolset", () => {
       expect(result.clicks[1]!.shiftKey).toBe(false);
     }, 15_000);
 
+    it("releases already-pressed modifiers when a later key in the sequence is invalid", async () => {
+      const result = await harness.runJson<{
+        clickError: string | null;
+        keypressError: string | null;
+        clicks: RecordedClick[];
+        keyEvents: RecordedKeyEvent[];
+      }>(
+        withCuaPage(
+          "cua-modifier-release",
+          `
+          let clickError = null;
+          try {
+            await page.cua.click({
+              x: 350,
+              y: 250,
+              modifiers: ["shift", "bogus"],
+              waitForNavigation: false,
+            });
+          } catch (error) {
+            clickError = String((error && error.message) || error);
+          }
+          let keypressError = null;
+          try {
+            await page.cua.keypress({ keys: ["ctrl", "bogus", "c"] });
+          } catch (error) {
+            keypressError = String((error && error.message) || error);
+          }
+          await page.cua.click({ x: 350, y: 250, waitForNavigation: false });
+          await page.evaluate(() => {
+            window.keyEvents = [];
+          });
+          await page.cua.keypress({ keys: ["a"] });
+          console.log(JSON.stringify({
+            clickError,
+            keypressError,
+            clicks: await page.evaluate(() => window.clicks),
+            keyEvents: await page.evaluate(() => window.keyEvents),
+          }));
+        `
+        )
+      );
+
+      expect(result.clickError).toContain("bogus");
+      expect(result.keypressError).toContain("bogus");
+      expect(result.clicks).toHaveLength(1);
+      expect(result.clicks[0]!.shiftKey).toBe(false);
+      expect(result.keyEvents).toHaveLength(1);
+      expect(result.keyEvents[0]!.shiftKey).toBe(false);
+      expect(result.keyEvents[0]!.ctrlKey).toBe(false);
+      expect(result.keyEvents[0]!.metaKey).toBe(false);
+    }, 15_000);
+
     it("moves the pointer", async () => {
       const result = await harness.runJson<{ moves: RecordedMouseEvent[] }>(
         withCuaPage(
@@ -678,14 +730,16 @@ describe.sequential("QuickJS page.cua toolset", () => {
       });
     }, 15_000);
 
-    it("pins clip coordinate semantics", async () => {
+    it("pins clip coordinate semantics as viewport-relative", async () => {
       const result = await harness.runJson<{ shot: ScreenshotResult }>(
         withCuaPage(
           "cua-shot-clip",
           `
+          await page.evaluate(() => window.scrollTo(0, 150));
+          await page.waitForFunction(() => window.scrollY === 150, { timeout: 5000 });
           const shot = await page.cua.screenshot({
             name: "cua-clip-test",
-            clip: { x: 300, y: 200, width: 100, height: 100 },
+            clip: { x: 300, y: 50, width: 100, height: 100 },
           });
           console.log(JSON.stringify({ shot }));
         `

--- a/daemon/src/sandbox/__tests__/cua.test.ts
+++ b/daemon/src/sandbox/__tests__/cua.test.ts
@@ -818,6 +818,38 @@ describe.sequential("QuickJS page.cua toolset", () => {
         height: result.shot.height,
       });
     }, 30_000);
+
+    it("downscales device-pixel screenshots back to css pixels", async () => {
+      const result = await harness.runJson<{
+        shot: ScreenshotResult;
+        dims: [number, number];
+      }>(
+        withCuaPage(
+          "cua-shot-retina",
+          `
+          const dims = await page.evaluate(() => [innerWidth, innerHeight]);
+          const oversized = await page.screenshot({
+            type: "jpeg",
+            quality: 80,
+            clip: { x: 0, y: 0, width: dims[0] * 2, height: dims[1] * 2 },
+          });
+          page.screenshot = async () => oversized;
+          const shot = await page.cua.screenshot({ name: "cua-retina-test" });
+          console.log(JSON.stringify({ shot, dims }));
+        `
+        )
+      );
+      screenshotCleanup.add(result.shot.path);
+
+      expect(result.shot.width).toBe(result.dims[0]);
+      expect(result.shot.height).toBe(result.dims[1]);
+
+      const data = await readFile(result.shot.path);
+      expect(readJpegDimensions(data)).toEqual({
+        width: result.shot.width,
+        height: result.shot.height,
+      });
+    }, 30_000);
   });
 
   describe.sequential("navigation waiting", () => {

--- a/daemon/src/sandbox/__tests__/cua.test.ts
+++ b/daemon/src/sandbox/__tests__/cua.test.ts
@@ -1,0 +1,846 @@
+import { once } from "node:events";
+import { mkdtemp, readFile, rm, stat } from "node:fs/promises";
+import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
+import type { AddressInfo } from "node:net";
+import os from "node:os";
+import path from "node:path";
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { BrowserManager } from "../../browser-manager.js";
+import { DEV_BROWSER_TMP_DIR } from "../../temp-files.js";
+import { removeDirectoryWithRetries } from "../../test-cleanup.js";
+import { QuickJSSandbox } from "../quickjs-sandbox.js";
+import { ensureSandboxClientBundle } from "./bundle-test-helpers.js";
+
+const SANDBOX_TIMEOUT_MS = 60_000;
+
+const CUA_TEST_PAGE_HTML = String.raw`<!DOCTYPE html>
+<html>
+  <head>
+    <title>CUA Test Page</title>
+    <style>
+      body {
+        margin: 0;
+      }
+
+      #target {
+        position: absolute;
+        left: 300px;
+        top: 200px;
+        width: 100px;
+        height: 100px;
+        background: #ff0000;
+      }
+
+      #field {
+        position: absolute;
+        left: 20px;
+        top: 20px;
+        width: 200px;
+      }
+
+      #spacer {
+        width: 3000px;
+        height: 3000px;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="target"></div>
+    <input id="field" type="text" />
+    <div id="spacer"></div>
+    <script>
+      window.clicks = [];
+      window.mouseEvents = [];
+      window.keyEvents = [];
+
+      document.addEventListener("click", (event) => {
+        window.clicks.push({
+          x: event.clientX,
+          y: event.clientY,
+          button: event.button,
+          detail: event.detail,
+          shiftKey: event.shiftKey,
+          altKey: event.altKey,
+        });
+      });
+
+      for (const type of ["mousedown", "mousemove", "mouseup"]) {
+        document.addEventListener(type, (event) => {
+          window.mouseEvents.push({
+            type,
+            x: event.clientX,
+            y: event.clientY,
+            button: event.button,
+          });
+        });
+      }
+
+      document.addEventListener("keydown", (event) => {
+        window.keyEvents.push({
+          key: event.key,
+          code: event.code,
+          shiftKey: event.shiftKey,
+          ctrlKey: event.ctrlKey,
+          metaKey: event.metaKey,
+        });
+      });
+
+      document.addEventListener("contextmenu", (event) => event.preventDefault());
+    </script>
+  </body>
+</html>`;
+
+interface CapturedOutput {
+  stdout: string[];
+  stderr: string[];
+}
+
+interface JsonSandboxHarness {
+  dispose: () => Promise<void>;
+  runJson: <T>(script: string) => Promise<T>;
+}
+
+interface NavigationServer {
+  baseUrl: string;
+  close: () => Promise<void>;
+}
+
+interface RecordedClick {
+  x: number;
+  y: number;
+  button: number;
+  detail: number;
+  shiftKey: boolean;
+  altKey: boolean;
+}
+
+interface RecordedMouseEvent {
+  type: string;
+  x: number;
+  y: number;
+  button: number;
+}
+
+interface RecordedKeyEvent {
+  key: string;
+  code: string;
+  shiftKey: boolean;
+  ctrlKey: boolean;
+  metaKey: boolean;
+}
+
+interface ScreenshotResult {
+  path: string;
+  width: number;
+  height: number;
+}
+
+function createOutput(): CapturedOutput & {
+  sink: {
+    onStdout: (data: string) => void;
+    onStderr: (data: string) => void;
+  };
+} {
+  const stdout: string[] = [];
+  const stderr: string[] = [];
+
+  return {
+    stdout,
+    stderr,
+    sink: {
+      onStdout: (data) => {
+        stdout.push(data);
+      },
+      onStderr: (data) => {
+        stderr.push(data);
+      },
+    },
+  };
+}
+
+function clearOutput(output: CapturedOutput): void {
+  output.stdout.length = 0;
+  output.stderr.length = 0;
+}
+
+function outputLines(output: CapturedOutput): string[] {
+  return output.stdout.map((line) => line.trim()).filter((line) => line.length > 0);
+}
+
+function parseLastJsonLine<T>(output: CapturedOutput): T {
+  const lines = outputLines(output);
+  expect(lines.length).toBeGreaterThan(0);
+  return JSON.parse(lines.at(-1)!) as T;
+}
+
+function withCuaPage(pageName: string, body: string): string {
+  return `
+    const page = await browser.getPage(${JSON.stringify(pageName)});
+    await page.setContent(${JSON.stringify(CUA_TEST_PAGE_HTML)}, { waitUntil: "load" });
+    ${body}
+  `;
+}
+
+async function createSandboxHarness(
+  manager: BrowserManager,
+  browserName: string
+): Promise<JsonSandboxHarness> {
+  await manager.ensureBrowser(browserName, {
+    headless: true,
+  });
+
+  const output = createOutput();
+  const sandbox = new QuickJSSandbox({
+    manager,
+    browserName,
+    onStdout: output.sink.onStdout,
+    onStderr: output.sink.onStderr,
+    timeoutMs: SANDBOX_TIMEOUT_MS,
+  });
+
+  await sandbox.initialize();
+
+  return {
+    dispose: async () => {
+      await sandbox.dispose();
+    },
+    runJson: async <T>(script: string): Promise<T> => {
+      clearOutput(output);
+      await sandbox.executeScript(`(async () => {\n${script}\n})()`);
+      expect(output.stderr).toEqual([]);
+      return parseLastJsonLine<T>(output);
+    },
+  };
+}
+
+function readJpegDimensions(data: Buffer): { width: number; height: number } {
+  expect(data[0]).toBe(0xff);
+  expect(data[1]).toBe(0xd8);
+  expect(data[2]).toBe(0xff);
+
+  let offset = 2;
+  while (offset + 4 <= data.length) {
+    if (data[offset] !== 0xff) {
+      throw new Error("Invalid JPEG segment");
+    }
+    const marker = data[offset + 1];
+    if (marker === undefined) {
+      break;
+    }
+    if (marker === 0xff) {
+      offset += 1;
+      continue;
+    }
+    if (marker === 0x01 || (marker >= 0xd0 && marker <= 0xd9)) {
+      offset += 2;
+      continue;
+    }
+    if (marker >= 0xc0 && marker <= 0xcf && marker !== 0xc4 && marker !== 0xc8 && marker !== 0xcc) {
+      return {
+        height: data.readUInt16BE(offset + 5),
+        width: data.readUInt16BE(offset + 7),
+      };
+    }
+    offset += 2 + data.readUInt16BE(offset + 2);
+  }
+
+  throw new Error("No JPEG SOF marker found");
+}
+
+function navigationPageHtml(pathname: string): string {
+  switch (pathname) {
+    case "/cua/first":
+      return `<!DOCTYPE html>
+<html>
+  <head><title>First Page</title></head>
+  <body>
+    <button id="nav" style="position:fixed;left:20px;top:20px;width:120px;height:40px" onclick="location.href='/cua/second'">Go</button>
+  </body>
+</html>`;
+    case "/cua/second":
+      return `<!DOCTYPE html>
+<html>
+  <head><title>Second Page</title></head>
+  <body><h1>Second</h1></body>
+</html>`;
+    case "/cua/iframe-host":
+      return `<!DOCTYPE html>
+<html>
+  <head><title>Iframe Host</title></head>
+  <body>
+    <button id="swap" style="position:fixed;left:20px;top:20px;width:120px;height:40px" onclick="document.getElementById('child').src='/cua/frame-b'">Swap</button>
+    <iframe id="child" src="/cua/frame-a" style="position:fixed;left:20px;top:80px;width:300px;height:150px"></iframe>
+  </body>
+</html>`;
+    case "/cua/frame-a":
+      return `<!DOCTYPE html>
+<html>
+  <head><title>Frame A</title></head>
+  <body>frame a</body>
+</html>`;
+    case "/cua/frame-b":
+      return `<!DOCTYPE html>
+<html>
+  <head><title>Frame B</title></head>
+  <body>frame b</body>
+</html>`;
+    default:
+      return "";
+  }
+}
+
+function handleNavigationRequest(request: IncomingMessage, response: ServerResponse): void {
+  const url = new URL(request.url ?? "/", "http://127.0.0.1");
+  const html = navigationPageHtml(url.pathname);
+
+  if (!html) {
+    response.writeHead(404, {
+      "content-type": "text/plain; charset=utf-8",
+    });
+    response.end("not found");
+    return;
+  }
+
+  response.writeHead(200, {
+    "content-type": "text/html; charset=utf-8",
+    "cache-control": "no-store",
+  });
+  response.end(html);
+}
+
+async function createNavigationServer(): Promise<NavigationServer> {
+  const server = createServer(handleNavigationRequest);
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("Navigation test server did not expose a TCP address");
+  }
+
+  const { port } = address as AddressInfo;
+
+  return {
+    baseUrl: `http://127.0.0.1:${port}`,
+    close: async () => {
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => {
+          if (error) {
+            reject(error);
+            return;
+          }
+          resolve();
+        });
+      });
+    },
+  };
+}
+
+describe.sequential("QuickJS page.cua toolset", () => {
+  let browserRootDir = "";
+  let manager: BrowserManager;
+  const screenshotCleanup = new Set<string>();
+
+  beforeAll(async () => {
+    await ensureSandboxClientBundle();
+
+    browserRootDir = await mkdtemp(path.join(os.tmpdir(), "dev-browser-cua-"));
+    manager = new BrowserManager(path.join(browserRootDir, "browsers"));
+  }, 180_000);
+
+  afterAll(async () => {
+    await manager.stopAll();
+    await removeDirectoryWithRetries(browserRootDir);
+    for (const filePath of screenshotCleanup) {
+      await rm(filePath, {
+        force: true,
+      });
+    }
+  }, 180_000);
+
+  describe.sequential("pointer and keyboard actions", () => {
+    const browserName = "cua-input";
+    let harness: JsonSandboxHarness;
+
+    beforeAll(async () => {
+      harness = await createSandboxHarness(manager, browserName);
+    }, 180_000);
+
+    afterAll(async () => {
+      await harness.dispose();
+      await manager.stopBrowser(browserName);
+    }, 180_000);
+
+    it("clicks at exact coordinates with the left button by default", async () => {
+      const result = await harness.runJson<{ clicks: RecordedClick[] }>(
+        withCuaPage(
+          "cua-click",
+          `
+          await page.cua.click({ x: 350, y: 250, waitForNavigation: false });
+          console.log(JSON.stringify({ clicks: await page.evaluate(() => window.clicks) }));
+        `
+        )
+      );
+
+      expect(result.clicks).toEqual([
+        {
+          x: 350,
+          y: 250,
+          button: 0,
+          detail: 1,
+          shiftKey: false,
+          altKey: false,
+        },
+      ]);
+    }, 15_000);
+
+    it("supports middle and right buttons and rejects unsupported buttons", async () => {
+      const result = await harness.runJson<{
+        downs: RecordedMouseEvent[];
+        buttonError: string | null;
+      }>(
+        withCuaPage(
+          "cua-buttons",
+          `
+          await page.cua.click({ x: 350, y: 250, button: "right", waitForNavigation: false });
+          await page.cua.click({ x: 350, y: 250, button: "middle", waitForNavigation: false });
+          const downs = await page.evaluate(() => {
+            return window.mouseEvents.filter((event) => event.type === "mousedown");
+          });
+          let buttonError = null;
+          try {
+            await page.cua.click({ x: 350, y: 250, button: "back" });
+          } catch (error) {
+            buttonError = String((error && error.message) || error);
+          }
+          console.log(JSON.stringify({ downs, buttonError }));
+        `
+        )
+      );
+
+      expect(result.downs.map((event) => event.button)).toEqual([2, 1]);
+      expect(result.buttonError).toContain('Unsupported mouse button "back"');
+      expect(result.buttonError).toContain('"left", "middle", or "right"');
+    }, 15_000);
+
+    it("doubleClick clicks twice at the same point", async () => {
+      const result = await harness.runJson<{ clicks: RecordedClick[] }>(
+        withCuaPage(
+          "cua-double-click",
+          `
+          await page.cua.doubleClick({ x: 350, y: 250 });
+          console.log(JSON.stringify({ clicks: await page.evaluate(() => window.clicks) }));
+        `
+        )
+      );
+
+      expect(result.clicks).toHaveLength(2);
+      expect(result.clicks.map((click) => click.detail)).toEqual([1, 2]);
+      for (const click of result.clicks) {
+        expect(click.x).toBe(350);
+        expect(click.y).toBe(250);
+      }
+    }, 15_000);
+
+    it("holds modifiers during clicks and releases them afterwards", async () => {
+      const result = await harness.runJson<{ clicks: RecordedClick[] }>(
+        withCuaPage(
+          "cua-modifiers",
+          `
+          await page.cua.click({ x: 350, y: 250, modifiers: ["shift"], waitForNavigation: false });
+          await page.cua.click({ x: 350, y: 250, waitForNavigation: false });
+          console.log(JSON.stringify({ clicks: await page.evaluate(() => window.clicks) }));
+        `
+        )
+      );
+
+      expect(result.clicks).toHaveLength(2);
+      expect(result.clicks[0]!.shiftKey).toBe(true);
+      expect(result.clicks[1]!.shiftKey).toBe(false);
+    }, 15_000);
+
+    it("moves the pointer", async () => {
+      const result = await harness.runJson<{ moves: RecordedMouseEvent[] }>(
+        withCuaPage(
+          "cua-move",
+          `
+          await page.cua.move({ x: 123, y: 217 });
+          const moves = await page.evaluate(() => {
+            return window.mouseEvents.filter((event) => event.type === "mousemove");
+          });
+          console.log(JSON.stringify({ moves }));
+        `
+        )
+      );
+
+      const lastMove = result.moves.at(-1);
+      expect(lastMove).toMatchObject({ x: 123, y: 217 });
+    }, 15_000);
+
+    it("drags along a path with pressed moves", async () => {
+      const result = await harness.runJson<{ events: RecordedMouseEvent[] }>(
+        withCuaPage(
+          "cua-drag",
+          `
+          await page.cua.drag({
+            path: [
+              { x: 310, y: 210 },
+              { x: 360, y: 260 },
+              { x: 390, y: 290 },
+            ],
+          });
+          console.log(JSON.stringify({ events: await page.evaluate(() => window.mouseEvents) }));
+        `
+        )
+      );
+
+      const downs = result.events.filter((event) => event.type === "mousedown");
+      const ups = result.events.filter((event) => event.type === "mouseup");
+      expect(downs).toEqual([{ type: "mousedown", x: 310, y: 210, button: 0 }]);
+      expect(ups).toEqual([{ type: "mouseup", x: 390, y: 290, button: 0 }]);
+
+      const downIndex = result.events.findIndex((event) => event.type === "mousedown");
+      const upIndex = result.events.findIndex((event) => event.type === "mouseup");
+      expect(downIndex).toBeLessThan(upIndex);
+
+      const pressedMoves = result.events
+        .slice(downIndex + 1, upIndex)
+        .filter((event) => event.type === "mousemove");
+      expect(pressedMoves.length).toBeGreaterThan(2);
+      expect(pressedMoves.some((event) => event.x === 360 && event.y === 260)).toBe(true);
+      expect(pressedMoves.at(-1)).toMatchObject({ x: 390, y: 290 });
+    }, 15_000);
+
+    it("scrolls delta-direct on both axes", async () => {
+      const result = await harness.runJson<{
+        afterDown: { x: number; y: number };
+        afterRight: { x: number; y: number };
+        afterUp: { x: number; y: number };
+      }>(
+        withCuaPage(
+          "cua-scroll",
+          `
+          const readScroll = () => page.evaluate(() => ({ x: window.scrollX, y: window.scrollY }));
+          await page.cua.scroll({ x: 400, y: 300, scrollX: 0, scrollY: 400 });
+          await page.waitForFunction(() => window.scrollY === 400, { timeout: 5000 });
+          const afterDown = await readScroll();
+          await page.cua.scroll({ x: 400, y: 300, scrollX: 250, scrollY: 0 });
+          await page.waitForFunction(() => window.scrollX === 250, { timeout: 5000 });
+          const afterRight = await readScroll();
+          await page.cua.scroll({ x: 400, y: 300, scrollX: 0, scrollY: -150 });
+          await page.waitForFunction(() => window.scrollY === 250, { timeout: 5000 });
+          const afterUp = await readScroll();
+          console.log(JSON.stringify({ afterDown, afterRight, afterUp }));
+        `
+        )
+      );
+
+      expect(result.afterDown).toEqual({ x: 0, y: 400 });
+      expect(result.afterRight).toEqual({ x: 250, y: 400 });
+      expect(result.afterUp).toEqual({ x: 250, y: 250 });
+    }, 15_000);
+
+    it("normalizes key aliases in keypress", async () => {
+      const result = await harness.runJson<Record<string, RecordedKeyEvent[]>>(
+        withCuaPage(
+          "cua-key-aliases",
+          `
+          const record = async (keys) => {
+            await page.evaluate(() => {
+              window.keyEvents = [];
+            });
+            await page.cua.keypress({ keys });
+            return await page.evaluate(() => window.keyEvents);
+          };
+          console.log(JSON.stringify({
+            esc: await record(["esc"]),
+            left: await record(["left"]),
+            pageup: await record(["pageup"]),
+            del: await record(["del"]),
+            ret: await record(["return"]),
+            space: await record(["space"]),
+          }));
+        `
+        )
+      );
+
+      expect(result.esc).toHaveLength(1);
+      expect(result.esc![0]!.key).toBe("Escape");
+      expect(result.left![0]!.key).toBe("ArrowLeft");
+      expect(result.pageup![0]!.key).toBe("PageUp");
+      expect(result.del![0]!.key).toBe("Delete");
+      expect(result.ret![0]!.key).toBe("Enter");
+      expect(result.space![0]!.code).toBe("Space");
+    }, 15_000);
+
+    it("applies chord rewrites: ctrl+a selects all, ctrl+y becomes redo", async () => {
+      const result = await harness.runJson<{
+        selection: { start: number; end: number };
+        selectAllKeys: RecordedKeyEvent[];
+        redoKeys: RecordedKeyEvent[];
+      }>(
+        withCuaPage(
+          "cua-chords",
+          `
+          await page.fill("#field", "hello world");
+          await page.focus("#field");
+          await page.evaluate(() => {
+            window.keyEvents = [];
+          });
+          await page.cua.keypress({ keys: ["ctrl", "a"] });
+          const selection = await page.evaluate(() => {
+            const field = document.getElementById("field");
+            return { start: field.selectionStart, end: field.selectionEnd };
+          });
+          const selectAllKeys = await page.evaluate(() => window.keyEvents);
+          await page.evaluate(() => {
+            window.keyEvents = [];
+          });
+          await page.cua.keypress({ keys: ["ctrl", "y"] });
+          const redoKeys = await page.evaluate(() => window.keyEvents);
+          console.log(JSON.stringify({ selection, selectAllKeys, redoKeys }));
+        `
+        )
+      );
+
+      expect(result.selection).toEqual({ start: 0, end: 11 });
+      const selectAllLast = result.selectAllKeys.at(-1)!;
+      expect(selectAllLast.key.toLowerCase()).toBe("a");
+      expect(selectAllLast.ctrlKey || selectAllLast.metaKey).toBe(true);
+
+      expect(result.redoKeys).toHaveLength(3);
+      const redoLast = result.redoKeys.at(-1)!;
+      expect(redoLast.key.toLowerCase()).toBe("z");
+      expect(redoLast.shiftKey).toBe(true);
+      expect(redoLast.ctrlKey || redoLast.metaKey).toBe(true);
+    }, 15_000);
+
+    it("types text with real keystrokes", async () => {
+      const result = await harness.runJson<{ value: string }>(
+        withCuaPage(
+          "cua-type",
+          `
+          await page.focus("#field");
+          await page.cua.type({ text: "hello world" });
+          console.log(JSON.stringify({ value: await page.inputValue("#field") }));
+        `
+        )
+      );
+
+      expect(result.value).toBe("hello world");
+    }, 15_000);
+  });
+
+  describe.sequential("screenshots", () => {
+    const browserName = "cua-screenshots";
+    let harness: JsonSandboxHarness;
+
+    beforeAll(async () => {
+      harness = await createSandboxHarness(manager, browserName);
+    }, 180_000);
+
+    afterAll(async () => {
+      await harness.dispose();
+      await manager.stopBrowser(browserName);
+    }, 180_000);
+
+    it("returns path and css-pixel viewport dimensions", async () => {
+      const result = await harness.runJson<{
+        shot: ScreenshotResult;
+        dims: [number, number];
+      }>(
+        withCuaPage(
+          "cua-shot-viewport",
+          `
+          const shot = await page.cua.screenshot();
+          const dims = await page.evaluate(() => [innerWidth, innerHeight]);
+          console.log(JSON.stringify({ shot, dims }));
+        `
+        )
+      );
+      screenshotCleanup.add(result.shot.path);
+
+      expect(path.isAbsolute(result.shot.path)).toBe(true);
+      expect(result.shot.path.startsWith(`${path.resolve(DEV_BROWSER_TMP_DIR)}${path.sep}`)).toBe(
+        true
+      );
+      expect(path.basename(result.shot.path)).toMatch(/^cua-page.*\.jpeg$/);
+      expect(result.shot.width).toBe(result.dims[0]);
+      expect(result.shot.height).toBe(result.dims[1]);
+
+      expect((await stat(result.shot.path)).size).toBeGreaterThan(0);
+      const data = await readFile(result.shot.path);
+      expect(readJpegDimensions(data)).toEqual({
+        width: result.shot.width,
+        height: result.shot.height,
+      });
+    }, 15_000);
+
+    it("pins clip coordinate semantics", async () => {
+      const result = await harness.runJson<{ shot: ScreenshotResult }>(
+        withCuaPage(
+          "cua-shot-clip",
+          `
+          const shot = await page.cua.screenshot({
+            name: "cua-clip-test",
+            clip: { x: 300, y: 200, width: 100, height: 100 },
+          });
+          console.log(JSON.stringify({ shot }));
+        `
+        )
+      );
+      screenshotCleanup.add(result.shot.path);
+
+      expect(path.basename(result.shot.path)).toBe("cua-clip-test.jpeg");
+      expect(result.shot.width).toBe(100);
+      expect(result.shot.height).toBe(100);
+
+      const data = await readFile(result.shot.path);
+      expect(readJpegDimensions(data)).toEqual({ width: 100, height: 100 });
+
+      const decoded = await harness.runJson<{
+        pixel: { width: number; height: number; r: number; g: number; b: number };
+      }>(`
+        const page = await browser.getPage("cua-shot-clip");
+        const pixel = await page.evaluate(async (encoded) => {
+          const image = new Image();
+          image.src = "data:image/jpeg;base64," + encoded;
+          await image.decode();
+          const canvas = document.createElement("canvas");
+          canvas.width = image.naturalWidth;
+          canvas.height = image.naturalHeight;
+          const context = canvas.getContext("2d");
+          context.drawImage(image, 0, 0);
+          const data = context.getImageData(50, 50, 1, 1).data;
+          return {
+            width: image.naturalWidth,
+            height: image.naturalHeight,
+            r: data[0],
+            g: data[1],
+            b: data[2],
+          };
+        }, ${JSON.stringify(data.toString("base64"))});
+        console.log(JSON.stringify({ pixel }));
+      `);
+
+      expect(decoded.pixel.width).toBe(100);
+      expect(decoded.pixel.height).toBe(100);
+      expect(decoded.pixel.r).toBeGreaterThan(200);
+      expect(decoded.pixel.g).toBeLessThan(80);
+      expect(decoded.pixel.b).toBeLessThan(80);
+    }, 30_000);
+
+    it("supports fullPage screenshots with document dimensions", async () => {
+      const result = await harness.runJson<{
+        shot: ScreenshotResult;
+        docDims: [number, number];
+        viewport: [number, number];
+      }>(
+        withCuaPage(
+          "cua-shot-fullpage",
+          `
+          const shot = await page.cua.screenshot({ name: "cua-fullpage-test", fullPage: true });
+          const docDims = await page.evaluate(() => [
+            document.documentElement.scrollWidth,
+            document.documentElement.scrollHeight,
+          ]);
+          const viewport = await page.evaluate(() => [innerWidth, innerHeight]);
+          console.log(JSON.stringify({ shot, docDims, viewport }));
+        `
+        )
+      );
+      screenshotCleanup.add(result.shot.path);
+
+      expect(path.basename(result.shot.path)).toBe("cua-fullpage-test.jpeg");
+      expect(result.shot.width).toBe(result.docDims[0]);
+      expect(result.shot.height).toBe(result.docDims[1]);
+      expect(result.shot.height).toBeGreaterThan(result.viewport[1]);
+
+      const data = await readFile(result.shot.path);
+      expect(readJpegDimensions(data)).toEqual({
+        width: result.shot.width,
+        height: result.shot.height,
+      });
+    }, 30_000);
+  });
+
+  describe.sequential("navigation waiting", () => {
+    const browserName = "cua-navigation";
+    let harness: JsonSandboxHarness;
+    let navigationServer: NavigationServer;
+
+    beforeAll(async () => {
+      harness = await createSandboxHarness(manager, browserName);
+      navigationServer = await createNavigationServer();
+    }, 180_000);
+
+    afterAll(async () => {
+      await harness.dispose();
+      await navigationServer.close();
+      await manager.stopBrowser(browserName);
+    }, 180_000);
+
+    it("waits for click-triggered navigation by default", async () => {
+      const firstUrl = `${navigationServer.baseUrl}/cua/first`;
+      const result = await harness.runJson<{ url: string; title: string }>(`
+        const page = await browser.getPage("cua-nav-default");
+        await page.goto(${JSON.stringify(firstUrl)}, { waitUntil: "load" });
+        const box = await page.locator("#nav").boundingBox();
+        await page.cua.click({ x: box.x + box.width / 2, y: box.y + box.height / 2 });
+        console.log(JSON.stringify({ url: page.url(), title: await page.title() }));
+      `);
+
+      expect(result.url).toBe(`${navigationServer.baseUrl}/cua/second`);
+      expect(result.title).toBe("Second Page");
+    }, 30_000);
+
+    it("skips the navigation wait with waitForNavigation: false", async () => {
+      const firstUrl = `${navigationServer.baseUrl}/cua/first`;
+      const result = await harness.runJson<{ elapsed: number; url: string }>(`
+        const page = await browser.getPage("cua-nav-escape");
+        await page.goto(${JSON.stringify(firstUrl)}, { waitUntil: "load" });
+        const box = await page.locator("#nav").boundingBox();
+        const start = Date.now();
+        await page.cua.click({
+          x: box.x + box.width / 2,
+          y: box.y + box.height / 2,
+          waitForNavigation: false,
+        });
+        const elapsed = Date.now() - start;
+        await page.waitForURL("**/cua/second");
+        console.log(JSON.stringify({ elapsed, url: page.url() }));
+      `);
+
+      expect(result.elapsed).toBeLessThan(900);
+      expect(result.url).toBe(`${navigationServer.baseUrl}/cua/second`);
+    }, 30_000);
+
+    it("ignores child-frame navigations via the main-frame predicate", async () => {
+      const hostUrl = `${navigationServer.baseUrl}/cua/iframe-host`;
+      const result = await harness.runJson<{
+        elapsed: number;
+        url: string;
+        frameUrls: string[];
+      }>(`
+        const page = await browser.getPage("cua-nav-iframe");
+        await page.goto(${JSON.stringify(hostUrl)}, { waitUntil: "load" });
+        const box = await page.locator("#swap").boundingBox();
+        const start = Date.now();
+        await page.cua.click({ x: box.x + box.width / 2, y: box.y + box.height / 2 });
+        const elapsed = Date.now() - start;
+        console.log(JSON.stringify({
+          elapsed,
+          url: page.url(),
+          frameUrls: page.frames().map((frame) => frame.url()),
+        }));
+      `);
+
+      expect(result.elapsed).toBeGreaterThanOrEqual(900);
+      expect(result.elapsed).toBeLessThan(5000);
+      expect(result.url).toBe(hostUrl);
+      expect(result.frameUrls).toContain(`${navigationServer.baseUrl}/cua/frame-b`);
+    }, 30_000);
+  });
+});

--- a/daemon/src/sandbox/__tests__/dom-cua.test.ts
+++ b/daemon/src/sandbox/__tests__/dom-cua.test.ts
@@ -1,0 +1,821 @@
+import { once } from "node:events";
+import { mkdtemp } from "node:fs/promises";
+import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
+import type { AddressInfo } from "node:net";
+import os from "node:os";
+import path from "node:path";
+import vm from "node:vm";
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { BrowserManager } from "../../browser-manager.js";
+import { removeDirectoryWithRetries } from "../../test-cleanup.js";
+import { domCuaRegister, domCuaWalker } from "../forked-client/src/client/domCuaInjected.js";
+import { QuickJSSandbox } from "../quickjs-sandbox.js";
+import { runScript } from "../script-runner-quickjs.js";
+import { ensureSandboxClientBundle } from "./bundle-test-helpers.js";
+
+const SANDBOX_TIMEOUT_MS = 60_000;
+
+const DOM_TEST_PAGE_HTML = `<!DOCTYPE html>
+<html>
+  <head>
+    <title>DomCua Test Page</title>
+  </head>
+  <body style="margin:0">
+    <input id="name" type="text" placeholder="name here" style="position:absolute;left:20px;top:20px;width:200px" />
+    <button id="submit" style="position:absolute;left:20px;top:60px">Submit</button>
+    <a id="link" href="https://example.com" style="position:absolute;left:20px;top:100px">Example link</a>
+    <input id="check" type="checkbox" checked style="position:absolute;left:20px;top:140px" />
+    <div id="closer" role="button" aria-label="Close" tabindex="0" style="position:absolute;left:20px;top:180px">x</div>
+    <button id="longtext" style="position:absolute;left:20px;top:220px">${"y".repeat(300)}</button>
+    <button id="whitespace" style="position:absolute;left:300px;top:20px">  Hello
+
+
+      World  </button>
+    <button id="escaped" style="position:absolute;left:300px;top:60px">a &amp; b &lt; c</button>
+    <input type="hidden" id="hiddenInput" value="secret" />
+    <button id="ariaHidden" aria-hidden="true" style="position:absolute;left:300px;top:100px">Hidden A</button>
+    <button id="attrHidden" hidden>Hidden B</button>
+    <button id="displayNone" style="display:none">Hidden C</button>
+    <button id="invisible" style="position:absolute;left:300px;top:140px;visibility:hidden">Hidden D</button>
+    <button id="transparent" style="position:absolute;left:300px;top:180px;opacity:0">Hidden E</button>
+    <button id="noPointer" style="position:absolute;left:300px;top:220px;pointer-events:none">Hidden F</button>
+    <div id="plain" style="position:absolute;left:300px;top:260px">plain text</div>
+    <button id="offscreen" style="position:absolute;left:20px;top:2000px">Below the fold</button>
+    <div id="spacer" style="width:10px;height:2600px"></div>
+  </body>
+</html>`;
+
+const HIDDEN_ACT_PAGE_HTML = `<!DOCTYPE html>
+<html>
+  <body style="margin:0">
+    <script>
+      window.clicks = [];
+      document.addEventListener("click", (event) => window.clicks.push(event.target.id));
+    </script>
+    <button id="target" style="position:fixed;left:20px;top:20px;width:100px;height:30px">Target</button>
+  </body>
+</html>`;
+
+const TYPE_ACT_PAGE_HTML = `<!DOCTYPE html>
+<html>
+  <body style="margin:0">
+    <input id="field" type="text" style="position:fixed;left:20px;top:20px;width:200px;height:24px" />
+  </body>
+</html>`;
+
+const SCROLL_ACT_PAGE_HTML = `<!DOCTYPE html>
+<html>
+  <body style="margin:0">
+    <div id="pane" style="position:fixed;left:600px;top:100px;width:300px;height:200px;overflow:auto">
+      <div style="height:1000px">
+        <a id="paneLink" href="#pane" style="position:absolute;left:10px;top:10px">Pane link</a>
+      </div>
+    </div>
+    <div style="width:10px;height:3000px"></div>
+  </body>
+</html>`;
+
+const BUDGET_PAGE_HTML = `<!DOCTYPE html>
+<html>
+  <body style="margin:0">
+    ${Array.from(
+      { length: 250 },
+      (_, i) =>
+        `<a href="#l${i}" style="position:absolute;left:${(i % 50) * 25}px;top:${
+          Math.floor(i / 50) * 20
+        }px">L${i}</a>`
+    ).join("\n    ")}
+  </body>
+</html>`;
+
+const ID_HELPERS = `
+  const idFor = (snapshot, needle) => {
+    const line = snapshot.split("\\n").find((entry) => entry.includes(needle));
+    if (!line) throw new Error("no snapshot line contains " + needle);
+    return Number(line.match(/node_id=(\\d+)/)[1]);
+  };
+  const allIds = (snapshot) =>
+    Array.from(snapshot.matchAll(/node_id=(\\d+)/g)).map((match) => Number(match[1]));
+`;
+
+interface CapturedOutput {
+  stdout: string[];
+  stderr: string[];
+}
+
+interface JsonSandboxHarness {
+  dispose: () => Promise<void>;
+  runJson: <T>(script: string) => Promise<T>;
+}
+
+interface DomServer {
+  baseUrl: string;
+  close: () => Promise<void>;
+}
+
+function createOutput(): CapturedOutput & {
+  sink: {
+    onStdout: (data: string) => void;
+    onStderr: (data: string) => void;
+  };
+} {
+  const stdout: string[] = [];
+  const stderr: string[] = [];
+
+  return {
+    stdout,
+    stderr,
+    sink: {
+      onStdout: (data) => {
+        stdout.push(data);
+      },
+      onStderr: (data) => {
+        stderr.push(data);
+      },
+    },
+  };
+}
+
+function clearOutput(output: CapturedOutput): void {
+  output.stdout.length = 0;
+  output.stderr.length = 0;
+}
+
+function parseLastJsonLine<T>(output: CapturedOutput): T {
+  const lines = output.stdout.map((line) => line.trim()).filter((line) => line.length > 0);
+  expect(lines.length).toBeGreaterThan(0);
+  return JSON.parse(lines.at(-1)!) as T;
+}
+
+async function createSandboxHarness(
+  manager: BrowserManager,
+  browserName: string
+): Promise<JsonSandboxHarness> {
+  await manager.ensureBrowser(browserName, {
+    headless: true,
+  });
+
+  const output = createOutput();
+  const sandbox = new QuickJSSandbox({
+    manager,
+    browserName,
+    onStdout: output.sink.onStdout,
+    onStderr: output.sink.onStderr,
+    timeoutMs: SANDBOX_TIMEOUT_MS,
+  });
+
+  await sandbox.initialize();
+
+  return {
+    dispose: async () => {
+      await sandbox.dispose();
+    },
+    runJson: async <T>(script: string): Promise<T> => {
+      clearOutput(output);
+      await sandbox.executeScript(`(async () => {\n${script}\n})()`);
+      expect(output.stderr).toEqual([]);
+      return parseLastJsonLine<T>(output);
+    },
+  };
+}
+
+const RECORDER_SCRIPT = `<script>
+  window.clicks = [];
+  document.addEventListener("click", (event) => {
+    window.clicks.push({ target: event.target.id, x: event.clientX, y: event.clientY });
+  });
+</script>`;
+
+function manyLinksHtml(count: number, prefix: string): string {
+  const links = Array.from(
+    { length: count },
+    (_, i) =>
+      `<a href="#${prefix}${i}" style="position:absolute;left:${(i % 20) * 55}px;top:${
+        Math.floor(i / 20) * 22
+      }px">${prefix.toUpperCase()}${i}</a>`
+  ).join("");
+  return `<!DOCTYPE html><html><body style="margin:0">${links}</body></html>`;
+}
+
+function domPageHtml(pathname: string): string {
+  switch (pathname) {
+    case "/dom/first":
+      return `<!DOCTYPE html>
+<html>
+  <head><title>Dom First</title></head>
+  <body style="margin:0">
+    ${RECORDER_SCRIPT}
+    <button id="one" style="position:fixed;left:20px;top:20px;width:120px;height:32px">One</button>
+    <button id="two" style="position:fixed;left:20px;top:70px;width:120px;height:32px">Two</button>
+    <button id="three" style="position:fixed;left:20px;top:120px;width:120px;height:32px">Three</button>
+  </body>
+</html>`;
+    case "/dom/second":
+      return `<!DOCTYPE html>
+<html>
+  <head><title>Dom Second</title></head>
+  <body style="margin:0">
+    ${RECORDER_SCRIPT}
+    <button id="alpha" style="position:fixed;left:20px;top:20px;width:120px;height:32px">Alpha</button>
+    <button id="bravo" style="position:fixed;left:20px;top:70px;width:120px;height:32px">Bravo</button>
+    <button id="charlie" style="position:fixed;left:20px;top:120px;width:120px;height:32px">Charlie</button>
+    <button id="delta" style="position:fixed;left:20px;top:170px;width:120px;height:32px">Delta</button>
+    <button id="echo" style="position:fixed;left:20px;top:220px;width:120px;height:32px">Echo</button>
+  </body>
+</html>`;
+    case "/dom/iframe-host":
+      return `<!DOCTYPE html>
+<html>
+  <head><title>Iframe Host</title></head>
+  <body style="margin:0">
+    <button id="outer" style="position:fixed;left:10px;top:10px;width:80px;height:30px">Outer</button>
+    <iframe id="child" src="/dom/iframe-content" style="position:fixed;left:100px;top:300px;width:400px;height:200px;border:0"></iframe>
+  </body>
+</html>`;
+    case "/dom/iframe-content":
+      return `<!DOCTYPE html>
+<html>
+  <body style="margin:0">
+    <script>
+      window.frameClicks = [];
+      document.addEventListener("click", (event) => {
+        window.frameClicks.push({ target: event.target.id, x: event.clientX, y: event.clientY });
+      });
+    </script>
+    <button id="inner" style="position:fixed;left:10px;top:10px;width:100px;height:30px">Inner button</button>
+  </body>
+</html>`;
+    case "/dom/frame-budget-host":
+      return `<!DOCTYPE html>
+<html>
+  <body style="margin:0">
+    <a id="hostlink" href="#host" style="position:fixed;left:10px;top:10px">Host link</a>
+    <iframe src="/dom/many-links" style="position:fixed;left:20px;top:60px;width:1200px;height:600px;border:0"></iframe>
+  </body>
+</html>`;
+    case "/dom/many-links":
+      return manyLinksHtml(60, "m");
+    default:
+      return "";
+  }
+}
+
+function handleDomRequest(request: IncomingMessage, response: ServerResponse): void {
+  const url = new URL(request.url ?? "/", "http://127.0.0.1");
+  const html = domPageHtml(url.pathname);
+
+  if (!html) {
+    response.writeHead(404, {
+      "content-type": "text/plain; charset=utf-8",
+    });
+    response.end("not found");
+    return;
+  }
+
+  response.writeHead(200, {
+    "content-type": "text/html; charset=utf-8",
+    "cache-control": "no-store",
+  });
+  response.end(html);
+}
+
+async function createDomServer(): Promise<DomServer> {
+  const server = createServer(handleDomRequest);
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("Dom test server did not expose a TCP address");
+  }
+
+  const { port } = address as AddressInfo;
+
+  return {
+    baseUrl: `http://127.0.0.1:${port}`,
+    close: async () => {
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => {
+          if (error) {
+            reject(error);
+            return;
+          }
+          resolve();
+        });
+      });
+    },
+  };
+}
+
+interface StubText {
+  nodeType: 3;
+  nodeValue: string;
+}
+
+interface StubElement {
+  nodeType: 1;
+  tagName: string;
+  childNodes: Array<StubElement | StubText>;
+  children: StubElement[];
+  shadowRoot: { childNodes: Array<StubElement | StubText>; children: StubElement[] } | null;
+  getAttribute: (name: string) => string | null;
+  hasAttribute: (name: string) => boolean;
+  getClientRects: () => Array<{
+    left: number;
+    top: number;
+    right: number;
+    bottom: number;
+    width: number;
+    height: number;
+  }>;
+}
+
+function stubText(value: string): StubText {
+  return { nodeType: 3, nodeValue: value };
+}
+
+function stubElement(
+  tag: string,
+  attrs: Record<string, string> = {},
+  children: Array<StubElement | StubText> = [],
+  shadowChildren?: Array<StubElement | StubText>
+): StubElement {
+  return {
+    nodeType: 1,
+    tagName: tag.toUpperCase(),
+    childNodes: children,
+    children: children.filter((child): child is StubElement => child.nodeType === 1),
+    shadowRoot: shadowChildren
+      ? {
+          childNodes: shadowChildren,
+          children: shadowChildren.filter(
+            (child): child is StubElement => child.nodeType === 1
+          ),
+        }
+      : null,
+    getAttribute: (name) =>
+      Object.prototype.hasOwnProperty.call(attrs, name) ? attrs[name]! : null,
+    hasAttribute: (name) => Object.prototype.hasOwnProperty.call(attrs, name),
+    getClientRects: () => [{ left: 10, top: 10, right: 110, bottom: 40, width: 100, height: 30 }],
+  };
+}
+
+function createIsolatedRealm(root: StubElement): vm.Context {
+  return vm.createContext({
+    document: { body: root, documentElement: root },
+    getComputedStyle: () => ({
+      visibility: "visible",
+      display: "block",
+      pointerEvents: "auto",
+      opacity: "1",
+    }),
+    innerWidth: 1280,
+    innerHeight: 720,
+  });
+}
+
+describe.sequential("QuickJS page.domCua toolset", () => {
+  let browserRootDir = "";
+  let manager: BrowserManager;
+  let server: DomServer;
+
+  beforeAll(async () => {
+    await ensureSandboxClientBundle();
+
+    browserRootDir = await mkdtemp(path.join(os.tmpdir(), "dev-browser-dom-cua-"));
+    manager = new BrowserManager(path.join(browserRootDir, "browsers"));
+    server = await createDomServer();
+  }, 180_000);
+
+  afterAll(async () => {
+    await manager.stopAll();
+    await server.close();
+    await removeDirectoryWithRetries(browserRootDir);
+  }, 180_000);
+
+  describe.sequential("snapshots", () => {
+    const browserName = "dom-cua-snapshots";
+    let harness: JsonSandboxHarness;
+
+    beforeAll(async () => {
+      harness = await createSandboxHarness(manager, browserName);
+    }, 180_000);
+
+    afterAll(async () => {
+      await harness.dispose();
+      await manager.stopBrowser(browserName);
+    }, 180_000);
+
+    it("renders interactive elements as pseudo-HTML lines with node ids", async () => {
+      const { snapshot } = await harness.runJson<{ snapshot: string }>(`
+        const page = await browser.getPage("dom-cua-format");
+        await page.setContent(${JSON.stringify(DOM_TEST_PAGE_HTML)}, { waitUntil: "load" });
+        console.log(JSON.stringify({ snapshot: await page.domCua.getVisibleDom() }));
+      `);
+
+      expect(snapshot).toMatch(/<input node_id=\d+ placeholder="name here" type="text" \/>/);
+      expect(snapshot).toMatch(/<button node_id=\d+>Submit<\/button>/);
+      expect(snapshot).toMatch(/<a node_id=\d+ href="https:\/\/example\.com">Example link<\/a>/);
+      expect(snapshot).toMatch(/<input node_id=\d+ type="checkbox"[^>]*checked="true"[^>]*\/>/);
+      expect(snapshot).toMatch(/<div node_id=\d+ aria-label="Close" role="button">x<\/div>/);
+      expect(snapshot).toMatch(/>Hello World</);
+      expect(snapshot).toMatch(/>a &amp; b &lt; c</);
+
+      const longLine = snapshot.split("\n").find((line) => line.includes("yyy"));
+      expect(longLine).toMatch(/>y{160}</);
+      expect(longLine).not.toMatch(/y{161}/);
+
+      expect(snapshot).not.toContain("secret");
+      expect(snapshot).not.toContain("Hidden A");
+      expect(snapshot).not.toContain("Hidden B");
+      expect(snapshot).not.toContain("Hidden C");
+      expect(snapshot).not.toContain("Hidden D");
+      expect(snapshot).not.toContain("Hidden E");
+      expect(snapshot).not.toContain("Hidden F");
+      expect(snapshot).not.toContain("plain text");
+      expect(snapshot).not.toContain("Below the fold");
+    }, 30_000);
+
+    it("filters by viewport and includes elements after scrolling", async () => {
+      const result = await harness.runJson<{ before: string; after: string }>(`
+        const page = await browser.getPage("dom-cua-viewport");
+        await page.setContent(${JSON.stringify(DOM_TEST_PAGE_HTML)}, { waitUntil: "load" });
+        const before = await page.domCua.getVisibleDom();
+        await page.evaluate(() => window.scrollTo(0, 2000));
+        const after = await page.domCua.getVisibleDom();
+        console.log(JSON.stringify({ before, after }));
+      `);
+
+      expect(result.before).toContain(">Submit<");
+      expect(result.before).not.toContain("Below the fold");
+      expect(result.after).toContain("Below the fold");
+      expect(result.after).not.toContain(">Submit<");
+    }, 30_000);
+
+    it("keeps ids sticky across snapshots and assigns fresh ids to new elements", async () => {
+      const result = await harness.runJson<{
+        firstIds: number[];
+        submitFirst: number;
+        submitSecond: number;
+        freshId: number;
+      }>(`
+        ${ID_HELPERS}
+        const page = await browser.getPage("dom-cua-sticky");
+        await page.setContent(${JSON.stringify(DOM_TEST_PAGE_HTML)}, { waitUntil: "load" });
+        const first = await page.domCua.getVisibleDom();
+        await page.evaluate(() => {
+          document.body.insertAdjacentHTML(
+            "beforeend",
+            '<button id="fresh" style="position:absolute;left:600px;top:60px">Fresh</button>'
+          );
+        });
+        const second = await page.domCua.getVisibleDom();
+        console.log(JSON.stringify({
+          firstIds: allIds(first),
+          submitFirst: idFor(first, ">Submit<"),
+          submitSecond: idFor(second, ">Submit<"),
+          freshId: idFor(second, ">Fresh<"),
+        }));
+      `);
+
+      expect(result.submitSecond).toBe(result.submitFirst);
+      expect(result.firstIds).not.toContain(result.freshId);
+      expect(result.freshId).toBeGreaterThan(Math.max(...result.firstIds));
+    }, 30_000);
+
+    it("appends a truncation marker when the element budget trips", async () => {
+      const { snapshot } = await harness.runJson<{ snapshot: string }>(`
+        const page = await browser.getPage("dom-cua-budget");
+        await page.setContent(${JSON.stringify(BUDGET_PAGE_HTML)}, { waitUntil: "load" });
+        console.log(JSON.stringify({ snapshot: await page.domCua.getVisibleDom() }));
+      `);
+
+      const lines = snapshot.split("\n");
+      expect(lines.filter((line) => line.startsWith("<a ")).length).toBe(200);
+      expect(snapshot).toContain("output truncated");
+    }, 30_000);
+
+    it("caps child frames at 50 elements with a truncation marker", async () => {
+      const hostUrl = `${server.baseUrl}/dom/frame-budget-host`;
+      const { snapshot } = await harness.runJson<{ snapshot: string }>(`
+        const page = await browser.getPage("dom-cua-frame-budget");
+        await page.goto(${JSON.stringify(hostUrl)}, { waitUntil: "load" });
+        console.log(JSON.stringify({ snapshot: await page.domCua.getVisibleDom() }));
+      `);
+
+      const frameLines = snapshot.split("\n").filter((line) => line.includes('href="#m'));
+      expect(frameLines.length).toBe(50);
+      expect(snapshot).toContain(">Host link<");
+      expect(snapshot).toContain("output truncated");
+    }, 30_000);
+  });
+
+  describe.sequential("acting by node id", () => {
+    const browserName = "dom-cua-act";
+    let harness: JsonSandboxHarness;
+
+    beforeAll(async () => {
+      harness = await createSandboxHarness(manager, browserName);
+    }, 180_000);
+
+    afterAll(async () => {
+      await harness.dispose();
+      await manager.stopBrowser(browserName);
+    }, 180_000);
+
+    it("clicks the element that owns a node id", async () => {
+      const firstUrl = `${server.baseUrl}/dom/first`;
+      const result = await harness.runJson<{
+        clicks: Array<{ target: string; x: number; y: number }>;
+      }>(`
+        ${ID_HELPERS}
+        const page = await browser.getPage("dom-cua-act-click");
+        await page.goto(${JSON.stringify(firstUrl)}, { waitUntil: "load" });
+        const snapshot = await page.domCua.getVisibleDom();
+        await page.domCua.click({ nodeId: idFor(snapshot, ">Two<"), waitForNavigation: false });
+        console.log(JSON.stringify({ clicks: await page.evaluate(() => window.clicks) }));
+      `);
+
+      expect(result.clicks).toEqual([{ target: "two", x: 80, y: 86 }]);
+    }, 30_000);
+
+    it("clicks elements inside an iframe at frame-offset coordinates", async () => {
+      const hostUrl = `${server.baseUrl}/dom/iframe-host`;
+      const result = await harness.runJson<{
+        snapshot: string;
+        frameClicks: Array<{ target: string; x: number; y: number }>;
+      }>(`
+        ${ID_HELPERS}
+        const page = await browser.getPage("dom-cua-act-iframe");
+        await page.goto(${JSON.stringify(hostUrl)}, { waitUntil: "load" });
+        const snapshot = await page.domCua.getVisibleDom();
+        await page.domCua.click({ nodeId: idFor(snapshot, ">Inner button<"), waitForNavigation: false });
+        const frame = page.frames().find((candidate) => candidate.url().includes("/dom/iframe-content"));
+        const frameClicks = await frame.evaluate(() => window.frameClicks);
+        console.log(JSON.stringify({ snapshot, frameClicks }));
+      `);
+
+      expect(result.snapshot).toContain(">Outer<");
+      expect(result.snapshot).toContain(">Inner button<");
+      expect(result.frameClicks).toEqual([{ target: "inner", x: 60, y: 25 }]);
+    }, 30_000);
+
+    it("doubleClick clicks twice at the node center", async () => {
+      const firstUrl = `${server.baseUrl}/dom/first`;
+      const result = await harness.runJson<{
+        clicks: Array<{ target: string; x: number; y: number }>;
+      }>(`
+        ${ID_HELPERS}
+        const page = await browser.getPage("dom-cua-act-double");
+        await page.goto(${JSON.stringify(firstUrl)}, { waitUntil: "load" });
+        const snapshot = await page.domCua.getVisibleDom();
+        await page.domCua.doubleClick({ nodeId: idFor(snapshot, ">One<") });
+        console.log(JSON.stringify({ clicks: await page.evaluate(() => window.clicks) }));
+      `);
+
+      expect(result.clicks).toHaveLength(2);
+      for (const click of result.clicks) {
+        expect(click).toEqual({ target: "one", x: 80, y: 36 });
+      }
+    }, 30_000);
+
+    it("scrolls at the node center when nodeId is given, viewport center otherwise", async () => {
+      const result = await harness.runJson<{
+        paneScroll: number;
+        windowScrollAfterPane: number;
+        windowScrollAfterViewport: number;
+      }>(`
+        ${ID_HELPERS}
+        const page = await browser.getPage("dom-cua-act-scroll");
+        await page.setContent(${JSON.stringify(SCROLL_ACT_PAGE_HTML)}, { waitUntil: "load" });
+        const snapshot = await page.domCua.getVisibleDom();
+        await page.domCua.scroll({ scrollY: 200, nodeId: idFor(snapshot, ">Pane link<") });
+        await page.waitForFunction(() => document.getElementById("pane").scrollTop === 200, { timeout: 5000 });
+        const paneScroll = await page.evaluate(() => document.getElementById("pane").scrollTop);
+        const windowScrollAfterPane = await page.evaluate(() => window.scrollY);
+        await page.domCua.scroll({ scrollY: 300 });
+        await page.waitForFunction(() => window.scrollY === 300, { timeout: 5000 });
+        const windowScrollAfterViewport = await page.evaluate(() => window.scrollY);
+        console.log(JSON.stringify({ paneScroll, windowScrollAfterPane, windowScrollAfterViewport }));
+      `);
+
+      expect(result.paneScroll).toBe(200);
+      expect(result.windowScrollAfterPane).toBe(0);
+      expect(result.windowScrollAfterViewport).toBe(300);
+    }, 30_000);
+
+    it("types into the element focused by a click by id", async () => {
+      const result = await harness.runJson<{ value: string }>(`
+        ${ID_HELPERS}
+        const page = await browser.getPage("dom-cua-act-type");
+        await page.setContent(${JSON.stringify(TYPE_ACT_PAGE_HTML)}, { waitUntil: "load" });
+        const snapshot = await page.domCua.getVisibleDom();
+        await page.domCua.click({ nodeId: idFor(snapshot, "<input"), waitForNavigation: false });
+        await page.domCua.type({ text: "hello dom" });
+        console.log(JSON.stringify({ value: await page.inputValue("#field") }));
+      `);
+
+      expect(result.value).toBe("hello dom");
+    }, 30_000);
+
+    it("fails fast with a clean error when the element is hidden", async () => {
+      const result = await harness.runJson<{
+        error: string | null;
+        elapsed: number;
+        clicks: string[];
+      }>(`
+        ${ID_HELPERS}
+        const page = await browser.getPage("dom-cua-act-hidden");
+        await page.setContent(${JSON.stringify(HIDDEN_ACT_PAGE_HTML)}, { waitUntil: "load" });
+        const snapshot = await page.domCua.getVisibleDom();
+        const nodeId = idFor(snapshot, ">Target<");
+        await page.evaluate(() => {
+          document.getElementById("target").style.display = "none";
+        });
+        const start = Date.now();
+        let error = null;
+        try {
+          await page.domCua.click({ nodeId });
+        } catch (caught) {
+          error = String((caught && caught.message) || caught);
+        }
+        const elapsed = Date.now() - start;
+        console.log(JSON.stringify({ error, elapsed, clicks: await page.evaluate(() => window.clicks) }));
+      `);
+
+      expect(result.error).toContain("stale or missing — re-run getVisibleDom()");
+      expect(result.elapsed).toBeLessThan(10_000);
+      expect(result.clicks).toEqual([]);
+    }, 30_000);
+  });
+
+  describe.sequential("navigation and staleness", () => {
+    const browserName = "dom-cua-stale";
+    let harness: JsonSandboxHarness;
+
+    beforeAll(async () => {
+      harness = await createSandboxHarness(manager, browserName);
+    }, 180_000);
+
+    afterAll(async () => {
+      await harness.dispose();
+      await manager.stopBrowser(browserName);
+    }, 180_000);
+
+    it("fails fast on ids from before a reload", async () => {
+      const firstUrl = `${server.baseUrl}/dom/first`;
+      const result = await harness.runJson<{ error: string | null; elapsed: number }>(`
+        ${ID_HELPERS}
+        const page = await browser.getPage("dom-cua-reload");
+        await page.goto(${JSON.stringify(firstUrl)}, { waitUntil: "load" });
+        const snapshot = await page.domCua.getVisibleDom();
+        const nodeId = idFor(snapshot, ">Three<");
+        await page.reload({ waitUntil: "load" });
+        const start = Date.now();
+        let error = null;
+        try {
+          await page.domCua.click({ nodeId });
+        } catch (caught) {
+          error = String((caught && caught.message) || caught);
+        }
+        console.log(JSON.stringify({ error, elapsed: Date.now() - start }));
+      `);
+
+      expect(result.error).toContain("stale or missing — re-run getVisibleDom()");
+      expect(result.elapsed).toBeLessThan(3000);
+    }, 30_000);
+
+    it("never reuses pre-navigation ids: acting on one errors instead of clicking", async () => {
+      const firstUrl = `${server.baseUrl}/dom/first`;
+      const secondUrl = `${server.baseUrl}/dom/second`;
+      const result = await harness.runJson<{
+        preNavIds: number[];
+        postNavIds: number[];
+        error: string | null;
+        clicks: Array<{ target: string }>;
+      }>(`
+        ${ID_HELPERS}
+        const page = await browser.getPage("dom-cua-id-reuse");
+        await page.goto(${JSON.stringify(firstUrl)}, { waitUntil: "load" });
+        const preNavIds = allIds(await page.domCua.getVisibleDom());
+        await page.goto(${JSON.stringify(secondUrl)}, { waitUntil: "load" });
+        const postNavIds = allIds(await page.domCua.getVisibleDom());
+        let error = null;
+        try {
+          await page.domCua.click({ nodeId: preNavIds[0] });
+        } catch (caught) {
+          error = String((caught && caught.message) || caught);
+        }
+        const clicks = await page.evaluate(() => window.clicks);
+        console.log(JSON.stringify({ preNavIds, postNavIds, error, clicks }));
+      `);
+
+      expect(result.preNavIds).toHaveLength(3);
+      expect(result.postNavIds).toHaveLength(5);
+      expect(Math.min(...result.postNavIds)).toBeGreaterThan(Math.max(...result.preNavIds));
+      expect(result.error).toContain("stale or missing — re-run getVisibleDom()");
+      expect(result.clicks).toEqual([]);
+    }, 30_000);
+  });
+
+  describe.sequential("cross-invocation", () => {
+    const browserName = "dom-cua-cross";
+
+    beforeAll(async () => {
+      await manager.ensureBrowser(browserName, {
+        headless: true,
+      });
+    }, 180_000);
+
+    afterAll(async () => {
+      await manager.stopBrowser(browserName);
+    }, 180_000);
+
+    it("acts on ids from a snapshot taken in a previous invocation", async () => {
+      const firstUrl = `${server.baseUrl}/dom/first`;
+
+      const snapshotOutput = createOutput();
+      await runScript(
+        `
+        ${ID_HELPERS}
+        const page = await browser.getPage("dom-cua-cross-page");
+        await page.goto(${JSON.stringify(firstUrl)}, { waitUntil: "load" });
+        const snapshot = await page.domCua.getVisibleDom();
+        console.log(JSON.stringify({ nodeId: idFor(snapshot, ">Two<") }));
+        `,
+        manager,
+        browserName,
+        snapshotOutput.sink
+      );
+      expect(snapshotOutput.stderr).toEqual([]);
+      const { nodeId } = parseLastJsonLine<{ nodeId: number }>(snapshotOutput);
+      expect(nodeId).toBeGreaterThan(0);
+
+      const clickOutput = createOutput();
+      await runScript(
+        `
+        const page = await browser.getPage("dom-cua-cross-page");
+        await page.domCua.click({ nodeId: ${nodeId}, waitForNavigation: false });
+        console.log(JSON.stringify({ clicks: await page.evaluate(() => window.clicks) }));
+        `,
+        manager,
+        browserName,
+        clickOutput.sink
+      );
+      expect(clickOutput.stderr).toEqual([]);
+      const { clicks } = parseLastJsonLine<{
+        clicks: Array<{ target: string; x: number; y: number }>;
+      }>(clickOutput);
+      expect(clicks).toEqual([{ target: "two", x: 80, y: 86 }]);
+    }, 60_000);
+  });
+
+  describe("walker self-containment", () => {
+    it("runs the serialized walker in an isolated realm against a DOM stub", () => {
+      const input = stubElement("input", { type: "text", placeholder: "name here" });
+      const button = stubElement("button", {}, [stubText("Submit")]);
+      const link = stubElement("a", { href: "https://example.com" }, [stubText("Example link")]);
+      const shadowed = stubElement("button", {}, [], [stubText("Shadow label")]);
+      const plain = stubElement("div", {}, [stubText("ignore me")]);
+      const root = stubElement("body", {}, [input, button, link, shadowed, plain]);
+      const realm = createIsolatedRealm(root);
+
+      const walkerInRealm = vm.runInContext(`(${String(domCuaWalker)})`, realm);
+      const result = walkerInRealm({ maxElements: 50 });
+
+      expect(result.blocked).toBe(false);
+      expect(result.truncated).toBe(false);
+      expect(result.entries.map((entry: { line: string }) => entry.line)).toEqual([
+        '<input node_id=1 placeholder="name here" type="text" />',
+        "<button node_id=2>Submit</button>",
+        '<a node_id=3 href="https://example.com">Example link</a>',
+        "<button node_id=4>Shadow label</button>",
+      ]);
+
+      const again = walkerInRealm({ maxElements: 50 });
+      expect(again.entries.map((entry: { ref: number }) => entry.ref)).toEqual([1, 2, 3, 4]);
+
+      const capped = walkerInRealm({ maxElements: 2 });
+      expect(capped.truncated).toBe(true);
+      expect(capped.entries).toHaveLength(2);
+    });
+
+    it("runs the serialized register function in an isolated realm", () => {
+      const realm = createIsolatedRealm(stubElement("body"));
+      const registerInRealm = vm.runInContext(`(${String(domCuaRegister)})`, realm);
+
+      const first = registerInRealm({ frames: [{ key: "main", refs: [1, 2, 3] }] });
+      expect(first.blocked).toBe(false);
+      expect(first.ids[0]).toHaveLength(3);
+      expect(first.ids[0][0]).toBeGreaterThanOrEqual(1_000_000);
+
+      const second = registerInRealm({ frames: [{ key: "main", refs: [2, 3, 9] }] });
+      expect(second.blocked).toBe(false);
+      expect(second.ids[0][0]).toBe(first.ids[0][1]);
+      expect(second.ids[0][1]).toBe(first.ids[0][2]);
+      expect(second.ids[0][2]).toBeGreaterThan(first.ids[0][2]);
+    });
+  });
+});

--- a/daemon/src/sandbox/__tests__/dom-cua.test.ts
+++ b/daemon/src/sandbox/__tests__/dom-cua.test.ts
@@ -247,6 +247,32 @@ function domPageHtml(pathname: string): string {
     <button id="inner" style="position:fixed;left:10px;top:10px;width:100px;height:30px">Inner button</button>
   </body>
 </html>`;
+    case "/dom/named-frame-host":
+      return `<!DOCTYPE html>
+<html>
+  <head><title>Named Frame Host</title></head>
+  <body style="margin:0">
+    <iframe name="child" src="/dom/frame-one" style="position:fixed;left:20px;top:20px;width:400px;height:200px;border:0"></iframe>
+  </body>
+</html>`;
+    case "/dom/frame-one":
+      return `<!DOCTYPE html>
+<html>
+  <body style="margin:0">
+    <button id="fa" style="position:fixed;left:10px;top:10px;width:120px;height:30px">FrameOne</button>
+  </body>
+</html>`;
+    case "/dom/frame-two":
+      return `<!DOCTYPE html>
+<html>
+  <body style="margin:0">
+    <script>
+      window.frameClicks = [];
+      document.addEventListener("click", (event) => window.frameClicks.push(event.target.id));
+    </script>
+    <button id="fb" style="position:fixed;left:10px;top:10px;width:120px;height:30px">FrameTwo</button>
+  </body>
+</html>`;
     case "/dom/frame-budget-host":
       return `<!DOCTYPE html>
 <html>
@@ -380,6 +406,7 @@ describe.sequential("QuickJS page.domCua toolset", () => {
   let browserRootDir = "";
   let manager: BrowserManager;
   let server: DomServer;
+  let crossOriginServer: DomServer;
 
   beforeAll(async () => {
     await ensureSandboxClientBundle();
@@ -387,11 +414,13 @@ describe.sequential("QuickJS page.domCua toolset", () => {
     browserRootDir = await mkdtemp(path.join(os.tmpdir(), "dev-browser-dom-cua-"));
     manager = new BrowserManager(path.join(browserRootDir, "browsers"));
     server = await createDomServer();
+    crossOriginServer = await createDomServer();
   }, 180_000);
 
   afterAll(async () => {
     await manager.stopAll();
     await server.close();
+    await crossOriginServer.close();
     await removeDirectoryWithRetries(browserRootDir);
   }, 180_000);
 
@@ -718,6 +747,71 @@ describe.sequential("QuickJS page.domCua toolset", () => {
       expect(result.error).toContain("stale or missing — re-run getVisibleDom()");
       expect(result.clicks).toEqual([]);
     }, 30_000);
+
+    it("never reuses pre-navigation ids across cross-origin navigations", async () => {
+      const firstUrl = `${server.baseUrl}/dom/first`;
+      const secondUrl = `${crossOriginServer.baseUrl}/dom/second`;
+      const result = await harness.runJson<{
+        preNavIds: number[];
+        postNavIds: number[];
+        error: string | null;
+        clicks: Array<{ target: string }>;
+      }>(`
+        ${ID_HELPERS}
+        const page = await browser.getPage("dom-cua-cross-origin");
+        await page.goto(${JSON.stringify(firstUrl)}, { waitUntil: "load" });
+        const preNavIds = allIds(await page.domCua.getVisibleDom());
+        await page.goto(${JSON.stringify(secondUrl)}, { waitUntil: "load" });
+        const postNavIds = allIds(await page.domCua.getVisibleDom());
+        let error = null;
+        try {
+          await page.domCua.click({ nodeId: preNavIds[0] });
+        } catch (caught) {
+          error = String((caught && caught.message) || caught);
+        }
+        const clicks = await page.evaluate(() => window.clicks);
+        console.log(JSON.stringify({ preNavIds, postNavIds, error, clicks }));
+      `);
+
+      expect(result.preNavIds).toHaveLength(3);
+      expect(result.postNavIds).toHaveLength(5);
+      expect(result.postNavIds.filter((id) => result.preNavIds.includes(id))).toEqual([]);
+      expect(result.error).toContain("stale or missing — re-run getVisibleDom()");
+      expect(result.clicks).toEqual([]);
+    }, 30_000);
+
+    it("assigns fresh ids after a child-frame navigation and stales the old ones", async () => {
+      const hostUrl = `${server.baseUrl}/dom/named-frame-host`;
+      const frameTwoUrl = `${server.baseUrl}/dom/frame-two`;
+      const result = await harness.runJson<{
+        oldId: number;
+        newId: number;
+        error: string | null;
+        frameClicks: string[];
+      }>(`
+        ${ID_HELPERS}
+        const page = await browser.getPage("dom-cua-frame-nav");
+        await page.goto(${JSON.stringify(hostUrl)}, { waitUntil: "load" });
+        const first = await page.domCua.getVisibleDom();
+        const oldId = idFor(first, ">FrameOne<");
+        const frame = page.frames().find((candidate) => candidate.name() === "child");
+        await frame.goto(${JSON.stringify(frameTwoUrl)}, { waitUntil: "load" });
+        const second = await page.domCua.getVisibleDom();
+        const newId = idFor(second, ">FrameTwo<");
+        let error = null;
+        try {
+          await page.domCua.click({ nodeId: oldId, waitForNavigation: false });
+        } catch (caught) {
+          error = String((caught && caught.message) || caught);
+        }
+        const frameClicks = await frame.evaluate(() => window.frameClicks);
+        console.log(JSON.stringify({ oldId, newId, error, frameClicks }));
+      `);
+
+      expect(result.newId).toBeGreaterThan(result.oldId);
+      expect(result.error).toContain("stale or missing — re-run getVisibleDom()");
+      expect(result.frameClicks).toEqual([]);
+    }, 30_000);
   });
 
   describe.sequential("cross-invocation", () => {
@@ -787,6 +881,7 @@ describe.sequential("QuickJS page.domCua toolset", () => {
 
       expect(result.blocked).toBe(false);
       expect(result.truncated).toBe(false);
+      expect(typeof result.docToken).toBe("string");
       expect(result.entries.map((entry: { line: string }) => entry.line)).toEqual([
         '<input node_id=1 placeholder="name here" type="text" />',
         "<button node_id=2>Submit</button>",
@@ -796,6 +891,7 @@ describe.sequential("QuickJS page.domCua toolset", () => {
 
       const again = walkerInRealm({ maxElements: 50 });
       expect(again.entries.map((entry: { ref: number }) => entry.ref)).toEqual([1, 2, 3, 4]);
+      expect(again.docToken).toBe(result.docToken);
 
       const capped = walkerInRealm({ maxElements: 2 });
       expect(capped.truncated).toBe(true);
@@ -806,16 +902,50 @@ describe.sequential("QuickJS page.domCua toolset", () => {
       const realm = createIsolatedRealm(stubElement("body"));
       const registerInRealm = vm.runInContext(`(${String(domCuaRegister)})`, realm);
 
-      const first = registerInRealm({ frames: [{ key: "main", refs: [1, 2, 3] }] });
+      const first = registerInRealm({
+        frames: [{ key: "main", docToken: "doc-1", refs: [1, 2, 3] }],
+      });
       expect(first.blocked).toBe(false);
       expect(first.ids[0]).toHaveLength(3);
       expect(first.ids[0][0]).toBeGreaterThanOrEqual(1_000_000);
 
-      const second = registerInRealm({ frames: [{ key: "main", refs: [2, 3, 9] }] });
+      const second = registerInRealm({
+        frames: [{ key: "main", docToken: "doc-1", refs: [2, 3, 9] }],
+      });
       expect(second.blocked).toBe(false);
       expect(second.ids[0][0]).toBe(first.ids[0][1]);
       expect(second.ids[0][1]).toBe(first.ids[0][2]);
       expect(second.ids[0][2]).toBeGreaterThan(first.ids[0][2]);
+
+      const replaced = registerInRealm({
+        frames: [{ key: "main", docToken: "doc-2", refs: [1, 2, 3] }],
+      });
+      expect(replaced.blocked).toBe(false);
+      for (const id of replaced.ids[0]) {
+        expect(id).toBeGreaterThan(second.ids[0][2]);
+      }
+    });
+
+    it("starts at a high base when sessionStorage works but holds no counter", () => {
+      const storage = new Map<string, string>();
+      const realm = vm.createContext({
+        sessionStorage: {
+          getItem: (key: string) => (storage.has(key) ? storage.get(key)! : null),
+          setItem: (key: string, value: string) => {
+            storage.set(key, String(value));
+          },
+        },
+      });
+      const registerInRealm = vm.runInContext(`(${String(domCuaRegister)})`, realm);
+
+      const result = registerInRealm({
+        frames: [{ key: "main", docToken: "doc-1", refs: [1, 2] }],
+      });
+      expect(result.blocked).toBe(false);
+      expect(Math.min(...result.ids[0])).toBeGreaterThanOrEqual(1_000_000);
+      expect(Number(storage.get("__devBrowserDomCuaNextPublicId"))).toBeGreaterThan(
+        Math.max(...result.ids[0])
+      );
     });
   });
 });

--- a/daemon/src/sandbox/__tests__/dom-cua.test.ts
+++ b/daemon/src/sandbox/__tests__/dom-cua.test.ts
@@ -568,6 +568,22 @@ describe.sequential("QuickJS page.domCua toolset", () => {
       expect(result.clicks).toEqual([{ target: "two", x: 80, y: 86 }]);
     }, 30_000);
 
+    it("accepts a numeric-string nodeId as regexed from the snapshot text", async () => {
+      const firstUrl = `${server.baseUrl}/dom/first`;
+      const result = await harness.runJson<{
+        clicks: Array<{ target: string; x: number; y: number }>;
+      }>(`
+        ${ID_HELPERS}
+        const page = await browser.getPage("dom-cua-act-string-id");
+        await page.goto(${JSON.stringify(firstUrl)}, { waitUntil: "load" });
+        const snapshot = await page.domCua.getVisibleDom();
+        await page.domCua.click({ nodeId: String(idFor(snapshot, ">Two<")), waitForNavigation: false });
+        console.log(JSON.stringify({ clicks: await page.evaluate(() => window.clicks) }));
+      `);
+
+      expect(result.clicks).toEqual([{ target: "two", x: 80, y: 86 }]);
+    }, 30_000);
+
     it("clicks elements inside an iframe at frame-offset coordinates", async () => {
       const hostUrl = `${server.baseUrl}/dom/iframe-host`;
       const result = await harness.runJson<{

--- a/daemon/src/sandbox/__tests__/dom-cua.test.ts
+++ b/daemon/src/sandbox/__tests__/dom-cua.test.ts
@@ -376,9 +376,7 @@ function stubElement(
     shadowRoot: shadowChildren
       ? {
           childNodes: shadowChildren,
-          children: shadowChildren.filter(
-            (child): child is StubElement => child.nodeType === 1
-          ),
+          children: shadowChildren.filter((child): child is StubElement => child.nodeType === 1),
         }
       : null,
     getAttribute: (name) =>

--- a/daemon/src/sandbox/__tests__/sandbox-integration.test.ts
+++ b/daemon/src/sandbox/__tests__/sandbox-integration.test.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
 import { BrowserManager } from "../../browser-manager.js";
+import { formatError } from "../../format-error.js";
 import { removeDirectoryWithRetries } from "../../test-cleanup.js";
 import { runScript } from "../script-runner-quickjs.js";
 import { ensureSandboxClientBundle } from "./bundle-test-helpers.js";
@@ -132,6 +133,25 @@ describe.sequential("QuickJS sandbox integration", () => {
     ).rejects.toThrow("boom");
   });
 
+  it("surfaces thrown error messages in formatted errors", async () => {
+    const output = createOutput();
+
+    const error = await runScript(
+      `
+        throw new Error("boom message");
+      `,
+      manager,
+      "default",
+      output.sink
+    ).then(
+      () => null,
+      (caught: unknown) => caught
+    );
+
+    expect(error).toBeInstanceOf(Error);
+    expect(formatError(error)).toContain("boom message");
+  });
+
   it("enforces CPU timeouts", async () => {
     const output = createOutput();
 
@@ -181,6 +201,26 @@ describe.sequential("QuickJS sandbox integration", () => {
     );
 
     expect(output.stdout.join("")).toContain("sandbox 42 { ok: true }");
+    expect(output.stderr.join("")).toBe("");
+  });
+
+  it("supports Buffer.isBuffer", async () => {
+    const output = createOutput();
+
+    await runScript(
+      `
+        console.log(
+          Buffer.isBuffer(Buffer.from([1, 2, 3])),
+          Buffer.isBuffer(new Uint8Array(3)),
+          Buffer.isBuffer("nope")
+        );
+      `,
+      manager,
+      "default",
+      output.sink
+    );
+
+    expect(output.stdout.join("")).toContain("true false false");
     expect(output.stderr.join("")).toBe("");
   });
 });

--- a/daemon/src/sandbox/__tests__/sandbox-security.test.ts
+++ b/daemon/src/sandbox/__tests__/sandbox-security.test.ts
@@ -170,6 +170,35 @@ describe.sequential("QuickJS sandbox security", () => {
     expect(payload.browserHasNullPrototype).toBe(true);
   }, 120_000);
 
+  it("exposes the cua and domCua namespaces on pages", async () => {
+    const output = await runSandboxScript(`
+      const page = await browser.newPage();
+      console.log(
+        JSON.stringify({
+          cuaClick: typeof page.cua.click,
+          cuaScreenshot: typeof page.cua.screenshot,
+          domCuaGetVisibleDom: typeof page.domCua.getVisibleDom,
+          domCuaClick: typeof page.domCua.click,
+        }),
+      );
+    `);
+
+    expect(output.stderr).toEqual([]);
+    expect(output.stdout).toHaveLength(1);
+
+    const reportLine = output.stdout[0];
+    if (reportLine === undefined) {
+      throw new Error("Sandbox namespace report was not captured");
+    }
+
+    expect(JSON.parse(reportLine)).toEqual({
+      cuaClick: "function",
+      cuaScreenshot: "function",
+      domCuaGetVisibleDom: "function",
+      domCuaClick: "function",
+    });
+  }, 120_000);
+
   it("captures console output without leaking to host stdout", async () => {
     const output = createOutput();
     const stdoutSpy = vi.spyOn(process.stdout, "write");

--- a/daemon/src/sandbox/forked-client/src/client/cua.ts
+++ b/daemon/src/sandbox/forked-client/src/client/cua.ts
@@ -12,6 +12,25 @@ function assertButton(button: string): void {
   }
 }
 
+function jpegDimensions(buffer: Buffer): { width: number; height: number } | null {
+  if (buffer.length < 4 || buffer[0] !== 0xff || buffer[1] !== 0xd8) return null;
+  let offset = 2;
+  while (offset + 9 < buffer.length) {
+    if (buffer[offset] !== 0xff) {
+      offset++;
+      continue;
+    }
+    const marker = buffer[offset + 1];
+    if (marker >= 0xc0 && marker <= 0xcf && marker !== 0xc4 && marker !== 0xc8 && marker !== 0xcc)
+      return {
+        height: (buffer[offset + 5] << 8) | buffer[offset + 6],
+        width: (buffer[offset + 7] << 8) | buffer[offset + 8],
+      };
+    offset += 2 + ((buffer[offset + 2] << 8) | buffer[offset + 3]);
+  }
+  return null;
+}
+
 export class Cua {
   #page: Page;
 
@@ -136,17 +155,13 @@ export class Cua {
     fullPage?: boolean;
     clip?: { x: number; y: number; width: number; height: number };
   } = {}): Promise<{ path: string; width: number; height: number }> {
-    const buffer = await this.#page.screenshot({
+    let buffer = await this.#page.screenshot({
       type: "jpeg",
       quality: 80,
       scale: "css",
       fullPage,
       clip,
     });
-    const save = globalThis.saveScreenshot;
-    if (typeof save !== "function")
-      throw new Error("saveScreenshot() is not available in the QuickJS sandbox");
-    const path = await save(buffer, (name ?? `cua-${this.#page._guid}`) + ".jpeg");
     let width: number;
     let height: number;
     if (clip) {
@@ -160,7 +175,41 @@ export class Cua {
     } else {
       [width, height] = await this.#page.evaluate(() => [innerWidth, innerHeight]);
     }
+    width = Math.round(width);
+    height = Math.round(height);
+    // Playwright ignores scale:"css" on viewport:null pages (headed and
+    // connected Chrome), returning device-pixel images that break the 1:1
+    // coordinate contract — downscale in-page when the dims disagree.
+    const actual = jpegDimensions(buffer);
+    if (actual && (Math.abs(actual.width - width) > 1 || Math.abs(actual.height - height) > 1))
+      buffer = await this.#downscaleToCssPixels(buffer, width, height);
+    const save = globalThis.saveScreenshot;
+    if (typeof save !== "function")
+      throw new Error("saveScreenshot() is not available in the QuickJS sandbox");
+    const path = await save(buffer, (name ?? `cua-${this.#page._guid}`) + ".jpeg");
     return { path, width, height };
+  }
+
+  async #downscaleToCssPixels(buffer: Buffer, width: number, height: number): Promise<Buffer> {
+    const base64 = await this.#page.evaluate(
+      async ({ data, width, height }) => {
+        const raw = atob(data);
+        const bytes = new Uint8Array(raw.length);
+        for (let i = 0; i < raw.length; i++) bytes[i] = raw.charCodeAt(i);
+        const bitmap = await createImageBitmap(new Blob([bytes], { type: "image/jpeg" }));
+        const canvas = new OffscreenCanvas(width, height);
+        canvas.getContext("2d").drawImage(bitmap, 0, 0, width, height);
+        bitmap.close();
+        const blob = await canvas.convertToBlob({ type: "image/jpeg", quality: 0.8 });
+        const out = new Uint8Array(await blob.arrayBuffer());
+        let binary = "";
+        for (let i = 0; i < out.length; i += 0x8000)
+          binary += String.fromCharCode.apply(null, out.subarray(i, i + 0x8000));
+        return btoa(binary);
+      },
+      { data: buffer.toString("base64"), width, height }
+    );
+    return Buffer.from(base64, "base64");
   }
 
   async #withModifiers(modifiers: string[], act: () => Promise<void>): Promise<void> {

--- a/daemon/src/sandbox/forked-client/src/client/cua.ts
+++ b/daemon/src/sandbox/forked-client/src/client/cua.ts
@@ -106,11 +106,15 @@ export class Cua {
     const normalized = normalizeKeys(keys);
     if (normalized.length === 0) return;
     const held = normalized.slice(0, -1);
-    for (const key of held) await this.#page.keyboard.down(key);
+    const pressed: string[] = [];
     try {
+      for (const key of held) {
+        await this.#page.keyboard.down(key);
+        pressed.push(key);
+      }
       await this.#page.keyboard.press(normalized[normalized.length - 1]);
     } finally {
-      for (const key of held.reverse()) await this.#page.keyboard.up(key);
+      for (const key of pressed.reverse()) await this.#page.keyboard.up(key);
     }
   }
 
@@ -161,11 +165,15 @@ export class Cua {
 
   async #withModifiers(modifiers: string[], act: () => Promise<void>): Promise<void> {
     const keys = normalizeKeys(modifiers ?? []);
-    for (const key of keys) await this.#page.keyboard.down(key);
+    const pressed: string[] = [];
     try {
+      for (const key of keys) {
+        await this.#page.keyboard.down(key);
+        pressed.push(key);
+      }
       await act();
     } finally {
-      for (const key of keys.slice().reverse()) await this.#page.keyboard.up(key);
+      for (const key of pressed.reverse()) await this.#page.keyboard.up(key);
     }
   }
 

--- a/daemon/src/sandbox/forked-client/src/client/cua.ts
+++ b/daemon/src/sandbox/forked-client/src/client/cua.ts
@@ -1,0 +1,183 @@
+// @ts-nocheck
+import { normalizeKeys } from "./cuaKeys";
+import type { Page } from "./page";
+
+const SUPPORTED_BUTTONS = ["left", "middle", "right"];
+
+function assertButton(button: string): void {
+  if (!SUPPORTED_BUTTONS.includes(button)) {
+    throw new Error(
+      `Unsupported mouse button "${button}" — must be one of "left", "middle", or "right"`
+    );
+  }
+}
+
+export class Cua {
+  #page: Page;
+
+  constructor(page: Page) {
+    this.#page = page;
+  }
+
+  /**
+   * Click at viewport coordinates. By default waits for a click-triggered
+   * navigation (a ~1s grace period is paid on every non-navigating click);
+   * pass `waitForNavigation: false` to skip the wait in tight loops.
+   */
+  async click({
+    x,
+    y,
+    button = "left",
+    clickCount = 1,
+    modifiers = [],
+    waitForNavigation = true,
+  }: {
+    x: number;
+    y: number;
+    button?: "left" | "middle" | "right";
+    clickCount?: number;
+    modifiers?: string[];
+    waitForNavigation?: boolean;
+  }): Promise<void> {
+    assertButton(button);
+    const act = () =>
+      this.#withModifiers(modifiers, () => this.#page.mouse.click(x, y, { button, clickCount }));
+    if (waitForNavigation) await this.#actAndSettle(act);
+    else await act();
+  }
+
+  async doubleClick({
+    x,
+    y,
+    modifiers = [],
+  }: {
+    x: number;
+    y: number;
+    modifiers?: string[];
+  }): Promise<void> {
+    await this.click({ x, y, clickCount: 2, modifiers });
+  }
+
+  async drag({
+    path,
+    modifiers = [],
+  }: {
+    path: Array<{ x: number; y: number }>;
+    modifiers?: string[];
+  }): Promise<void> {
+    if (!Array.isArray(path) || path.length === 0)
+      throw new Error("cua.drag requires a non-empty path of {x, y} points");
+    await this.#withModifiers(modifiers, async () => {
+      await this.#page.mouse.move(path[0].x, path[0].y);
+      await this.#page.mouse.down();
+      try {
+        for (const point of path.slice(1))
+          await this.#page.mouse.move(point.x, point.y, { steps: 10 });
+      } finally {
+        await this.#page.mouse.up();
+      }
+    });
+  }
+
+  async move({ x, y }: { x: number; y: number }): Promise<void> {
+    await this.#page.mouse.move(x, y);
+  }
+
+  async scroll({
+    x,
+    y,
+    scrollX = 0,
+    scrollY = 0,
+    modifiers = [],
+  }: {
+    x: number;
+    y: number;
+    scrollX?: number;
+    scrollY?: number;
+    modifiers?: string[];
+  }): Promise<void> {
+    await this.#withModifiers(modifiers, async () => {
+      await this.#page.mouse.move(x, y);
+      await this.#page.mouse.wheel(scrollX, scrollY);
+    });
+  }
+
+  async keypress({ keys }: { keys: string[] }): Promise<void> {
+    const normalized = normalizeKeys(keys);
+    if (normalized.length === 0) return;
+    const held = normalized.slice(0, -1);
+    for (const key of held) await this.#page.keyboard.down(key);
+    try {
+      await this.#page.keyboard.press(normalized[normalized.length - 1]);
+    } finally {
+      for (const key of held.reverse()) await this.#page.keyboard.up(key);
+    }
+  }
+
+  async type({ text }: { text: string }): Promise<void> {
+    await this.#page.keyboard.type(text);
+  }
+
+  /**
+   * Save a JPEG screenshot whose pixels map 1:1 onto cua coordinates
+   * (CSS pixels at any DPR). Never derive click coordinates from a
+   * `fullPage` image — scroll, then take a viewport screenshot instead.
+   */
+  async screenshot({
+    name,
+    fullPage,
+    clip,
+  }: {
+    name?: string;
+    fullPage?: boolean;
+    clip?: { x: number; y: number; width: number; height: number };
+  } = {}): Promise<{ path: string; width: number; height: number }> {
+    const buffer = await this.#page.screenshot({
+      type: "jpeg",
+      quality: 80,
+      scale: "css",
+      fullPage,
+      clip,
+    });
+    const save = globalThis.saveScreenshot;
+    if (typeof save !== "function")
+      throw new Error("saveScreenshot() is not available in the QuickJS sandbox");
+    const path = await save(buffer, (name ?? `cua-${this.#page._guid}`) + ".jpeg");
+    let width: number;
+    let height: number;
+    if (clip) {
+      width = clip.width;
+      height = clip.height;
+    } else if (fullPage) {
+      [width, height] = await this.#page.evaluate(() => [
+        document.documentElement.scrollWidth,
+        document.documentElement.scrollHeight,
+      ]);
+    } else {
+      [width, height] = await this.#page.evaluate(() => [innerWidth, innerHeight]);
+    }
+    return { path, width, height };
+  }
+
+  async #withModifiers(modifiers: string[], act: () => Promise<void>): Promise<void> {
+    const keys = normalizeKeys(modifiers ?? []);
+    for (const key of keys) await this.#page.keyboard.down(key);
+    try {
+      await act();
+    } finally {
+      for (const key of keys.slice().reverse()) await this.#page.keyboard.up(key);
+    }
+  }
+
+  async #actAndSettle(act: () => Promise<void>): Promise<void> {
+    const nav = this.#page
+      .waitForEvent("framenavigated", {
+        predicate: (frame) => frame === this.#page.mainFrame(),
+        timeout: 1000,
+      })
+      .catch(() => null);
+    await act();
+    if (await nav)
+      await this.#page.waitForLoadState("domcontentloaded", { timeout: 10_000 }).catch(() => {});
+  }
+}

--- a/daemon/src/sandbox/forked-client/src/client/cuaKeys.ts
+++ b/daemon/src/sandbox/forked-client/src/client/cuaKeys.ts
@@ -1,0 +1,66 @@
+// @ts-nocheck
+const KEY_ALIASES: Record<string, string> = {
+  alt: "Alt",
+  option: "Alt",
+  arrowdown: "ArrowDown",
+  arrowleft: "ArrowLeft",
+  arrowright: "ArrowRight",
+  arrowup: "ArrowUp",
+  down: "ArrowDown",
+  left: "ArrowLeft",
+  right: "ArrowRight",
+  up: "ArrowUp",
+  backspace: "Backspace",
+  capslock: "CapsLock",
+  cmd: "Meta",
+  command: "Meta",
+  meta: "Meta",
+  super: "Meta",
+  win: "Meta",
+  ctrl: "ControlOrMeta",
+  control: "ControlOrMeta",
+  del: "Delete",
+  delete: "Delete",
+  end: "End",
+  enter: "Enter",
+  return: "Enter",
+  esc: "Escape",
+  escape: "Escape",
+  home: "Home",
+  insert: "Insert",
+  pagedown: "PageDown",
+  pgdn: "PageDown",
+  pageup: "PageUp",
+  pgup: "PageUp",
+  shift: "Shift",
+  space: "Space",
+  spacebar: "Space",
+  tab: "Tab",
+};
+
+const CHORD_REWRITES: Record<string, string[]> = {
+  "ctrl+a": ["ControlOrMeta", "a"],
+  "ctrl+c": ["ControlOrMeta", "c"],
+  "ctrl+l": ["ControlOrMeta", "l"],
+  "ctrl+n": ["ControlOrMeta", "n"],
+  "ctrl+v": ["ControlOrMeta", "v"],
+  "ctrl+x": ["ControlOrMeta", "x"],
+  "ctrl+y": ["ControlOrMeta", "Shift", "z"],
+  "ctrl+z": ["ControlOrMeta", "z"],
+};
+
+function normalizeKey(key: string): string {
+  const lowered = String(key).trim().toLowerCase();
+  const alias = KEY_ALIASES[lowered];
+  if (alias) return alias;
+  if (/^f\d{1,2}$/.test(lowered)) return "F" + lowered.slice(1);
+  if (lowered.length === 1) return lowered;
+  return key;
+}
+
+export function normalizeKeys(keys: string[]): string[] {
+  const lowered = keys.map((key) => String(key).trim().toLowerCase());
+  const chord = CHORD_REWRITES[lowered.join("+")];
+  if (chord) return chord.slice();
+  return keys.map(normalizeKey);
+}

--- a/daemon/src/sandbox/forked-client/src/client/domCua.ts
+++ b/daemon/src/sandbox/forked-client/src/client/domCua.ts
@@ -111,7 +111,7 @@ export class DomCua {
     modifiers = [],
     waitForNavigation = true,
   }: {
-    nodeId: number;
+    nodeId: number | string;
     button?: "left" | "middle" | "right";
     modifiers?: string[];
     waitForNavigation?: boolean;
@@ -120,7 +120,7 @@ export class DomCua {
     await this.#page.cua.click({ x, y, button, modifiers, waitForNavigation });
   }
 
-  async doubleClick({ nodeId }: { nodeId: number }): Promise<void> {
+  async doubleClick({ nodeId }: { nodeId: number | string }): Promise<void> {
     const { x, y } = await this.#resolveNodeCenter(nodeId);
     await this.#page.cua.click({ x, y, clickCount: 2 });
   }
@@ -132,7 +132,7 @@ export class DomCua {
   }: {
     scrollX?: number;
     scrollY?: number;
-    nodeId?: number;
+    nodeId?: number | string;
   }): Promise<void> {
     let x: number;
     let y: number;
@@ -154,7 +154,8 @@ export class DomCua {
     await this.#page.cua.keypress({ keys });
   }
 
-  async #resolveNodeCenter(nodeId: number): Promise<{ x: number; y: number }> {
+  async #resolveNodeCenter(nodeId: number | string): Promise<{ x: number; y: number }> {
+    if (typeof nodeId === "string" && /^\d+$/.test(nodeId)) nodeId = Number(nodeId);
     if (typeof nodeId !== "number")
       throw new Error("domCua requires a numeric nodeId from getVisibleDom()");
     const target = await this.#page

--- a/daemon/src/sandbox/forked-client/src/client/domCua.ts
+++ b/daemon/src/sandbox/forked-client/src/client/domCua.ts
@@ -1,0 +1,185 @@
+// @ts-nocheck
+import { domCuaRegister, domCuaWalker } from "./domCuaInjected";
+import { TimeoutError } from "./errors";
+import type { Frame } from "./frame";
+import type { Page } from "./page";
+
+const MAIN_FRAME_ELEMENT_BUDGET = 200;
+const CHILD_FRAME_ELEMENT_BUDGET = 50;
+const MAX_LINES = 200;
+const MAX_CHARS = 20_000;
+const FRAME_TRUNCATION_MARKER = "<!-- output truncated: frame element budget reached -->";
+const SNAPSHOT_TRUNCATION_MARKER = "<!-- output truncated: snapshot budget reached -->";
+
+function frameKey(frame: Frame): string {
+  const name = frame.name();
+  if (name) return name;
+  const indexPath: number[] = [];
+  let current = frame;
+  for (let parent = current.parentFrame(); parent; parent = current.parentFrame()) {
+    indexPath.unshift(parent.childFrames().indexOf(current));
+    current = parent;
+  }
+  return `${frame.url()}@${indexPath.join(".")}`;
+}
+
+function staleNodeError(nodeId: number): Error {
+  return new Error(`DOM node ${nodeId} is stale or missing — re-run getVisibleDom()`);
+}
+
+function blockedStateError(): Error {
+  return new Error("this page blocks domCua state — domCua cannot track elements here");
+}
+
+export class DomCua {
+  #page: Page;
+
+  constructor(page: Page) {
+    this.#page = page;
+  }
+
+  /**
+   * Snapshot the visible interactive elements of every frame as pseudo-HTML
+   * lines with `node_id=N` attributes. Ids are only valid against the latest
+   * snapshot of the current document — re-run after any navigation.
+   */
+  async getVisibleDom(): Promise<string> {
+    const mainFrame = this.#page.mainFrame();
+    const frames = [mainFrame, ...this.#page.frames().filter((frame) => frame !== mainFrame)];
+    const snapshots: Array<{
+      key: string;
+      entries: Array<{ ref: number; line: string }>;
+      truncated: boolean;
+    }> = [];
+    for (const frame of frames) {
+      const isMain = frame === mainFrame;
+      let result;
+      try {
+        result = await frame.evaluate(domCuaWalker, {
+          maxElements: isMain ? MAIN_FRAME_ELEMENT_BUDGET : CHILD_FRAME_ELEMENT_BUDGET,
+        });
+      } catch (error) {
+        if (isMain) throw error;
+        continue;
+      }
+      if (result.blocked) {
+        if (isMain) throw blockedStateError();
+        continue;
+      }
+      snapshots.push({ key: frameKey(frame), entries: result.entries, truncated: result.truncated });
+    }
+
+    const registration = await mainFrame.evaluate(domCuaRegister, {
+      frames: snapshots.map((snapshot) => ({
+        key: snapshot.key,
+        refs: snapshot.entries.map((entry) => entry.ref),
+      })),
+    });
+    if (registration.blocked) throw blockedStateError();
+
+    const lines: string[] = [];
+    let chars = 0;
+    let budgetExceeded = false;
+    for (let i = 0; i < snapshots.length && !budgetExceeded; i++) {
+      const snapshot = snapshots[i];
+      const ids = registration.ids[i];
+      for (let j = 0; j < snapshot.entries.length; j++) {
+        const line = snapshot.entries[j].line.replace(/node_id=\d+/, `node_id=${ids[j]}`);
+        if (lines.length >= MAX_LINES || chars + line.length > MAX_CHARS) {
+          budgetExceeded = true;
+          break;
+        }
+        lines.push(line);
+        chars += line.length + 1;
+      }
+      if (!budgetExceeded && snapshot.truncated) lines.push(FRAME_TRUNCATION_MARKER);
+    }
+    if (budgetExceeded) lines.push(SNAPSHOT_TRUNCATION_MARKER);
+    return lines.join("\n");
+  }
+
+  async click({
+    nodeId,
+    button = "left",
+    modifiers = [],
+    waitForNavigation = true,
+  }: {
+    nodeId: number;
+    button?: "left" | "middle" | "right";
+    modifiers?: string[];
+    waitForNavigation?: boolean;
+  }): Promise<void> {
+    const { x, y } = await this.#resolveNodeCenter(nodeId);
+    await this.#page.cua.click({ x, y, button, modifiers, waitForNavigation });
+  }
+
+  async doubleClick({ nodeId }: { nodeId: number }): Promise<void> {
+    const { x, y } = await this.#resolveNodeCenter(nodeId);
+    await this.#page.cua.click({ x, y, clickCount: 2 });
+  }
+
+  async scroll({
+    scrollX = 0,
+    scrollY = 0,
+    nodeId,
+  }: {
+    scrollX?: number;
+    scrollY?: number;
+    nodeId?: number;
+  }): Promise<void> {
+    let x: number;
+    let y: number;
+    if (nodeId !== undefined) {
+      ({ x, y } = await this.#resolveNodeCenter(nodeId));
+    } else {
+      const [width, height] = await this.#page.evaluate(() => [innerWidth, innerHeight]);
+      x = width / 2;
+      y = height / 2;
+    }
+    await this.#page.cua.scroll({ x, y, scrollX, scrollY });
+  }
+
+  async type({ text }: { text: string }): Promise<void> {
+    await this.#page.cua.type({ text });
+  }
+
+  async keypress({ keys }: { keys: string[] }): Promise<void> {
+    await this.#page.cua.keypress({ keys });
+  }
+
+  async #resolveNodeCenter(nodeId: number): Promise<{ x: number; y: number }> {
+    if (typeof nodeId !== "number")
+      throw new Error("domCua requires a numeric nodeId from getVisibleDom()");
+    const target = await this.#page
+      .mainFrame()
+      .evaluate(
+        (id) => globalThis.__devBrowserDomCua?.actionableByPublicId?.get(id) ?? null,
+        nodeId
+      );
+    if (!target) throw staleNodeError(nodeId);
+    const frame = this.#page.frames().find((candidate) => frameKey(candidate) === target.frameKey);
+    if (!frame) throw staleNodeError(nodeId);
+    const handle = await frame.evaluateHandle(
+      (ref) => globalThis.__devBrowserDomCua?.refToElement?.get(ref) ?? null,
+      target.ref
+    );
+    const element = handle.asElement();
+    if (!element) {
+      await handle.dispose();
+      throw staleNodeError(nodeId);
+    }
+    try {
+      try {
+        await element.scrollIntoViewIfNeeded({ timeout: 3000 });
+      } catch (error) {
+        if (error instanceof TimeoutError) throw staleNodeError(nodeId);
+        throw error;
+      }
+      const box = await element.boundingBox();
+      if (!box) throw staleNodeError(nodeId);
+      return { x: box.x + box.width / 2, y: box.y + box.height / 2 };
+    } finally {
+      await element.dispose();
+    }
+  }
+}

--- a/daemon/src/sandbox/forked-client/src/client/domCua.ts
+++ b/daemon/src/sandbox/forked-client/src/client/domCua.ts
@@ -48,6 +48,7 @@ export class DomCua {
     const frames = [mainFrame, ...this.#page.frames().filter((frame) => frame !== mainFrame)];
     const snapshots: Array<{
       key: string;
+      docToken: string;
       entries: Array<{ ref: number; line: string }>;
       truncated: boolean;
     }> = [];
@@ -66,12 +67,18 @@ export class DomCua {
         if (isMain) throw blockedStateError();
         continue;
       }
-      snapshots.push({ key: frameKey(frame), entries: result.entries, truncated: result.truncated });
+      snapshots.push({
+        key: frameKey(frame),
+        docToken: result.docToken,
+        entries: result.entries,
+        truncated: result.truncated,
+      });
     }
 
     const registration = await mainFrame.evaluate(domCuaRegister, {
       frames: snapshots.map((snapshot) => ({
         key: snapshot.key,
+        docToken: snapshot.docToken,
         refs: snapshot.entries.map((entry) => entry.ref),
       })),
     });

--- a/daemon/src/sandbox/forked-client/src/client/domCuaInjected.ts
+++ b/daemon/src/sandbox/forked-client/src/client/domCuaInjected.ts
@@ -67,6 +67,8 @@ export const domCuaWalker = function (options) {
   }
   if (!(state.elementToRef instanceof WeakMap)) state.elementToRef = new WeakMap();
   if (typeof state.nextRef !== "number") state.nextRef = 1;
+  if (typeof state.docToken !== "string")
+    state.docToken = Date.now() + "-" + Math.random();
   const refToElement = new Map();
   state.refToElement = refToElement;
   if (state.refToElement !== refToElement || !(state.elementToRef instanceof WeakMap))
@@ -239,7 +241,7 @@ export const domCuaWalker = function (options) {
 
   const root = document.body || document.documentElement;
   if (root) visit(root);
-  return { blocked: false, entries, truncated };
+  return { blocked: false, entries, truncated, docToken: state.docToken };
 };
 
 export const domCuaRegister = function (data) {
@@ -261,19 +263,7 @@ export const domCuaRegister = function (data) {
       stored = null;
     }
     const parsed = stored === null ? NaN : parseInt(stored, 10);
-    if (parsed >= 1) {
-      next = parsed;
-    } else {
-      next = 1;
-      let roundTrips = false;
-      try {
-        sessionStorage.setItem(STORAGE_KEY, "1");
-        roundTrips = sessionStorage.getItem(STORAGE_KEY) === "1";
-      } catch (error) {
-        roundTrips = false;
-      }
-      if (!roundTrips) next = 1_000_000 + Math.floor(Math.random() * 2_000_000_000);
-    }
+    next = parsed >= 1 ? parsed : 1_000_000 + Math.floor(Math.random() * 2_000_000_000);
   }
 
   if (!(state.publicIdByFrameKey instanceof Map)) state.publicIdByFrameKey = new Map();
@@ -291,10 +281,11 @@ export const domCuaRegister = function (data) {
   const ids = [];
   for (let i = 0; i < data.frames.length; i++) {
     const frame = data.frames[i];
-    let frameMap = sticky.get(frame.key);
+    const stickyKey = frame.key + "::" + frame.docToken;
+    let frameMap = sticky.get(stickyKey);
     if (!frameMap) {
       frameMap = new Map();
-      sticky.set(frame.key, frameMap);
+      sticky.set(stickyKey, frameMap);
     }
     const frameIds = [];
     for (let j = 0; j < frame.refs.length; j++) {

--- a/daemon/src/sandbox/forked-client/src/client/domCuaInjected.ts
+++ b/daemon/src/sandbox/forked-client/src/client/domCuaInjected.ts
@@ -1,0 +1,326 @@
+// @ts-nocheck
+// WARNING: every export in this file is serialized with String(fn) and
+// re-evaluated inside the page (frame.evaluate ships source text over the
+// wire). Each export must stay ONE truly self-contained function expression —
+// no references to module-level helpers, constants, or imports. A closure
+// would bundle and stringify fine but explode as a ReferenceError in-page at
+// runtime. Bundler flags that rewrite function bodies (minify, keepNames)
+// would also corrupt the serialized source; see
+// daemon/scripts/bundle-sandbox-client.ts.
+
+export const domCuaWalker = function (options) {
+  const maxElements =
+    options && typeof options.maxElements === "number" ? options.maxElements : 50;
+
+  const INTERACTIVE_TAGS = {
+    a: 1,
+    button: 1,
+    details: 1,
+    input: 1,
+    option: 1,
+    select: 1,
+    summary: 1,
+    textarea: 1,
+  };
+  const INTERACTIVE_ROLES = {
+    button: 1,
+    checkbox: 1,
+    combobox: 1,
+    link: 1,
+    menuitem: 1,
+    option: 1,
+    radio: 1,
+    slider: 1,
+    spinbutton: 1,
+    switch: 1,
+    tab: 1,
+    textbox: 1,
+  };
+  const SKIPPED_TAGS = { script: 1, style: 1, template: 1, noscript: 1 };
+  const TEXT_ATTRIBUTES = [
+    "aria-disabled",
+    "aria-label",
+    "contenteditable",
+    "href",
+    "name",
+    "placeholder",
+    "role",
+    "title",
+    "type",
+    "value",
+  ];
+  const BOOLEAN_ATTRIBUTES = [
+    ["checked", "checked"],
+    ["disabled", "disabled"],
+    ["multiple", "multiple"],
+    ["readonly", "readOnly"],
+    ["required", "required"],
+    ["selected", "selected"],
+  ];
+
+  let state = globalThis.__devBrowserDomCua;
+  if (!state || typeof state !== "object") {
+    state = {};
+    globalThis.__devBrowserDomCua = state;
+    if (globalThis.__devBrowserDomCua !== state)
+      return { blocked: true, entries: [], truncated: false };
+  }
+  if (!(state.elementToRef instanceof WeakMap)) state.elementToRef = new WeakMap();
+  if (typeof state.nextRef !== "number") state.nextRef = 1;
+  const refToElement = new Map();
+  state.refToElement = refToElement;
+  if (state.refToElement !== refToElement || !(state.elementToRef instanceof WeakMap))
+    return { blocked: true, entries: [], truncated: false };
+
+  const viewport =
+    typeof visualViewport !== "undefined" && visualViewport
+      ? {
+          left: visualViewport.offsetLeft,
+          top: visualViewport.offsetTop,
+          width: visualViewport.width,
+          height: visualViewport.height,
+        }
+      : { left: 0, top: 0, width: innerWidth, height: innerHeight };
+
+  function collapseWhitespace(text) {
+    return text.replace(/\s+/g, " ").trim();
+  }
+
+  function escapeHtml(text) {
+    return text
+      .replace(/&/g, "&amp;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;")
+      .replace(/"/g, "&quot;");
+  }
+
+  function isStyleVisible(element) {
+    const style = getComputedStyle(element);
+    return (
+      style.visibility === "visible" &&
+      style.display !== "none" &&
+      style.pointerEvents !== "none" &&
+      parseFloat(style.opacity) > 0.01
+    );
+  }
+
+  function isTextVisible(element) {
+    const style = getComputedStyle(element);
+    return (
+      style.visibility === "visible" &&
+      style.display !== "none" &&
+      parseFloat(style.opacity) > 0.01
+    );
+  }
+
+  function intersectsViewport(element) {
+    const rects = element.getClientRects();
+    for (let i = 0; i < rects.length; i++) {
+      const rect = rects[i];
+      if (
+        rect.width > 0 &&
+        rect.height > 0 &&
+        rect.right > viewport.left &&
+        rect.left < viewport.left + viewport.width &&
+        rect.bottom > viewport.top &&
+        rect.top < viewport.top + viewport.height
+      )
+        return true;
+    }
+    return false;
+  }
+
+  function visibleText(root) {
+    let out = "";
+    const nodes = root.childNodes || [];
+    for (let i = 0; i < nodes.length; i++) {
+      const node = nodes[i];
+      if (node.nodeType === 3) {
+        out += node.nodeValue || "";
+        continue;
+      }
+      if (node.nodeType !== 1) continue;
+      if (SKIPPED_TAGS[node.tagName.toLowerCase()] === 1) continue;
+      if (node.getAttribute("aria-hidden") === "true" || node.hasAttribute("hidden")) continue;
+      if (!isTextVisible(node)) continue;
+      if (node.shadowRoot) out += visibleText(node.shadowRoot) + " ";
+      out += visibleText(node);
+    }
+    return out;
+  }
+
+  function isInteractive(element) {
+    const tag = element.tagName.toLowerCase();
+    if (INTERACTIVE_TAGS[tag] === 1) return true;
+    if (
+      element.hasAttribute("contenteditable") &&
+      element.getAttribute("contenteditable") !== "false"
+    )
+      return true;
+    if (element.hasAttribute("href")) return true;
+    if (element.hasAttribute("onclick")) return true;
+    const role = element.getAttribute("role");
+    if (role && INTERACTIVE_ROLES[role.toLowerCase()] === 1) return true;
+    const tabIndex = element.getAttribute("tabindex");
+    if (tabIndex !== null && parseInt(tabIndex, 10) >= 0) return true;
+    return false;
+  }
+
+  function renderLine(element, ref) {
+    const tag = element.tagName.toLowerCase();
+    const parts = ["<" + tag + " node_id=" + ref];
+    for (let i = 0; i < TEXT_ATTRIBUTES.length; i++) {
+      const name = TEXT_ATTRIBUTES[i];
+      const value =
+        name === "value" && typeof element.value === "string"
+          ? element.value
+          : element.getAttribute(name);
+      if (value === null || value === undefined || value === "") continue;
+      parts.push(name + '="' + escapeHtml(collapseWhitespace(String(value))) + '"');
+    }
+    for (let j = 0; j < BOOLEAN_ATTRIBUTES.length; j++) {
+      const attrName = BOOLEAN_ATTRIBUTES[j][0];
+      const propName = BOOLEAN_ATTRIBUTES[j][1];
+      const enabled =
+        propName in element ? element[propName] === true : element.hasAttribute(attrName);
+      if (enabled) parts.push(attrName + '="true"');
+    }
+    let text = visibleText(element);
+    if (element.shadowRoot) text = visibleText(element.shadowRoot) + " " + text;
+    text = collapseWhitespace(text);
+    if (text.length > 160) text = text.slice(0, 160);
+    const opener = parts.join(" ");
+    if (!text) return opener + " />";
+    return opener + ">" + escapeHtml(text) + "</" + tag + ">";
+  }
+
+  const entries = [];
+  let truncated = false;
+
+  function visit(node) {
+    if (truncated) return;
+    if (node.nodeType !== 1) return;
+    const tag = node.tagName.toLowerCase();
+    if (SKIPPED_TAGS[tag] === 1) return;
+    if (node.getAttribute("aria-hidden") === "true" || node.hasAttribute("hidden")) return;
+    const hiddenInput =
+      tag === "input" && (node.getAttribute("type") || "").toLowerCase() === "hidden";
+    if (
+      !hiddenInput &&
+      isInteractive(node) &&
+      isStyleVisible(node) &&
+      intersectsViewport(node)
+    ) {
+      if (entries.length >= maxElements) {
+        truncated = true;
+        return;
+      }
+      let ref = state.elementToRef.get(node);
+      if (ref === undefined) {
+        ref = state.nextRef++;
+        state.elementToRef.set(node, ref);
+      }
+      refToElement.set(ref, node);
+      entries.push({ ref, line: renderLine(node, ref) });
+    }
+    if (node.shadowRoot) {
+      const shadowChildren = node.shadowRoot.children;
+      for (let i = 0; i < shadowChildren.length; i++) {
+        visit(shadowChildren[i]);
+        if (truncated) return;
+      }
+    }
+    const children = node.children;
+    for (let j = 0; j < children.length; j++) {
+      visit(children[j]);
+      if (truncated) return;
+    }
+  }
+
+  const root = document.body || document.documentElement;
+  if (root) visit(root);
+  return { blocked: false, entries, truncated };
+};
+
+export const domCuaRegister = function (data) {
+  const STORAGE_KEY = "__devBrowserDomCuaNextPublicId";
+
+  let state = globalThis.__devBrowserDomCua;
+  if (!state || typeof state !== "object") {
+    state = {};
+    globalThis.__devBrowserDomCua = state;
+    if (globalThis.__devBrowserDomCua !== state) return { blocked: true, ids: [] };
+  }
+
+  let next = state.nextPublicId;
+  if (typeof next !== "number" || !isFinite(next)) {
+    let stored = null;
+    try {
+      stored = sessionStorage.getItem(STORAGE_KEY);
+    } catch (error) {
+      stored = null;
+    }
+    const parsed = stored === null ? NaN : parseInt(stored, 10);
+    if (parsed >= 1) {
+      next = parsed;
+    } else {
+      next = 1;
+      let roundTrips = false;
+      try {
+        sessionStorage.setItem(STORAGE_KEY, "1");
+        roundTrips = sessionStorage.getItem(STORAGE_KEY) === "1";
+      } catch (error) {
+        roundTrips = false;
+      }
+      if (!roundTrips) next = 1_000_000 + Math.floor(Math.random() * 2_000_000_000);
+    }
+  }
+
+  if (!(state.publicIdByFrameKey instanceof Map)) state.publicIdByFrameKey = new Map();
+  const sticky = state.publicIdByFrameKey;
+  let total = 0;
+  sticky.forEach((frameMap) => {
+    total += frameMap.size;
+  });
+  if (total > 5000) {
+    sticky.clear();
+    next += 1_000_000;
+  }
+
+  const actionable = new Map();
+  const ids = [];
+  for (let i = 0; i < data.frames.length; i++) {
+    const frame = data.frames[i];
+    let frameMap = sticky.get(frame.key);
+    if (!frameMap) {
+      frameMap = new Map();
+      sticky.set(frame.key, frameMap);
+    }
+    const frameIds = [];
+    for (let j = 0; j < frame.refs.length; j++) {
+      const ref = frame.refs[j];
+      let id = frameMap.get(ref);
+      if (id === undefined) {
+        id = next++;
+        frameMap.set(ref, id);
+      }
+      actionable.set(id, { frameKey: frame.key, ref });
+      frameIds.push(id);
+    }
+    ids.push(frameIds);
+  }
+  state.actionableByPublicId = actionable;
+  state.nextPublicId = next;
+  try {
+    sessionStorage.setItem(STORAGE_KEY, String(next));
+  } catch (error) {
+    // sessionStorage may be blocked; the random high base covers the next document
+  }
+  if (
+    globalThis.__devBrowserDomCua !== state ||
+    state.actionableByPublicId !== actionable ||
+    state.publicIdByFrameKey !== sticky
+  )
+    return { blocked: true, ids: [] };
+  return { blocked: false, ids };
+};

--- a/daemon/src/sandbox/forked-client/src/client/domCuaInjected.ts
+++ b/daemon/src/sandbox/forked-client/src/client/domCuaInjected.ts
@@ -9,8 +9,7 @@
 // daemon/scripts/bundle-sandbox-client.ts.
 
 export const domCuaWalker = function (options) {
-  const maxElements =
-    options && typeof options.maxElements === "number" ? options.maxElements : 50;
+  const maxElements = options && typeof options.maxElements === "number" ? options.maxElements : 50;
 
   const INTERACTIVE_TAGS = {
     a: 1,
@@ -67,8 +66,7 @@ export const domCuaWalker = function (options) {
   }
   if (!(state.elementToRef instanceof WeakMap)) state.elementToRef = new WeakMap();
   if (typeof state.nextRef !== "number") state.nextRef = 1;
-  if (typeof state.docToken !== "string")
-    state.docToken = Date.now() + "-" + Math.random();
+  if (typeof state.docToken !== "string") state.docToken = Date.now() + "-" + Math.random();
   const refToElement = new Map();
   state.refToElement = refToElement;
   if (state.refToElement !== refToElement || !(state.elementToRef instanceof WeakMap))
@@ -109,9 +107,7 @@ export const domCuaWalker = function (options) {
   function isTextVisible(element) {
     const style = getComputedStyle(element);
     return (
-      style.visibility === "visible" &&
-      style.display !== "none" &&
-      parseFloat(style.opacity) > 0.01
+      style.visibility === "visible" && style.display !== "none" && parseFloat(style.opacity) > 0.01
     );
   }
 
@@ -207,12 +203,7 @@ export const domCuaWalker = function (options) {
     if (node.getAttribute("aria-hidden") === "true" || node.hasAttribute("hidden")) return;
     const hiddenInput =
       tag === "input" && (node.getAttribute("type") || "").toLowerCase() === "hidden";
-    if (
-      !hiddenInput &&
-      isInteractive(node) &&
-      isStyleVisible(node) &&
-      intersectsViewport(node)
-    ) {
+    if (!hiddenInput && isInteractive(node) && isStyleVisible(node) && intersectsViewport(node)) {
       if (entries.length >= maxElements) {
         truncated = true;
         return;

--- a/daemon/src/sandbox/forked-client/src/client/page.ts
+++ b/daemon/src/sandbox/forked-client/src/client/page.ts
@@ -22,6 +22,7 @@ import { evaluationScript } from "./clientHelper";
 import { Coverage } from "./coverage";
 import { Cua } from "./cua";
 import { DisposableObject, DisposableStub } from "./disposable";
+import { DomCua } from "./domCua";
 import { Download } from "./download";
 import { ElementHandle, determineScreenshotType } from "./elementHandle";
 import { TargetClosedError, isTargetClosedError, parseError, serializeError } from "./errors";
@@ -115,6 +116,7 @@ export class Page extends ChannelOwner<channels.PageChannel> implements api.Page
 
   readonly coverage: Coverage;
   readonly cua: Cua;
+  readonly domCua: DomCua;
   readonly keyboard: Keyboard;
   readonly mouse: Mouse;
   readonly request: APIRequestContext;
@@ -158,6 +160,7 @@ export class Page extends ChannelOwner<channels.PageChannel> implements api.Page
     );
 
     this.cua = new Cua(this);
+    this.domCua = new DomCua(this);
     this.keyboard = new Keyboard(this);
     this.mouse = new Mouse(this);
     this.request = this._browserContext.request;

--- a/daemon/src/sandbox/forked-client/src/client/page.ts
+++ b/daemon/src/sandbox/forked-client/src/client/page.ts
@@ -20,6 +20,7 @@ import { Artifact } from "./artifact";
 import { ChannelOwner } from "./channelOwner";
 import { evaluationScript } from "./clientHelper";
 import { Coverage } from "./coverage";
+import { Cua } from "./cua";
 import { DisposableObject, DisposableStub } from "./disposable";
 import { Download } from "./download";
 import { ElementHandle, determineScreenshotType } from "./elementHandle";
@@ -113,6 +114,7 @@ export class Page extends ChannelOwner<channels.PageChannel> implements api.Page
   _webSocketRoutes: WebSocketRouteHandler[] = [];
 
   readonly coverage: Coverage;
+  readonly cua: Cua;
   readonly keyboard: Keyboard;
   readonly mouse: Mouse;
   readonly request: APIRequestContext;
@@ -155,6 +157,7 @@ export class Page extends ChannelOwner<channels.PageChannel> implements api.Page
       this._browserContext._timeoutSettings
     );
 
+    this.cua = new Cua(this);
     this.keyboard = new Keyboard(this);
     this.mouse = new Mouse(this);
     this.request = this._browserContext.request;

--- a/daemon/src/sandbox/quickjs-sandbox.ts
+++ b/daemon/src/sandbox/quickjs-sandbox.ts
@@ -301,6 +301,10 @@ export class QuickJSSandbox {
               super(value);
             }
 
+            static isBuffer(value) {
+              return value instanceof Buffer;
+            }
+
             static from(value, encodingOrOffset, length) {
               if (typeof value === "string") {
                 if (encodingOrOffset !== undefined && encodingOrOffset !== "base64") {


### PR DESCRIPTION
Ports the interaction tiers from OpenAI Codex's chrome plugin (`tab.cua` / `tab.dom_cua`) into dev-browser as two new namespaces on every sandbox `page`, so agents can act by screenshot coordinates or by snapshot node ids when locators aren't enough.

## page.cua — pixel/vision tier

- `click / doubleClick / drag / move / scroll / keypress / type / screenshot`, all options-object camelCase.
- `screenshot()` saves a JPEG whose pixels map **1:1 onto cua coordinates at any DPR** and returns `{path, width, height}`. Playwright silently ignores `scale:'css'` on `viewport:null` pages (headed + connected Chrome, 2x on Retina), so the helper detects the mismatch by parsing the JPEG dimensions and downscales in-page via `OffscreenCanvas`.
- `click` waits ~1s for a click-triggered main-frame navigation (then up to 10s for the load); `waitForNavigation: false` opts out.
- Key chords use Codex's alias table (`ctrl` → `ControlOrMeta`, `ctrl+y` → `ControlOrMeta+Shift+z`, …); modifiers are tracked and released in reverse in `finally`, so a failed chord can't leave keys stuck on the persistent page.
- Scroll is delta-direct (`mouse.move` + `mouse.wheel`); buttons are `left|middle|right` with a clear error otherwise.

## page.domCua — DOM-id tier

- `getVisibleDom()` runs a self-contained in-page walker (serialized via `String(fn)`) per frame: interactable + visible-in-viewport predicates, shadow DOM, pseudo-HTML output lines (`<button node_id=42>Submit</button>`), 200-line/20k-char/50-per-frame budgets with explicit truncation markers.
- `click / doubleClick / scroll / type / keypress` act by `nodeId` (number or numeric string). Ids are sticky across snapshots, survive across CLI invocations on named pages, and are minted from a random high base keyed by a per-document token — a stale id always fails fast with `DOM node N is stale or missing — re-run getVisibleDom()` instead of silently clicking whatever now owns that number after a navigation.
- Acting resolves the element in its frame, scrolls it into view (3s cap), and clicks its center through the shared cua pipeline, so iframes (including frame offsets) work.

## Prerequisite fix

QuickJS `Error.stack` has no `Name: message` header, and `formatError` preferred the stack — so thrown script error messages were dropped entirely (`throw new Error("boom")` printed only frame lines). `formatError` now composes the header (extracted to `format-error.ts` for testability); reproduced with a failing test first.

## Tests & docs

- ~1,950 lines of new tests (`cua.test.ts`, `dom-cua.test.ts`, `format-error.test.ts`): exact-coordinate assertions, clip semantics verified while scrolled, iframe act-by-id, id-reuse-after-navigation regressions (same-origin, cross-origin, child-frame), isolated-realm walker serialization check, cross-invocation snapshot→act, and the Retina downscale path. Full suite green; `tsc`, prettier, both bundles, and `cargo build` clean.
- `cli/llm-guide.txt` gains Vision and DOM-id workflow sections, the tier-preference ladder, and method-table rows; README + CHANGELOG updated.

## Verified live

Tested end-to-end against a real running Chrome over `--connect`: `domCua` snapshot of google.com, click search box by node id, `cua.type` + Enter, results screenshot. The Retina coordinate-contract bug was found by exactly this test and fixed in the last commit.

Remaining manual checks before release: headed-mode Retina pass and a true cross-origin (OOPIF) iframe click.

🤖 Generated with [Claude Code](https://claude.com/claude-code)