### PR TITLE
fix: daemon hardening — frame cap, browser-stop lock, cold-start race, Chrome 147 CDP attach

### DIFF
--- a/cli/src/daemon.rs
+++ b/cli/src/daemon.rs
@@ -103,7 +103,19 @@ fn acquire_spawn_lock() -> Result<fs::File, Box<dyn Error>> {
         .truncate(false)
         .write(true)
         .open(base_dir.join("daemon-spawn.lock"))?;
-    lock_file.lock()?;
+
+    // Use flock(2) rather than std::fs::File::lock so the CLI keeps a low MSRV
+    // (File::lock was only stabilized in Rust 1.89). The advisory lock releases
+    // when the returned handle drops. Best-effort on non-Unix: the daemon-side
+    // bind also serializes concurrent starts.
+    #[cfg(unix)]
+    {
+        use std::os::unix::io::AsRawFd;
+        if unsafe { libc::flock(lock_file.as_raw_fd(), libc::LOCK_EX) } != 0 {
+            return Err(io::Error::last_os_error().into());
+        }
+    }
+
     Ok(lock_file)
 }
 
@@ -257,7 +269,12 @@ fn sync_text_file(path: &Path, contents: &str) -> Result<(), Box<dyn Error>> {
     };
 
     if needs_update {
-        fs::write(path, contents)?;
+        // Write to a per-process temp file and rename into place so a
+        // concurrent daemon spawn reading this file never observes a partial
+        // (truncated) write.
+        let tmp_path = path.with_extension(format!("tmp.{}", std::process::id()));
+        fs::write(&tmp_path, contents)?;
+        fs::rename(&tmp_path, path)?;
     }
 
     Ok(())

--- a/cli/src/daemon.rs
+++ b/cli/src/daemon.rs
@@ -37,6 +37,14 @@ pub fn ensure_daemon() -> Result<(), Box<dyn Error>> {
         return Ok(());
     }
 
+    // Hold an exclusive lock while spawning so concurrent CLI invocations on a
+    // cold start cannot each spawn a daemon and race on the socket path. The
+    // lock is released when the file handle drops.
+    let _spawn_lock = acquire_spawn_lock()?;
+    if is_daemon_running() {
+        return Ok(());
+    }
+
     let command = find_daemon_command()?;
     if command.requires_runtime_install && !embedded_runtime_installed(&command.current_dir) {
         return Err(
@@ -85,6 +93,18 @@ pub fn install_daemon_runtime() -> Result<(), Box<dyn Error>> {
 
 pub fn is_daemon_running() -> bool {
     connect_to_daemon().is_ok()
+}
+
+fn acquire_spawn_lock() -> Result<fs::File, Box<dyn Error>> {
+    let base_dir = daemon_base_dir()?;
+    fs::create_dir_all(&base_dir)?;
+    let lock_file = fs::OpenOptions::new()
+        .create(true)
+        .truncate(false)
+        .write(true)
+        .open(base_dir.join("daemon-spawn.lock"))?;
+    lock_file.lock()?;
+    Ok(lock_file)
 }
 
 pub fn current_daemon_pid() -> Option<i32> {

--- a/daemon/src/daemon.ts
+++ b/daemon/src/daemon.ts
@@ -34,6 +34,15 @@ const EMBEDDED_PACKAGE_JSON = JSON.stringify({
   },
 });
 
+// Chrome 147's built-in remote debugging does not emit Target.attachedToTarget
+// for some target types, which hangs connectOverCDP unless Playwright is
+// allowed to attach to "other" targets. Respect an explicit user override.
+// See https://github.com/SawyerHood/dev-browser/issues/103 and
+// https://github.com/microsoft/playwright/issues/40027.
+if (process.env.PW_CHROMIUM_ATTACH_TO_OTHER === undefined) {
+  process.env.PW_CHROMIUM_ATTACH_TO_OTHER = "1";
+}
+
 const manager = new BrowserManager(BROWSERS_DIR);
 const startedAt = Date.now();
 const withBrowserLock = createKeyedLock<string>();

--- a/daemon/src/daemon.ts
+++ b/daemon/src/daemon.ts
@@ -22,7 +22,10 @@ const PID_PATH = getPidPath();
 const BROWSERS_DIR = getBrowsersDir();
 const DEFAULT_SCRIPT_TIMEOUT_MS = 30_000;
 const SOCKET_CLOSE_TIMEOUT_MS = 500;
-const MAX_FRAME_BYTES = 10 * 1024 * 1024;
+// Bounds the in-memory request buffer. The socket decodes to UTF-8 strings, so
+// this is measured in JavaScript string length (UTF-16 code units), which is
+// what caps the JS string we actually retain.
+const MAX_FRAME_CHARS = 10 * 1024 * 1024;
 const EMBEDDED_PACKAGE_JSON = JSON.stringify({
   name: "dev-browser-runtime",
   private: true,
@@ -411,19 +414,45 @@ async function isEndpointActive(endpoint: string): Promise<boolean> {
   });
 }
 
+function listenOnEndpoint(target: net.Server): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    const onError = (error: Error) => reject(error);
+    target.once("error", onError);
+    target.listen(SOCKET_PATH, () => {
+      target.off("error", onError);
+      resolve();
+    });
+  });
+}
+
+async function bindEndpoint(target: net.Server): Promise<void> {
+  try {
+    await listenOnEndpoint(target);
+    return;
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    // Binding is the atomic claim. Only fall back to replacing the path when
+    // the bind actually failed because the path already exists.
+    if (code !== "EADDRINUSE" || !requiresDaemonEndpointCleanup()) {
+      throw error;
+    }
+  }
+
+  // The path exists. If a live daemon answers, defer to it; unlinking a bound
+  // Unix socket would not stop it and would only split clients between daemons.
+  if (await isEndpointActive(SOCKET_PATH)) {
+    process.stderr.write("daemon already running\n");
+    process.exit(0);
+  }
+
+  // Stale socket file from a crashed daemon — remove it and claim the path.
+  await unlinkIfExists(SOCKET_PATH);
+  await listenOnEndpoint(target);
+}
+
 async function start(): Promise<void> {
   await mkdir(BASE_DIR, { recursive: true });
   await ensureDevBrowserTempDir();
-  if (requiresDaemonEndpointCleanup()) {
-    // Unlinking a live Unix socket path does not stop the bound server — it
-    // would silently split clients between two daemons. Only replace the
-    // socket path if nothing is listening on it.
-    if (await isEndpointActive(SOCKET_PATH)) {
-      process.stderr.write("daemon already running\n");
-      process.exit(0);
-    }
-    await unlinkIfExists(SOCKET_PATH);
-  }
 
   server = net.createServer((socket) => {
     if (shuttingDown) {
@@ -438,20 +467,20 @@ async function start(): Promise<void> {
     let queue = Promise.resolve();
 
     socket.on("data", (chunk: string) => {
-      if (socket.destroyed) {
-        return;
-      }
-
       buffer += chunk;
       const lines = buffer.split("\n");
       buffer = lines.pop() ?? "";
 
-      if (buffer.length > MAX_FRAME_BYTES || lines.some((line) => line.length > MAX_FRAME_BYTES)) {
+      if (buffer.length > MAX_FRAME_CHARS || lines.some((line) => line.length > MAX_FRAME_CHARS)) {
+        // Pause synchronously so the unparsed remainder of an oversized frame
+        // cannot be reinterpreted as fresh requests while the error response
+        // drains (the write callback may be deferred under backpressure).
+        socket.pause();
         buffer = "";
         void writeMessage(socket, {
           id: "unknown",
           type: "error",
-          message: `Request exceeds the maximum frame size of ${MAX_FRAME_BYTES} bytes`,
+          message: `Request exceeds the maximum frame size of ${MAX_FRAME_CHARS} characters`,
         })
           .catch(() => undefined)
           .finally(() => {
@@ -490,17 +519,13 @@ async function start(): Promise<void> {
     });
   });
 
+  await bindEndpoint(server);
+
+  // Only attach the runtime error handler after a successful bind so a bind
+  // failure handled by bindEndpoint cannot also trip a shutdown.
   server.on("error", (error) => {
     console.error("Daemon server error:", error);
     void shutdown(1);
-  });
-
-  await new Promise<void>((resolve, reject) => {
-    server?.once("error", reject);
-    server?.listen(SOCKET_PATH, () => {
-      server?.off("error", reject);
-      resolve();
-    });
   });
 
   ownsEndpoint = true;

--- a/daemon/src/daemon.ts
+++ b/daemon/src/daemon.ts
@@ -22,6 +22,7 @@ const PID_PATH = getPidPath();
 const BROWSERS_DIR = getBrowsersDir();
 const DEFAULT_SCRIPT_TIMEOUT_MS = 30_000;
 const SOCKET_CLOSE_TIMEOUT_MS = 500;
+const MAX_FRAME_BYTES = 10 * 1024 * 1024;
 const EMBEDDED_PACKAGE_JSON = JSON.stringify({
   name: "dev-browser-runtime",
   private: true,
@@ -403,9 +404,27 @@ async function start(): Promise<void> {
     let queue = Promise.resolve();
 
     socket.on("data", (chunk: string) => {
+      if (socket.destroyed) {
+        return;
+      }
+
       buffer += chunk;
       const lines = buffer.split("\n");
       buffer = lines.pop() ?? "";
+
+      if (buffer.length > MAX_FRAME_BYTES || lines.some((line) => line.length > MAX_FRAME_BYTES)) {
+        buffer = "";
+        void writeMessage(socket, {
+          id: "unknown",
+          type: "error",
+          message: `Request exceeds the maximum frame size of ${MAX_FRAME_BYTES} bytes`,
+        })
+          .catch(() => undefined)
+          .finally(() => {
+            socket.destroy();
+          });
+        return;
+      }
 
       for (const rawLine of lines) {
         const line = rawLine.trim();

--- a/daemon/src/daemon.ts
+++ b/daemon/src/daemon.ts
@@ -304,7 +304,7 @@ async function handleRequest(socket: net.Socket, line: string): Promise<void> {
       return;
 
     case "browser-stop":
-      await manager.stopBrowser(request.browser);
+      await withBrowserLock(request.browser, () => manager.stopBrowser(request.browser));
       await writeMessage(socket, {
         id: request.id,
         type: "result",

--- a/daemon/src/daemon.ts
+++ b/daemon/src/daemon.ts
@@ -42,6 +42,7 @@ const clients = new Set<net.Socket>();
 
 let server: net.Server | null = null;
 let shuttingDown: Promise<void> | null = null;
+let ownsEndpoint = false;
 
 async function writeMessage(socket: net.Socket, message: Response): Promise<void> {
   if (socket.destroyed) {
@@ -369,9 +370,15 @@ async function shutdown(exitCode = 0): Promise<void> {
     await manager.stopAll();
     await Promise.allSettled(Array.from(clients, (socket) => closeClientSocket(socket)));
     await serverClosed;
-    const cleanup = [unlinkIfExists(PID_PATH)];
-    if (requiresDaemonEndpointCleanup()) {
-      cleanup.push(unlinkIfExists(SOCKET_PATH));
+    // Only remove the pid file and socket path if this process successfully
+    // bound them; otherwise a daemon that lost the startup race would delete
+    // the live daemon's endpoint.
+    const cleanup: Promise<void>[] = [];
+    if (ownsEndpoint) {
+      cleanup.push(unlinkIfExists(PID_PATH));
+      if (requiresDaemonEndpointCleanup()) {
+        cleanup.push(unlinkIfExists(SOCKET_PATH));
+      }
     }
     await Promise.allSettled(cleanup);
 
@@ -383,13 +390,31 @@ async function shutdown(exitCode = 0): Promise<void> {
   return shuttingDown;
 }
 
+async function isEndpointActive(endpoint: string): Promise<boolean> {
+  return await new Promise((resolve) => {
+    const probe = net.connect(endpoint);
+    const finish = (active: boolean) => {
+      probe.destroy();
+      resolve(active);
+    };
+    probe.once("connect", () => finish(true));
+    probe.once("error", () => finish(false));
+  });
+}
+
 async function start(): Promise<void> {
   await mkdir(BASE_DIR, { recursive: true });
   await ensureDevBrowserTempDir();
   if (requiresDaemonEndpointCleanup()) {
+    // Unlinking a live Unix socket path does not stop the bound server — it
+    // would silently split clients between two daemons. Only replace the
+    // socket path if nothing is listening on it.
+    if (await isEndpointActive(SOCKET_PATH)) {
+      process.stderr.write("daemon already running\n");
+      process.exit(0);
+    }
     await unlinkIfExists(SOCKET_PATH);
   }
-  await writeFile(PID_PATH, `${process.pid}\n`);
 
   server = net.createServer((socket) => {
     if (shuttingDown) {
@@ -468,6 +493,9 @@ async function start(): Promise<void> {
       resolve();
     });
   });
+
+  ownsEndpoint = true;
+  await writeFile(PID_PATH, `${process.pid}\n`);
 
   process.stderr.write("daemon ready\n");
 }


### PR DESCRIPTION
Fixes four open issues in the daemon/CLI, plus a follow-up commit addressing an adversarial review pass over the changes.

## Issues fixed

### #112 — Socket reader had no max frame size (local DoS)
The per-connection reader buffered bytes until a newline with no bound, so a local client could OOM the daemon by streaming data without a line terminator. Oversized frames are now rejected with an error response and the connection is dropped before any JSON parsing.

Review hardening on top of the original fix:
- The socket is **paused synchronously** on detection, so the unparsed remainder of a rejected frame can't be reinterpreted as fresh requests while the error response drains under write backpressure (the destroy was previously deferred to a `.finally()` that may never fire if the peer stops reading).
- The limit is named `MAX_FRAME_CHARS` and the error says "characters" — it bounds the retained JS string (UTF-16 code units), which is the actual memory the daemon holds, rather than overstating a byte guarantee.

### #111 — `browser-stop` bypassed the per-browser lock
`execute` serializes per browser via `withBrowserLock`, but `browser-stop` tore the browser down directly, so a second client could kill a browser mid-script. `browser-stop` now acquires the same keyed lock.

### #110 — Cold-start race spawned duplicate daemons
Concurrent CLI invocations on a cold start could both spawn a daemon; the second would unlink the first's *live* socket path (unlinking a bound Unix socket doesn't stop it), splitting clients and orphaning the first daemon.
- **CLI:** holds an exclusive `flock(2)` around the probe-and-spawn section so concurrent invocations serialize. Uses `libc::flock` (already a dependency) rather than `std::fs::File::lock`, which would have silently raised the MSRV to Rust 1.89.
- **Daemon:** claims the socket by **binding first**, and only unlinks on `EADDRINUSE` after a liveness probe confirms no daemon is listening — so a losing daemon can never delete a live socket. The pid file is written only after a successful bind, and shutdown only removes the socket/pid files if this process owns them.
- Runtime file extraction now writes via temp-file + atomic rename so a concurrent spawn never reads a truncated `daemon.mjs`.

### #103 — Chrome 147 built-in remote debugging hangs `connectOverCDP`
Chrome 147 doesn't emit `Target.attachedToTarget` for some target types, hanging Playwright's auto-attach walk. The daemon now defaults `PW_CHROMIUM_ATTACH_TO_OTHER=1` (respecting an explicit user override), matching the workaround the reporter validated. Note: as the reporter documented, an already-running daemon must be restarted once for this to take effect.

## Validation
- `npx tsc --noEmit` — clean
- `pnpm vitest run` — 133/133 passing
- `pnpm bundle` + `pnpm bundle:sandbox-client` — regenerated
- `cargo build` + `cargo clippy` — clean

## Review notes (deliberately not changed)
- **`PW_CHROMIUM_ATTACH_TO_OTHER` is process-wide**, so it also affects browsers the daemon launches, not just CDP-connected ones. Scoping it per-connect would require mutating the env var around async calls, which is racier; this matches the reporter's requested approach.
- **`shutdown()`'s `stopAll()` doesn't take the per-browser lock** — locking during shutdown could hang on a stuck script holding the lock. The targeted race in #111 is the single-browser `browser-stop` path.
- A residual, very narrow shutdown/replacement window remains for filesystem sockets; the CLI flock + bind-first claim covers all realistic spawn paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)