### PR TITLE
Bound request lifetimes and speed up browser agent actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,17 @@ Windows npm installs download the native `dev-browser-windows-x64.exe` release a
 
 ### Using with AI agents
 
-After installing, just tell your agent to run `dev-browser --help` — the help output includes a full LLM usage guide with examples and API reference. No plugin or skill installation needed.
+After installing, tell your agent to run `dev-browser --help` — the help output includes the current LLM usage guide and API reference.
+
+For agents that discover local skills, install or refresh the embedded skill explicitly:
+
+```bash
+dev-browser install-skill --codex   # ~/.codex/skills/dev-browser/SKILL.md
+dev-browser install-skill --claude  # ~/.claude/skills/dev-browser/SKILL.md
+dev-browser install-skill --agents  # ~/.agents/skills/dev-browser/SKILL.md
+```
+
+Flags may be combined. With an interactive terminal, `dev-browser install-skill` prompts for targets. In non-interactive environments it updates all three locations, including Codex, so an older copied skill does not survive a CLI upgrade.
 
 <details>
 <summary>Allowing dev-browser in Claude Code without permission prompts</summary>
@@ -131,7 +141,7 @@ You can also allow related commands in the same list:
 </details>
 
 <details>
-<summary>Legacy plugin installation (Claude Code / Amp / Codex)</summary>
+<summary>Legacy Claude Code plugin installation</summary>
 
 ### Claude Code
 
@@ -141,20 +151,6 @@ You can also allow related commands in the same list:
 ```
 
 Restart Claude Code after installation.
-
-### Amp / Codex
-
-Copy the skill to your skills directory:
-
-```bash
-# For Amp: ~/.claude/skills | For Codex: ~/.codex/skills
-SKILLS_DIR=~/.claude/skills  # or ~/.codex/skills
-
-mkdir -p $SKILLS_DIR
-git clone https://github.com/sawyerhood/dev-browser /tmp/dev-browser-skill
-cp -r /tmp/dev-browser-skill/skills/dev-browser $SKILLS_DIR/dev-browser
-rm -rf /tmp/dev-browser-skill
-```
 
 </details>
 

--- a/cli/llm-guide.txt
+++ b/cli/llm-guide.txt
@@ -1,6 +1,6 @@
 LLM USAGE GUIDE:
-  Write small, focused scripts. Each script should do ONE thing: navigate, click, fill, or check.
-  End each script by logging the state you need for the next decision.
+  Make each script one decision-sized step. Batch tightly coupled inspect/act/verify work when the target is already known.
+  End each script by logging only the state needed for the next decision.
   Use descriptive page names like "login", "checkout", or "results" instead of "page1".
   Named pages from browser.getPage("name") persist between script runs, so you usually do not need to re-navigate.
   Inside page.evaluate(...), write plain JavaScript only - no TypeScript syntax in the browser context.
@@ -27,20 +27,20 @@ LLM USAGE GUIDE:
   AI snapshots for element discovery:
     dev-browser <<'EOF'
     const page = await browser.getPage("main");
-    const result = await page.snapshotForAI();
+    const result = await page.snapshotForAI({ track: "main", timeout: 5000 });
     console.log(result.full);
     // Returns { full: string, incremental?: string }.
     // Optional args: { track?: string, depth?: number, timeout?: number }.
-    // Read result.full to identify the right element.
-    // Then interact with it using Playwright:
-    // await page.getByRole("button", { name: "Continue" }).click();
-    // Re-run page.snapshotForAI({ track: "main" }) after the page changes.
+    // Read result.full and copy the target's ref, such as e12 or f2e5.
+    // In the next decision-sized script:
+    // await page.getByRef("e12").click({ timeout: 5000 });
+    // console.log((await page.snapshotForAI({ track: "main", timeout: 5000 })).incremental);
     EOF
 
   Choosing your approach:
-    Unknown pages: use page.snapshotForAI() first to discover the page, then interact based on what you find.
-    Known pages/selectors: skip the snapshot and use direct Playwright selectors like page.click(), page.fill(), or page.locator() for faster, more reliable automation.
-    Prefer locators/snapshotForAI first; switch to page.domCua node ids when a unique stable locator can't be built or after 2 failed locator attempts on the same target; switch to page.cua coordinates when the visual structure is clearer than the DOM.
+    Unknown pages: snapshotForAI({ track, timeout: 5000 }), act with getByRef(ref), then take a tracked snapshot to verify the change.
+    Known pages/selectors: skip the snapshot and use direct Playwright selectors with short explicit action timeouts. Use getByRole(...) as a semantic fallback when no stable direct selector is known.
+    Switch to page.domCua node ids when a stable locator cannot be built; use page.cua coordinates when visual structure is clearer than the DOM.
     After acting, collect the cheapest state check; don't take both a snapshot and a screenshot by default.
 
   Vision workflow (page.cua):
@@ -64,8 +64,13 @@ LLM USAGE GUIDE:
     Also available: cua.doubleClick({x, y}), cua.drag({path: [{x, y}, ...]}), cua.move({x, y}),
     cua.scroll({x, y, scrollX, scrollY}) (positive scrollY scrolls content down),
     cua.keypress({keys: ["ctrl", "a"]}), cua.type({text}).
-    cua.click and domCua.click wait ~1s for a click-triggered navigation (then up to 10s for the load);
-    pass waitForNavigation: false to skip that grace wait in tight loops.
+    cua.click, cua.doubleClick, domCua.click, and domCua.doubleClick do not wait for navigation by default.
+    For a known destination, pair the action with page.waitForURL(...):
+      await Promise.all([
+        page.waitForURL("**/confirmation", { timeout: 5000 }),
+        page.cua.click({ x: 412, y: 233 }),
+      ]);
+    For an unknown click destination, pass waitForNavigation: true to settle a main-frame navigation.
 
   DOM-id workflow (page.domCua):
     Snapshot the visible interactive elements, then act on them by node id.
@@ -100,8 +105,8 @@ LLM USAGE GUIDE:
   Waiting patterns:
     dev-browser <<'EOF'
     const page = await browser.getPage("search-results");
-    await page.waitForSelector(".results");
-    await page.waitForURL("**/success");
+    await page.waitForSelector(".results", { timeout: 5000 });
+    await page.waitForURL("**/success", { timeout: 5000 });
     console.log(JSON.stringify({
       url: page.url(),
       title: await page.title(),
@@ -134,6 +139,7 @@ LLM USAGE GUIDE:
     page.url()                             Get the current URL
     page.snapshotForAI(options)            Get an AI-optimized snapshot; returns { full, incremental? }
                                            Options: { track?: string, depth?: number, timeout?: number }
+    page.getByRef(ref)                     Target an eN or iframe fNeN ref from snapshotForAI()
     page.getByRole(role, { name })         Target elements discovered from the snapshot
     page.textContent(selector)             Get the text content of an element
     page.innerHTML(selector)               Get the inner HTML of an element
@@ -146,9 +152,11 @@ LLM USAGE GUIDE:
     page.screenshot()                      Capture a screenshot buffer; save it with saveScreenshot(...)
     page.cua.screenshot(options)           Save a JPEG for the vision workflow; returns { path, width, height }
                                            Options: { name?: string, fullPage?: boolean, clip? }
-    page.cua.click({ x, y })               Click at viewport coordinates measured on a cua screenshot
+    page.cua.click({ x, y, waitForNavigation? })
+                                           Click at viewport coordinates; navigation wait defaults false
     page.domCua.getVisibleDom()            Snapshot visible interactive elements as node_id=N lines
-    page.domCua.click({ nodeId })          Click an element by node id from the latest snapshot
+    page.domCua.click({ nodeId, waitForNavigation? })
+                                           Click a current node id; navigation wait defaults false
     page.$$eval(selector, fn)              Run a function on all matching elements
     page.$eval(selector, fn)               Run a function on the first matching element
     page.evaluate(fn)                      Run JavaScript in the page context (plain JS only)

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -170,7 +170,7 @@ enum Command {
     Install,
     #[command(
         about = "Install the dev-browser skill into agent skill directories",
-        long_about = "Install the embedded dev-browser skill into agent skill directories.\n\nBy default, launches an interactive multi-select prompt for the supported install targets when a TTY is available.\n\nIn non-interactive environments, installs to both supported skill directories.\n\nUse `--claude` and/or `--agents` to skip prompting and install to specific targets."
+        long_about = "Install the embedded dev-browser skill into agent skill directories.\n\nBy default, launches an interactive multi-select prompt for the supported install targets when a TTY is available.\n\nIn non-interactive environments, installs to all supported skill directories, including Codex, so upgrades replace stale skill copies.\n\nUse `--claude`, `--agents`, and/or `--codex` to skip prompting and install to specific targets."
     )]
     InstallSkill {
         #[arg(
@@ -183,6 +183,11 @@ enum Command {
             help = "Install the skill into ~/.agents/skills without prompting"
         )]
         agents: bool,
+        #[arg(
+            long,
+            help = "Install the skill into ~/.codex/skills without prompting"
+        )]
+        codex: bool,
     },
     #[command(
         about = "List all managed browser instances",
@@ -263,8 +268,12 @@ fn run() -> Result<i32, Box<dyn Error>> {
             install_daemon_runtime()?;
             Ok(0)
         }
-        Some(Command::InstallSkill { claude, agents }) => {
-            install_skill(*claude, *agents)?;
+        Some(Command::InstallSkill {
+            claude,
+            agents,
+            codex,
+        }) => {
+            install_skill(*claude, *agents, *codex)?;
             Ok(0)
         }
         Some(Command::Status) => {

--- a/cli/src/skill.rs
+++ b/cli/src/skill.rs
@@ -15,7 +15,7 @@ struct InstallTarget {
     root_relative_path: &'static str,
 }
 
-const INSTALL_TARGETS: [InstallTarget; 2] = [
+const INSTALL_TARGETS: [InstallTarget; 3] = [
     InstallTarget {
         prompt_label: "~/.claude/skills/dev-browser/",
         root_display: "~/.claude/skills",
@@ -27,6 +27,12 @@ const INSTALL_TARGETS: [InstallTarget; 2] = [
         root_display: "~/.agents/skills",
         file_display: "~/.agents/skills/dev-browser/SKILL.md",
         root_relative_path: ".agents/skills",
+    },
+    InstallTarget {
+        prompt_label: "~/.codex/skills/dev-browser/",
+        root_display: "~/.codex/skills",
+        file_display: "~/.codex/skills/dev-browser/SKILL.md",
+        root_relative_path: ".codex/skills",
     },
 ];
 
@@ -41,10 +47,15 @@ enum InstallTargetSelection {
     Selected(Vec<usize>),
 }
 
-pub fn install_skill(install_claude: bool, install_agents: bool) -> Result<(), Box<dyn Error>> {
+pub fn install_skill(
+    install_claude: bool,
+    install_agents: bool,
+    install_codex: bool,
+) -> Result<(), Box<dyn Error>> {
     let selections = match resolve_install_target_selection(
         install_claude,
         install_agents,
+        install_codex,
         interactive_terminal_available(),
     ) {
         InstallTargetSelection::Prompt => {
@@ -91,15 +102,19 @@ pub fn install_skill(install_claude: bool, install_agents: bool) -> Result<(), B
 fn resolve_install_target_selection(
     install_claude: bool,
     install_agents: bool,
+    install_codex: bool,
     interactive_terminal: bool,
 ) -> InstallTargetSelection {
-    if install_claude || install_agents {
+    if install_claude || install_agents || install_codex {
         let mut selections = Vec::new();
         if install_claude {
             selections.push(0);
         }
         if install_agents {
             selections.push(1);
+        }
+        if install_codex {
+            selections.push(2);
         }
 
         return InstallTargetSelection::Selected(selections);
@@ -225,32 +240,38 @@ mod tests {
 
     #[test]
     fn explicit_claude_flag_skips_prompt() {
-        let selection = resolve_install_target_selection(true, false, true);
+        let selection = resolve_install_target_selection(true, false, false, true);
         assert_selected(selection, &[0]);
     }
 
     #[test]
     fn explicit_agents_flag_skips_prompt() {
-        let selection = resolve_install_target_selection(false, true, true);
+        let selection = resolve_install_target_selection(false, true, false, true);
         assert_selected(selection, &[1]);
     }
 
     #[test]
-    fn explicit_flags_can_select_both_targets() {
-        let selection = resolve_install_target_selection(true, true, false);
-        assert_selected(selection, &[0, 1]);
+    fn explicit_codex_flag_skips_prompt() {
+        let selection = resolve_install_target_selection(false, false, true, true);
+        assert_selected(selection, &[2]);
+    }
+
+    #[test]
+    fn explicit_flags_can_select_all_targets() {
+        let selection = resolve_install_target_selection(true, true, true, false);
+        assert_selected(selection, &[0, 1, 2]);
     }
 
     #[test]
     fn interactive_terminal_without_flags_prompts() {
-        let selection = resolve_install_target_selection(false, false, true);
+        let selection = resolve_install_target_selection(false, false, false, true);
         assert!(matches!(selection, InstallTargetSelection::Prompt));
     }
 
     #[test]
-    fn non_interactive_without_flags_defaults_to_both_targets() {
-        let selection = resolve_install_target_selection(false, false, false);
-        assert_selected(selection, &[0, 1]);
+    fn non_interactive_without_flags_defaults_to_all_targets() {
+        let selection = resolve_install_target_selection(false, false, false, false);
+        assert_selected(selection, &[0, 1, 2]);
     }
 
     fn assert_selected(selection: InstallTargetSelection, expected: &[usize]) {

--- a/daemon/src/browser-manager-title-timeout.test.ts
+++ b/daemon/src/browser-manager-title-timeout.test.ts
@@ -10,9 +10,10 @@ type BrowserManagerInternals = {
   getPageTargetId: (context: BrowserContext, page: Page) => Promise<string | null>;
 };
 
-function createMockEntry(page: Page): BrowserEntry {
+function createMockEntry(pages: Page | Page[]): BrowserEntry {
+  const pageList = Array.isArray(pages) ? pages : [pages];
   const context = {
-    pages: () => [page],
+    pages: () => pageList,
   } as unknown as BrowserContext;
 
   const browser = {
@@ -63,6 +64,49 @@ describe("BrowserManager listPages title handling", () => {
         title: "",
         url: "chrome://blank",
       },
+    ]);
+  });
+
+  it("starts every title lookup concurrently and uses one timeout window", async () => {
+    vi.useFakeTimers();
+
+    const started: number[] = [];
+    const pages = [0, 1, 2].map(
+      (index) =>
+        ({
+          isClosed: () => false,
+          on: () => undefined,
+          title: () => {
+            started.push(index);
+            return new Promise<string>(() => {});
+          },
+          url: () => `chrome://page-${index}`,
+        }) as unknown as Page
+    );
+
+    const manager = new BrowserManager("/tmp/dev-browser-concurrent-title-timeout");
+    const internals = manager as unknown as BrowserManagerInternals;
+    internals.browsers.set(browserName, createMockEntry(pages));
+    vi.spyOn(internals, "getPageTargetId").mockImplementation(async (_context, page) => {
+      return `target-${pages.indexOf(page)}`;
+    });
+
+    let settled = false;
+    const pagesPromise = manager.listPages(browserName).finally(() => {
+      settled = true;
+    });
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(started).toEqual([0, 1, 2]);
+
+    await vi.advanceTimersByTimeAsync(1_499);
+    expect(settled).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(1);
+    await expect(pagesPromise).resolves.toEqual([
+      { id: "target-0", name: null, title: "", url: "chrome://page-0" },
+      { id: "target-1", name: null, title: "", url: "chrome://page-1" },
+      { id: "target-2", name: null, title: "", url: "chrome://page-2" },
     ]);
   });
 

--- a/daemon/src/browser-manager.ts
+++ b/daemon/src/browser-manager.ts
@@ -39,6 +39,11 @@ type BrowserManagerDependencies = {
   readFile: typeof readFile;
 };
 
+interface BrowserOperationOptions {
+  deadline?: number;
+  signal?: AbortSignal;
+}
+
 type DebuggerWebSocketLookupResult =
   | {
       status: "ok";
@@ -92,9 +97,13 @@ export class BrowserManager {
     options: {
       headless?: boolean;
       ignoreHTTPSErrors?: boolean;
+      deadline?: number;
+      signal?: AbortSignal;
     } = {}
   ): Promise<BrowserEntry> {
+    this.throwIfOperationAborted(options);
     await this.ensureBaseDir();
+    this.throwIfOperationAborted(options);
     const existing = this.browsers.get(name);
     const requestedHeadless = options.headless ?? existing?.headless ?? false;
     const requestedIgnoreHTTPSErrors =
@@ -115,11 +124,13 @@ export class BrowserManager {
       await this.stopBrowser(name);
     }
 
-    return this.launchBrowser(name, requestedHeadless, requestedIgnoreHTTPSErrors);
+    return this.launchBrowser(name, requestedHeadless, requestedIgnoreHTTPSErrors, options);
   }
 
-  async autoConnect(name: string): Promise<BrowserEntry> {
+  async autoConnect(name: string, options: BrowserOperationOptions = {}): Promise<BrowserEntry> {
+    this.throwIfOperationAborted(options);
     await this.ensureBaseDir();
+    this.throwIfOperationAborted(options);
 
     const existing = this.browsers.get(name);
     if (existing?.type === "connected" && existing.browser.isConnected()) {
@@ -141,21 +152,25 @@ export class BrowserManager {
       attemptedEndpoints.add(endpoint);
 
       try {
-        return await this.openConnectedBrowser(name, endpoint);
+        return await this.openConnectedBrowser(name, endpoint, options);
       } catch (error) {
+        this.throwIfOperationAborted(options);
         lastError = error;
         return null;
       }
     };
 
     const devToolsEndpoint = await this.readDevToolsActivePort();
+    this.throwIfOperationAborted(options);
     const devToolsBrowser = await tryEndpoint(devToolsEndpoint);
     if (devToolsBrowser) {
       return devToolsBrowser;
     }
 
     for (const port of DISCOVERY_PORTS) {
+      this.throwIfOperationAborted(options);
       const endpoint = await this.probePort(port);
+      this.throwIfOperationAborted(options);
       const connectedBrowser = await tryEndpoint(endpoint);
       if (connectedBrowser) {
         return connectedBrowser;
@@ -165,13 +180,20 @@ export class BrowserManager {
     throw new Error(this.buildAutoConnectError(lastError));
   }
 
-  async connectBrowser(name: string, endpoint: string): Promise<BrowserEntry> {
+  async connectBrowser(
+    name: string,
+    endpoint: string,
+    options: BrowserOperationOptions = {}
+  ): Promise<BrowserEntry> {
     if (endpoint === "auto") {
-      return this.autoConnect(name);
+      return this.autoConnect(name, options);
     }
 
+    this.throwIfOperationAborted(options);
     await this.ensureBaseDir();
+    this.throwIfOperationAborted(options);
     const resolvedEndpoint = await this.resolveEndpoint(endpoint);
+    this.throwIfOperationAborted(options);
 
     const existing = this.browsers.get(name);
     if (existing) {
@@ -187,7 +209,7 @@ export class BrowserManager {
       await this.stopBrowser(name);
     }
 
-    return this.openConnectedBrowser(name, resolvedEndpoint);
+    return this.openConnectedBrowser(name, resolvedEndpoint, options);
   }
 
   getBrowser(name: string): BrowserEntry | undefined {
@@ -234,34 +256,36 @@ export class BrowserManager {
 
     this.pruneClosedPages(entry);
     const namesByPage = this.getNamedPagesByPage(entry);
-    const summaries: BrowserPageSummary[] = [];
+    const summaries = await Promise.all(
+      this.getContextPages(entry).map(
+        async ({ context, page }): Promise<BrowserPageSummary | null> => {
+          const id = await this.getPageTargetId(context, page);
+          if (!id) {
+            return null;
+          }
 
-    for (const { context, page } of this.getContextPages(entry)) {
-      const id = await this.getPageTargetId(context, page);
-      if (!id) {
-        continue;
-      }
+          let title = "";
+          try {
+            title = await this.getPageTitle(page);
+          } catch (error) {
+            if (page.isClosed()) {
+              return null;
+            }
 
-      let title = "";
-      try {
-        title = await this.getPageTitle(page);
-      } catch (error) {
-        if (page.isClosed()) {
-          continue;
+            throw error;
+          }
+
+          return {
+            id,
+            url: page.url(),
+            title,
+            name: namesByPage.get(page) ?? null,
+          };
         }
+      )
+    );
 
-        throw error;
-      }
-
-      summaries.push({
-        id,
-        url: page.url(),
-        title,
-        name: namesByPage.get(page) ?? null,
-      });
-    }
-
-    return summaries;
+    return summaries.filter((summary): summary is BrowserPageSummary => summary !== null);
   }
 
   async closePage(browserName: string, pageName: string): Promise<void> {
@@ -349,11 +373,13 @@ export class BrowserManager {
   private async launchBrowser(
     name: string,
     headless: boolean,
-    ignoreHTTPSErrors: boolean
+    ignoreHTTPSErrors: boolean,
+    operation: BrowserOperationOptions = {}
   ): Promise<BrowserEntry> {
     const profileDir = path.join(this.baseDir, name, "chromium-profile");
     await this.dependencies.mkdir(profileDir, { recursive: true });
 
+    const timeout = this.remainingOperationTimeout(operation);
     const context = await this.dependencies.launchPersistentContext(profileDir, {
       headless,
       viewport: headless ? undefined : null,
@@ -361,8 +387,19 @@ export class BrowserManager {
       handleSIGINT: false,
       handleSIGTERM: false,
       handleSIGHUP: false,
+      ...(timeout === undefined ? {} : { timeout }),
     });
     const browser = context.browser();
+
+    try {
+      this.throwIfOperationAborted(operation);
+    } catch (error) {
+      await context.close().catch(() => undefined);
+      if (browser?.isConnected()) {
+        await browser.close().catch(() => undefined);
+      }
+      throw error;
+    }
 
     if (!browser) {
       await context.close();
@@ -385,8 +422,22 @@ export class BrowserManager {
     return entry;
   }
 
-  private async openConnectedBrowser(name: string, endpoint: string): Promise<BrowserEntry> {
-    const browser = await this.dependencies.connectOverCDP(endpoint);
+  private async openConnectedBrowser(
+    name: string,
+    endpoint: string,
+    operation: BrowserOperationOptions = {}
+  ): Promise<BrowserEntry> {
+    const timeout = this.remainingOperationTimeout(operation);
+    const browser =
+      timeout === undefined
+        ? await this.dependencies.connectOverCDP(endpoint)
+        : await this.dependencies.connectOverCDP(endpoint, { timeout });
+    try {
+      this.throwIfOperationAborted(operation);
+    } catch (error) {
+      await browser.close().catch(() => undefined);
+      throw error;
+    }
     const contexts = browser.contexts();
 
     // Enumerate existing tabs for connected browsers, but leave them unnamed so getPage(name)
@@ -426,6 +477,25 @@ export class BrowserManager {
         this.browsers.delete(entry.name);
       }
     });
+  }
+
+  private throwIfOperationAborted(options: BrowserOperationOptions): void {
+    if (options.signal?.aborted) {
+      throw options.signal.reason instanceof Error
+        ? options.signal.reason
+        : new Error(String(options.signal.reason));
+    }
+    if (options.deadline !== undefined && Date.now() >= options.deadline) {
+      throw new Error("Browser setup deadline exceeded");
+    }
+  }
+
+  private remainingOperationTimeout(options: BrowserOperationOptions): number | undefined {
+    this.throwIfOperationAborted(options);
+    if (options.deadline === undefined) {
+      return undefined;
+    }
+    return Math.max(1, options.deadline - Date.now());
   }
 
   private async closeLaunchedBrowser(entry: BrowserEntry): Promise<void> {

--- a/daemon/src/daemon.ts
+++ b/daemon/src/daemon.ts
@@ -3,6 +3,7 @@ import { mkdir, unlink, writeFile } from "node:fs/promises";
 import net from "node:net";
 import path from "node:path";
 import { BrowserManager } from "./browser-manager.js";
+import { executeRequest } from "./execute-request.js";
 import { formatError } from "./format-error.js";
 import { createKeyedLock, createMutex } from "./lock.js";
 import {
@@ -131,62 +132,46 @@ function createMessageQueue(socket: net.Socket) {
 }
 
 async function handleExecute(socket: net.Socket, request: ExecuteRequest): Promise<void> {
-  await withBrowserLock(request.browser, async () => {
-    if (request.connect === "auto") {
-      await manager.autoConnect(request.browser);
-    } else if (request.connect) {
-      await manager.connectBrowser(request.browser, request.connect);
-    } else {
-      await manager.ensureBrowser(request.browser, {
-        headless: request.headless,
-        ignoreHTTPSErrors: request.ignoreHTTPSErrors,
-      });
-    }
-
-    const output = createMessageQueue(socket);
-    const timeoutMs = request.timeoutMs ?? DEFAULT_SCRIPT_TIMEOUT_MS;
-
-    try {
-      await runScript(
-        request.script,
-        manager,
-        request.browser,
-        {
-          onStdout: (data) => {
-            void output.push({
-              id: request.id,
-              type: "stdout",
-              data,
-            });
-          },
-          onStderr: (data) => {
-            void output.push({
-              id: request.id,
-              type: "stderr",
-              data,
-            });
-          },
-        },
-        {
-          timeout: timeoutMs,
+  await executeRequest(
+    request,
+    request.timeoutMs ?? DEFAULT_SCRIPT_TIMEOUT_MS,
+    {
+      isOpen: () => !socket.destroyed && socket.writable && !socket.writableEnded,
+      onDisconnect: (listener) => {
+        const onDisconnect = () => listener();
+        socket.once("close", onDisconnect);
+        socket.once("error", onDisconnect);
+        return () => {
+          socket.off("close", onDisconnect);
+          socket.off("error", onDisconnect);
+        };
+      },
+      send: (message) => writeMessage(socket, message),
+    },
+    {
+      withBrowserLock,
+      prepareBrowser: async (currentRequest, context) => {
+        const operation = { deadline: context.deadline, signal: context.signal };
+        if (currentRequest.connect === "auto") {
+          await manager.autoConnect(currentRequest.browser, operation);
+        } else if (currentRequest.connect) {
+          await manager.connectBrowser(currentRequest.browser, currentRequest.connect, operation);
+        } else {
+          await manager.ensureBrowser(currentRequest.browser, {
+            headless: currentRequest.headless,
+            ignoreHTTPSErrors: currentRequest.ignoreHTTPSErrors,
+            ...operation,
+          });
         }
-      );
-
-      await output.drain();
-      await writeMessage(socket, {
-        id: request.id,
-        type: "complete",
-        success: true,
-      });
-    } catch (error) {
-      await output.drain().catch(() => undefined);
-      await writeMessage(socket, {
-        id: request.id,
-        type: "error",
-        message: formatError(error),
-      });
+      },
+      runScript: async (currentRequest, output, context) => {
+        await runScript(currentRequest.script, manager, currentRequest.browser, output, {
+          signal: context.signal,
+          timeout: Math.max(1, context.deadline - Date.now()),
+        });
+      },
     }
-  });
+  );
 }
 
 async function handleInstall(socket: net.Socket, request: { id: string }): Promise<void> {

--- a/daemon/src/execute-request.test.ts
+++ b/daemon/src/execute-request.test.ts
@@ -1,0 +1,254 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { executeRequest, type ExecuteRequestTransport } from "./execute-request.js";
+import { createKeyedLock } from "./lock.js";
+import type { ExecuteRequest, Response } from "./protocol.js";
+
+function deferred<T = void>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  const promise = new Promise<T>((innerResolve) => {
+    resolve = innerResolve;
+  });
+  return { promise, resolve };
+}
+
+class FakeTransport implements ExecuteRequestTransport {
+  readonly messages: Response[] = [];
+  readonly listeners = new Set<() => void>();
+  open = true;
+
+  isOpen(): boolean {
+    return this.open;
+  }
+
+  onDisconnect(listener: () => void): () => void {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  }
+
+  async send(message: Response): Promise<void> {
+    this.messages.push(message);
+  }
+
+  disconnect(): void {
+    this.open = false;
+    for (const listener of [...this.listeners]) {
+      listener();
+    }
+  }
+}
+
+function request(id: string, browser = "shared"): ExecuteRequest {
+  return {
+    id,
+    type: "execute",
+    browser,
+    script: "",
+  };
+}
+
+describe("executeRequest", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("expires in the browser queue and never starts later", async () => {
+    vi.useFakeTimers();
+    const withBrowserLock = createKeyedLock<string>();
+    const releaseFirst = deferred();
+    const firstStarted = deferred();
+    const first = withBrowserLock("shared", async () => {
+      firstStarted.resolve();
+      await releaseFirst.promise;
+    });
+    await firstStarted.promise;
+
+    const transport = new FakeTransport();
+    const prepareBrowser = vi.fn(async () => undefined);
+    const execution = executeRequest(request("queued"), 50, transport, {
+      withBrowserLock,
+      prepareBrowser,
+      runScript: vi.fn(async () => undefined),
+    });
+
+    await vi.advanceTimersByTimeAsync(50);
+    await execution;
+
+    expect(prepareBrowser).not.toHaveBeenCalled();
+    expect(transport.messages).toEqual([
+      {
+        id: "queued",
+        type: "error",
+        message: "Script timed out after 50ms and was terminated.",
+      },
+    ]);
+    expect(transport.listeners.size).toBe(0);
+    expect(vi.getTimerCount()).toBe(0);
+
+    releaseFirst.resolve();
+    await first;
+    await vi.advanceTimersByTimeAsync(0);
+    expect(prepareBrowser).not.toHaveBeenCalled();
+  });
+
+  it("holds the browser lock through disconnect cancellation before the next request", async () => {
+    const withBrowserLock = createKeyedLock<string>();
+    const firstTransport = new FakeTransport();
+    const secondTransport = new FakeTransport();
+    const firstRunning = deferred();
+    const stopStarted = deferred();
+    const allowStop = deferred();
+    const events: string[] = [];
+
+    const runScript = async (
+      current: ExecuteRequest,
+      _output: unknown,
+      { signal }: { signal: AbortSignal }
+    ) => {
+      if (current.id !== "first") {
+        events.push("second:run");
+        return;
+      }
+
+      events.push("first:run");
+      firstRunning.resolve();
+      await new Promise<void>((_resolve, reject) => {
+        signal.addEventListener(
+          "abort",
+          () => {
+            events.push("first:stop-start");
+            stopStarted.resolve();
+            void allowStop.promise.then(() => {
+              events.push("first:stop-end");
+              reject(signal.reason);
+            });
+          },
+          { once: true }
+        );
+      });
+    };
+
+    const dependencies = {
+      withBrowserLock,
+      prepareBrowser: async (current: ExecuteRequest) => {
+        events.push(`${current.id}:prepare`);
+      },
+      runScript,
+    };
+
+    const first = executeRequest(request("first"), 10_000, firstTransport, dependencies);
+    await firstRunning.promise;
+    firstTransport.disconnect();
+    await stopStarted.promise;
+
+    const second = executeRequest(request("second"), 10_000, secondTransport, dependencies);
+    await Promise.resolve();
+    expect(events).not.toContain("second:prepare");
+
+    allowStop.resolve();
+    await first;
+    await second;
+
+    expect(firstTransport.messages).toEqual([]);
+    expect(secondTransport.messages).toEqual([{ id: "second", type: "complete", success: true }]);
+    expect(events).toEqual([
+      "first:prepare",
+      "first:run",
+      "first:stop-start",
+      "first:stop-end",
+      "second:prepare",
+      "second:run",
+    ]);
+    expect(firstTransport.listeners.size).toBe(0);
+    expect(secondTransport.listeners.size).toBe(0);
+  });
+
+  it("suppresses output and duplicate terminal frames after the deadline", async () => {
+    vi.useFakeTimers();
+    const transport = new FakeTransport();
+    const withBrowserLock = createKeyedLock<string>();
+
+    const execution = executeRequest(request("running"), 25, transport, {
+      withBrowserLock,
+      prepareBrowser: async () => undefined,
+      runScript: async (_request, output, { signal }) => {
+        output.onStdout("before\n");
+        await new Promise<void>((_resolve, reject) => {
+          signal.addEventListener(
+            "abort",
+            () => {
+              output.onStdout("late\n");
+              output.onStderr("later\n");
+              reject(new Error("late inner failure"));
+            },
+            { once: true }
+          );
+        });
+      },
+    });
+
+    await vi.advanceTimersByTimeAsync(25);
+    await execution;
+
+    expect(transport.messages).toEqual([
+      { id: "running", type: "stdout", data: "before\n" },
+      {
+        id: "running",
+        type: "error",
+        message: "Script timed out after 25ms and was terminated.",
+      },
+    ]);
+    expect(transport.messages.filter((message) => message.type === "error")).toHaveLength(1);
+    expect(transport.messages.some((message) => message.type === "complete")).toBe(false);
+    expect(transport.listeners.size).toBe(0);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("preserves an inner error that wins before the hard deadline", async () => {
+    vi.useFakeTimers();
+    const transport = new FakeTransport();
+
+    await executeRequest(request("inner-error"), 1_000, transport, {
+      withBrowserLock: createKeyedLock<string>(),
+      prepareBrowser: async () => undefined,
+      runScript: async () => {
+        throw new Error("locator click failed: target closed");
+      },
+    });
+
+    expect(transport.messages).toHaveLength(1);
+    expect(transport.messages[0]).toEqual(
+      expect.objectContaining({
+        id: "inner-error",
+        type: "error",
+        message: expect.stringContaining("locator click failed: target closed"),
+      })
+    );
+    expect(transport.listeners.size).toBe(0);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("returns the deadline error instead of success when the timer callback is delayed", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(10_000);
+    const transport = new FakeTransport();
+
+    await executeRequest(request("boundary"), 100, transport, {
+      withBrowserLock: createKeyedLock<string>(),
+      prepareBrowser: async () => undefined,
+      runScript: async () => {
+        vi.setSystemTime(10_100);
+      },
+    });
+
+    expect(transport.messages).toEqual([
+      {
+        id: "boundary",
+        type: "error",
+        message: "Script timed out after 100ms and was terminated.",
+      },
+    ]);
+    expect(transport.listeners.size).toBe(0);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+});

--- a/daemon/src/execute-request.ts
+++ b/daemon/src/execute-request.ts
@@ -1,0 +1,225 @@
+import { formatError } from "./format-error.js";
+import type { ExecuteRequest, Response } from "./protocol.js";
+
+export interface ExecuteRequestTransport {
+  isOpen(): boolean;
+  onDisconnect(listener: () => void): () => void;
+  send(message: Response): Promise<void>;
+}
+
+interface ScriptOutput {
+  onStdout(data: string): void;
+  onStderr(data: string): void;
+}
+
+export interface ExecuteRequestDependencies {
+  prepareBrowser(
+    request: ExecuteRequest,
+    context: { deadline: number; signal: AbortSignal }
+  ): Promise<void>;
+  runScript(
+    request: ExecuteRequest,
+    output: ScriptOutput,
+    context: { deadline: number; signal: AbortSignal }
+  ): Promise<void>;
+  withBrowserLock<T>(
+    browser: string,
+    action: () => Promise<T>,
+    options: { signal: AbortSignal }
+  ): Promise<T>;
+}
+
+class RequestTimeoutError extends Error {
+  constructor(timeoutMs: number) {
+    super(`Script timed out after ${formatTimeoutDuration(timeoutMs)} and was terminated.`);
+    this.name = "ScriptTimeoutError";
+  }
+}
+
+class RequestDisconnectedError extends Error {
+  constructor() {
+    super("Client disconnected");
+    this.name = "RequestDisconnectedError";
+  }
+}
+
+function formatTimeoutDuration(timeoutMs: number): string {
+  if (timeoutMs % 1_000 === 0) {
+    return `${timeoutMs / 1_000}s`;
+  }
+
+  return `${timeoutMs}ms`;
+}
+
+function abortReason(signal: AbortSignal): Error {
+  return signal.reason instanceof Error ? signal.reason : new Error(String(signal.reason));
+}
+
+class RequestSession {
+  readonly deadline: number;
+  readonly signal: AbortSignal;
+
+  readonly #controller = new AbortController();
+  readonly #detachDisconnect: () => void;
+  readonly #request: ExecuteRequest;
+  readonly #timeout: ReturnType<typeof setTimeout>;
+  readonly #timeoutMs: number;
+  readonly #transport: ExecuteRequestTransport;
+
+  #active = true;
+  #messages = Promise.resolve();
+  #terminal = Promise.resolve();
+
+  constructor(request: ExecuteRequest, timeoutMs: number, transport: ExecuteRequestTransport) {
+    this.#request = request;
+    this.#timeoutMs = timeoutMs;
+    this.#transport = transport;
+    this.deadline = Date.now() + timeoutMs;
+    this.signal = this.#controller.signal;
+    this.#detachDisconnect = transport.onDisconnect(() => {
+      this.#disconnect();
+    });
+    this.#timeout = setTimeout(() => {
+      this.#finish(
+        {
+          id: request.id,
+          type: "error",
+          message: new RequestTimeoutError(timeoutMs).message,
+        },
+        new RequestTimeoutError(timeoutMs)
+      );
+    }, timeoutMs);
+    this.#timeout.unref?.();
+  }
+
+  stream(type: "stdout" | "stderr", data: string): void {
+    if (!this.#active) {
+      return;
+    }
+
+    this.#messages = this.#messages
+      .then(async () => {
+        if (this.#transport.isOpen()) {
+          await this.#transport.send({ id: this.#request.id, type, data });
+        }
+      })
+      .catch(() => undefined);
+  }
+
+  async complete(): Promise<void> {
+    this.#finish({ id: this.#request.id, type: "complete", success: true });
+    await this.#terminal;
+  }
+
+  async fail(error: unknown): Promise<void> {
+    this.#finish({ id: this.#request.id, type: "error", message: formatError(error) });
+    await this.#terminal;
+  }
+
+  throwIfAborted(): void {
+    if (this.signal.aborted) {
+      throw abortReason(this.signal);
+    }
+  }
+
+  throwIfAbortedOrExpired(): void {
+    this.throwIfAborted();
+    if (Date.now() < this.deadline) {
+      return;
+    }
+
+    const error = new RequestTimeoutError(this.#timeoutMs);
+    this.#finish(
+      {
+        id: this.#request.id,
+        type: "error",
+        message: error.message,
+      },
+      error
+    );
+    throw error;
+  }
+
+  async dispose(): Promise<void> {
+    clearTimeout(this.#timeout);
+    this.#detachDisconnect();
+    await this.#terminal;
+  }
+
+  #disconnect(): void {
+    if (!this.#active) {
+      return;
+    }
+
+    this.#active = false;
+    clearTimeout(this.#timeout);
+    this.#controller.abort(new RequestDisconnectedError());
+  }
+
+  #finish(message: Response, abortError?: Error): void {
+    if (!this.#active) {
+      return;
+    }
+
+    this.#active = false;
+    clearTimeout(this.#timeout);
+    if (abortError) {
+      this.#controller.abort(abortError);
+    }
+    this.#terminal = this.#messages
+      .then(async () => {
+        if (this.#transport.isOpen()) {
+          await this.#transport.send(message);
+        }
+      })
+      .catch(() => undefined);
+  }
+}
+
+export async function executeRequest(
+  request: ExecuteRequest,
+  timeoutMs: number,
+  transport: ExecuteRequestTransport,
+  dependencies: ExecuteRequestDependencies
+): Promise<void> {
+  const session = new RequestSession(request, timeoutMs, transport);
+
+  try {
+    await dependencies.withBrowserLock(
+      request.browser,
+      async () => {
+        session.throwIfAbortedOrExpired();
+        await dependencies.prepareBrowser(request, {
+          deadline: session.deadline,
+          signal: session.signal,
+        });
+        session.throwIfAbortedOrExpired();
+        await dependencies.runScript(
+          request,
+          {
+            onStdout: (data) => session.stream("stdout", data),
+            onStderr: (data) => session.stream("stderr", data),
+          },
+          {
+            deadline: session.deadline,
+            signal: session.signal,
+          }
+        );
+        session.throwIfAbortedOrExpired();
+      },
+      { signal: session.signal }
+    );
+
+    session.throwIfAbortedOrExpired();
+    await session.complete();
+  } catch (error) {
+    try {
+      session.throwIfAbortedOrExpired();
+    } catch {
+      // A timeout or disconnect already owns the terminal outcome.
+    }
+    await session.fail(error);
+  } finally {
+    await session.dispose();
+  }
+}

--- a/daemon/src/lock.ts
+++ b/daemon/src/lock.ts
@@ -1,26 +1,61 @@
 type AsyncAction<T> = () => Promise<T>;
 
+function abortReason(signal: AbortSignal): Error {
+  return signal.reason instanceof Error ? signal.reason : new Error(String(signal.reason));
+}
+
+async function waitForTurn(previous: Promise<void>, signal: AbortSignal): Promise<void> {
+  if (signal.aborted) {
+    throw abortReason(signal);
+  }
+
+  await new Promise<void>((resolve, reject) => {
+    const onAbort = () => {
+      signal.removeEventListener("abort", onAbort);
+      reject(abortReason(signal));
+    };
+
+    signal.addEventListener("abort", onAbort, { once: true });
+    previous.then(() => {
+      signal.removeEventListener("abort", onAbort);
+      resolve();
+    });
+  });
+}
+
 export function createKeyedLock<K>() {
   const locks = new Map<K, Promise<void>>();
 
-  return async function withLock<T>(key: K, action: AsyncAction<T>): Promise<T> {
-    const previous = locks.get(key) ?? Promise.resolve();
+  return async function withLock<T>(
+    key: K,
+    action: AsyncAction<T>,
+    options: { signal?: AbortSignal } = {}
+  ): Promise<T> {
+    const previous = (locks.get(key) ?? Promise.resolve()).catch(() => undefined);
     let release!: () => void;
     const current = new Promise<void>((resolve) => {
       release = resolve;
     });
-    const tail = previous.catch(() => undefined).then(() => current);
+    const tail = previous.then(() => current);
     locks.set(key, tail);
 
-    await previous.catch(() => undefined);
-
     try {
+      if (options.signal) {
+        await waitForTurn(previous, options.signal);
+      } else {
+        await previous;
+      }
+      if (options.signal?.aborted) {
+        throw abortReason(options.signal);
+      }
       return await action();
     } finally {
       release();
-      if (locks.get(key) === tail) {
-        locks.delete(key);
-      }
+      void tail.then(() => {
+        if (locks.get(key) === tail) {
+          locks.delete(key);
+        }
+      });
     }
   };
 }

--- a/daemon/src/sandbox/__tests__/auto-connect.test.ts
+++ b/daemon/src/sandbox/__tests__/auto-connect.test.ts
@@ -278,6 +278,29 @@ describe("BrowserManager auto-connect", () => {
     expect(relaunchedEntry.ignoreHTTPSErrors).toBe(true);
   });
 
+  it("closes a persistent context that returns after its request is aborted", async () => {
+    const controller = new AbortController();
+    const context = new MockContext();
+    const browser = new MockBrowser([context]);
+    context.setBrowser(browser);
+    const launchPersistentContext = vi.fn(async () => {
+      controller.abort(new Error("launch request disconnected"));
+      return context;
+    });
+    const { manager } = createManager({ launchPersistentContext });
+
+    await expect(
+      manager.ensureBrowser("late-launch", {
+        headless: true,
+        signal: controller.signal,
+      })
+    ).rejects.toThrow("launch request disconnected");
+
+    expect(context.closeCalls).toBe(1);
+    expect(browser.closeCalls).toBe(1);
+    expect(manager.getBrowser("late-launch")).toBeUndefined();
+  });
+
   it("parses DevToolsActivePort and returns the browser websocket endpoint", async () => {
     const homeDir = "/Users/tester";
     const devToolsPath = path.join(
@@ -495,6 +518,25 @@ describe("BrowserManager auto-connect", () => {
         type: "connected",
       },
     ]);
+  });
+
+  it("closes a CDP browser connection that returns after its request is aborted", async () => {
+    const controller = new AbortController();
+    const browser = new MockBrowser([new MockContext()]);
+    const connectOverCDP = vi.fn(async () => {
+      controller.abort(new Error("connect request disconnected"));
+      return browser;
+    });
+    const { manager } = createManager({ connectOverCDP });
+
+    await expect(
+      manager.connectBrowser("late-connect", "ws://127.0.0.1:9222/devtools/browser/late", {
+        signal: controller.signal,
+      })
+    ).rejects.toThrow("connect request disconnected");
+
+    expect(browser.closeCalls).toBe(1);
+    expect(manager.getBrowser("late-connect")).toBeUndefined();
   });
 
   it("getBrowser returns connected entries without relaunching them", async () => {

--- a/daemon/src/sandbox/__tests__/cua.test.ts
+++ b/daemon/src/sandbox/__tests__/cua.test.ts
@@ -374,7 +374,7 @@ describe.sequential("QuickJS page.cua toolset", () => {
     }, 180_000);
 
     it("clicks at exact coordinates with the left button by default", async () => {
-      const result = await harness.runJson<{ clicks: RecordedClick[] }>(
+      const result = await harness.runJson<{ clicks: RecordedClick[]; elapsed: number }>(
         withCuaPage(
           "cua-click",
           `
@@ -426,16 +426,19 @@ describe.sequential("QuickJS page.cua toolset", () => {
     }, 15_000);
 
     it("doubleClick clicks twice at the same point", async () => {
-      const result = await harness.runJson<{ clicks: RecordedClick[] }>(
+      const result = await harness.runJson<{ clicks: RecordedClick[]; elapsed: number }>(
         withCuaPage(
           "cua-double-click",
           `
+          const start = Date.now();
           await page.cua.doubleClick({ x: 350, y: 250 });
-          console.log(JSON.stringify({ clicks: await page.evaluate(() => window.clicks) }));
+          const elapsed = Date.now() - start;
+          console.log(JSON.stringify({ elapsed, clicks: await page.evaluate(() => window.clicks) }));
         `
         )
       );
 
+      expect(result.elapsed).toBeLessThan(900);
       expect(result.clicks).toHaveLength(2);
       expect(result.clicks.map((click) => click.detail)).toEqual([1, 2]);
       for (const click of result.clicks) {
@@ -868,32 +871,14 @@ describe.sequential("QuickJS page.cua toolset", () => {
       await manager.stopBrowser(browserName);
     }, 180_000);
 
-    it("waits for click-triggered navigation by default", async () => {
+    it("does not pay the navigation grace delay by default", async () => {
       const firstUrl = `${navigationServer.baseUrl}/cua/first`;
-      const result = await harness.runJson<{ url: string; title: string }>(`
+      const result = await harness.runJson<{ elapsed: number; url: string }>(`
         const page = await browser.getPage("cua-nav-default");
         await page.goto(${JSON.stringify(firstUrl)}, { waitUntil: "load" });
         const box = await page.locator("#nav").boundingBox();
-        await page.cua.click({ x: box.x + box.width / 2, y: box.y + box.height / 2 });
-        console.log(JSON.stringify({ url: page.url(), title: await page.title() }));
-      `);
-
-      expect(result.url).toBe(`${navigationServer.baseUrl}/cua/second`);
-      expect(result.title).toBe("Second Page");
-    }, 30_000);
-
-    it("skips the navigation wait with waitForNavigation: false", async () => {
-      const firstUrl = `${navigationServer.baseUrl}/cua/first`;
-      const result = await harness.runJson<{ elapsed: number; url: string }>(`
-        const page = await browser.getPage("cua-nav-escape");
-        await page.goto(${JSON.stringify(firstUrl)}, { waitUntil: "load" });
-        const box = await page.locator("#nav").boundingBox();
         const start = Date.now();
-        await page.cua.click({
-          x: box.x + box.width / 2,
-          y: box.y + box.height / 2,
-          waitForNavigation: false,
-        });
+        await page.cua.click({ x: box.x + box.width / 2, y: box.y + box.height / 2 });
         const elapsed = Date.now() - start;
         await page.waitForURL("**/cua/second");
         console.log(JSON.stringify({ elapsed, url: page.url() }));
@@ -901,6 +886,24 @@ describe.sequential("QuickJS page.cua toolset", () => {
 
       expect(result.elapsed).toBeLessThan(900);
       expect(result.url).toBe(`${navigationServer.baseUrl}/cua/second`);
+    }, 30_000);
+
+    it("settles main-frame navigation when explicitly requested", async () => {
+      const firstUrl = `${navigationServer.baseUrl}/cua/first`;
+      const result = await harness.runJson<{ title: string; url: string }>(`
+        const page = await browser.getPage("cua-nav-explicit");
+        await page.goto(${JSON.stringify(firstUrl)}, { waitUntil: "load" });
+        const box = await page.locator("#nav").boundingBox();
+        await page.cua.click({
+          x: box.x + box.width / 2,
+          y: box.y + box.height / 2,
+          waitForNavigation: true,
+        });
+        console.log(JSON.stringify({ title: await page.title(), url: page.url() }));
+      `);
+
+      expect(result.url).toBe(`${navigationServer.baseUrl}/cua/second`);
+      expect(result.title).toBe("Second Page");
     }, 30_000);
 
     it("ignores child-frame navigations via the main-frame predicate", async () => {
@@ -914,7 +917,11 @@ describe.sequential("QuickJS page.cua toolset", () => {
         await page.goto(${JSON.stringify(hostUrl)}, { waitUntil: "load" });
         const box = await page.locator("#swap").boundingBox();
         const start = Date.now();
-        await page.cua.click({ x: box.x + box.width / 2, y: box.y + box.height / 2 });
+        await page.cua.click({
+          x: box.x + box.width / 2,
+          y: box.y + box.height / 2,
+          waitForNavigation: true,
+        });
         const elapsed = Date.now() - start;
         console.log(JSON.stringify({
           elapsed,

--- a/daemon/src/sandbox/__tests__/dom-cua.test.ts
+++ b/daemon/src/sandbox/__tests__/dom-cua.test.ts
@@ -556,15 +556,19 @@ describe.sequential("QuickJS page.domCua toolset", () => {
       const firstUrl = `${server.baseUrl}/dom/first`;
       const result = await harness.runJson<{
         clicks: Array<{ target: string; x: number; y: number }>;
+        elapsed: number;
       }>(`
         ${ID_HELPERS}
         const page = await browser.getPage("dom-cua-act-click");
         await page.goto(${JSON.stringify(firstUrl)}, { waitUntil: "load" });
         const snapshot = await page.domCua.getVisibleDom();
-        await page.domCua.click({ nodeId: idFor(snapshot, ">Two<"), waitForNavigation: false });
-        console.log(JSON.stringify({ clicks: await page.evaluate(() => window.clicks) }));
+        const start = Date.now();
+        await page.domCua.click({ nodeId: idFor(snapshot, ">Two<") });
+        const elapsed = Date.now() - start;
+        console.log(JSON.stringify({ elapsed, clicks: await page.evaluate(() => window.clicks) }));
       `);
 
+      expect(result.elapsed).toBeLessThan(900);
       expect(result.clicks).toEqual([{ target: "two", x: 80, y: 86 }]);
     }, 30_000);
 
@@ -609,15 +613,19 @@ describe.sequential("QuickJS page.domCua toolset", () => {
       const firstUrl = `${server.baseUrl}/dom/first`;
       const result = await harness.runJson<{
         clicks: Array<{ target: string; x: number; y: number }>;
+        elapsed: number;
       }>(`
         ${ID_HELPERS}
         const page = await browser.getPage("dom-cua-act-double");
         await page.goto(${JSON.stringify(firstUrl)}, { waitUntil: "load" });
         const snapshot = await page.domCua.getVisibleDom();
+        const start = Date.now();
         await page.domCua.doubleClick({ nodeId: idFor(snapshot, ">One<") });
-        console.log(JSON.stringify({ clicks: await page.evaluate(() => window.clicks) }));
+        const elapsed = Date.now() - start;
+        console.log(JSON.stringify({ elapsed, clicks: await page.evaluate(() => window.clicks) }));
       `);
 
+      expect(result.elapsed).toBeLessThan(900);
       expect(result.clicks).toHaveLength(2);
       for (const click of result.clicks) {
         expect(click).toEqual({ target: "one", x: 80, y: 36 });

--- a/daemon/src/sandbox/__tests__/playwright-api.test.ts
+++ b/daemon/src/sandbox/__tests__/playwright-api.test.ts
@@ -739,6 +739,70 @@ describe.sequential("QuickJS Playwright Page API coverage", () => {
       expect(result.full).toContain('heading "Hello World"');
       expect(result.full).toContain('button "Submit"');
     });
+
+    it("uses refs from snapshotForAI() as injection-safe locators", async () => {
+      const result = await harness.runJson<{
+        clicked: string;
+        invalidRefError: string;
+        ref: string;
+      }>(
+        withTestPage(
+          "snapshot-ref",
+          `
+          const snapshot = await page.snapshotForAI({ timeout: 5000 });
+          const submitLine = snapshot.full
+            .split("\\n")
+            .find((line) => line.includes('button "Submit"'));
+          const ref = submitLine?.match(/ref=((?:f\\d+)?e\\d+)/)?.[1];
+          if (!ref) throw new Error("Submit snapshot ref not found");
+
+          await page.getByRef(ref).click({ timeout: 5000 });
+
+          let invalidRefError = "";
+          try {
+            page.getByRef('e1 >> button');
+          } catch (error) {
+            invalidRefError = error.message;
+          }
+
+          console.log(JSON.stringify({
+            clicked: await page.locator("#result").textContent(),
+            invalidRefError,
+            ref,
+          }));
+        `
+        )
+      );
+
+      expect(result.ref).toMatch(/^(?:f\d+)?e\d+$/);
+      expect(result.clicked).toBe("clicked::red");
+      expect(result.invalidRefError).toContain("Invalid snapshot ref");
+    });
+
+    it("uses iframe refs from snapshotForAI()", async () => {
+      const result = await harness.runJson<{ clicked: string; ref: string }>(`
+        const page = await browser.getPage("snapshot-iframe-ref");
+        await page.setContent(
+          '<iframe srcdoc="<button id=inside onclick=&quot;this.dataset.clicked=1&quot;>Inside</button>"></iframe>',
+          { waitUntil: "load" },
+        );
+        const snapshot = await page.snapshotForAI({ timeout: 5000 });
+        const insideLine = snapshot.full
+          .split("\\n")
+          .find((line) => line.includes('button "Inside"'));
+        const ref = insideLine?.match(/ref=(f\\d+e\\d+)/)?.[1];
+        if (!ref) throw new Error("Iframe snapshot ref not found");
+        await page.getByRef(ref).click({ timeout: 5000 });
+        const child = page.frames().find((frame) => frame !== page.mainFrame());
+        console.log(JSON.stringify({
+          clicked: await child.locator("#inside").getAttribute("data-clicked"),
+          ref,
+        }));
+      `);
+
+      expect(result.ref).toMatch(/^f\d+e\d+$/);
+      expect(result.clicked).toBe("1");
+    });
   });
 
   describe.sequential("screenshots and input devices", () => {

--- a/daemon/src/sandbox/__tests__/sandbox-integration.test.ts
+++ b/daemon/src/sandbox/__tests__/sandbox-integration.test.ts
@@ -188,6 +188,66 @@ describe.sequential("QuickJS sandbox integration", () => {
     ).rejects.toThrow(/timed out|terminated|interrupted/i);
   }, 120_000);
 
+  it("stops pending Playwright operations on abort before reusing the browser", async () => {
+    const controller = new AbortController();
+    let announceReady!: () => void;
+    const ready = new Promise<void>((resolve) => {
+      announceReady = resolve;
+    });
+    const firstOutput = createOutput();
+    const onStdout = firstOutput.sink.onStdout;
+    firstOutput.sink.onStdout = (data) => {
+      onStdout(data);
+      if (data.includes("waiting")) announceReady();
+    };
+
+    const blocked = runScript(
+      `
+        const page = await browser.getPage("abort-reuse");
+        await page.setContent("<button id='ok'>Ready</button>");
+        console.log("waiting");
+        await page.locator("#never").click({ timeout: 60000 });
+        console.log("late");
+      `,
+      manager,
+      "default",
+      firstOutput.sink,
+      { signal: controller.signal, timeout: 60_000 }
+    );
+    const blockedOutcome = blocked.then(
+      () => null,
+      (error: unknown) => error
+    );
+
+    await ready;
+    const abortStarted = Date.now();
+    controller.abort(new Error("client disconnected"));
+    const blockedError = await Promise.race([
+      blockedOutcome,
+      new Promise((_, reject) =>
+        setTimeout(() => reject(new Error("sandbox abort did not settle")), 2_000)
+      ),
+    ]);
+    expect(blockedError).toBeInstanceOf(Error);
+    expect((blockedError as Error).message).toContain("client disconnected");
+    expect(Date.now() - abortStarted).toBeLessThan(2_000);
+    expect(firstOutput.stdout.join("")).not.toContain("late");
+
+    const nextOutput = createOutput();
+    await runScript(
+      `
+        const page = await browser.getPage("abort-reuse");
+        await page.locator("#ok").click({ timeout: 5000 });
+        console.log(await page.locator("#ok").textContent());
+      `,
+      manager,
+      "default",
+      nextOutput.sink,
+      { timeout: 10_000 }
+    );
+    expect(nextOutput.stdout.join("")).toContain("Ready");
+  }, 30_000);
+
   it("routes console output to stdout", async () => {
     const output = createOutput();
 

--- a/daemon/src/sandbox/forked-client/src/client/cua.ts
+++ b/daemon/src/sandbox/forked-client/src/client/cua.ts
@@ -38,18 +38,14 @@ export class Cua {
     this.#page = page;
   }
 
-  /**
-   * Click at viewport coordinates. By default waits for a click-triggered
-   * navigation (a ~1s grace period is paid on every non-navigating click);
-   * pass `waitForNavigation: false` to skip the wait in tight loops.
-   */
+  /** Click at viewport coordinates. Opt into navigation settling when needed. */
   async click({
     x,
     y,
     button = "left",
     clickCount = 1,
     modifiers = [],
-    waitForNavigation = true,
+    waitForNavigation = false,
   }: {
     x: number;
     y: number;
@@ -69,12 +65,14 @@ export class Cua {
     x,
     y,
     modifiers = [],
+    waitForNavigation = false,
   }: {
     x: number;
     y: number;
     modifiers?: string[];
+    waitForNavigation?: boolean;
   }): Promise<void> {
-    await this.click({ x, y, clickCount: 2, modifiers });
+    await this.click({ x, y, clickCount: 2, modifiers, waitForNavigation });
   }
 
   async drag({

--- a/daemon/src/sandbox/forked-client/src/client/domCua.ts
+++ b/daemon/src/sandbox/forked-client/src/client/domCua.ts
@@ -109,7 +109,7 @@ export class DomCua {
     nodeId,
     button = "left",
     modifiers = [],
-    waitForNavigation = true,
+    waitForNavigation = false,
   }: {
     nodeId: number | string;
     button?: "left" | "middle" | "right";
@@ -120,9 +120,15 @@ export class DomCua {
     await this.#page.cua.click({ x, y, button, modifiers, waitForNavigation });
   }
 
-  async doubleClick({ nodeId }: { nodeId: number | string }): Promise<void> {
+  async doubleClick({
+    nodeId,
+    waitForNavigation = false,
+  }: {
+    nodeId: number | string;
+    waitForNavigation?: boolean;
+  }): Promise<void> {
     const { x, y } = await this.#resolveNodeCenter(nodeId);
-    await this.#page.cua.click({ x, y, clickCount: 2 });
+    await this.#page.cua.click({ x, y, clickCount: 2, waitForNavigation });
   }
 
   async scroll({

--- a/daemon/src/sandbox/forked-client/src/client/page.ts
+++ b/daemon/src/sandbox/forked-client/src/client/page.ts
@@ -917,6 +917,12 @@ export class Page extends ChannelOwner<channels.PageChannel> implements api.Page
     return this.mainFrame().locator(selector, options);
   }
 
+  getByRef(ref: string): Locator {
+    if (!/^(?:f\d+)?e\d+$/.test(ref))
+      throw new Error(`Invalid snapshot ref "${ref}" — expected e<number> or f<number>e<number>`);
+    return this.locator("aria-ref=" + ref);
+  }
+
   getByTestId(testId: string | RegExp): Locator {
     return this.mainFrame().getByTestId(testId);
   }

--- a/daemon/src/sandbox/host-bridge.ts
+++ b/daemon/src/sandbox/host-bridge.ts
@@ -55,6 +55,21 @@ export class HostBridge {
     await this.dispatcherConnection.dispatch(JSON.parse(json) as Record<string, unknown>);
   }
 
+  async stopPendingOperations(error: Error): Promise<void> {
+    const dispatchers = this.dispatcherConnection._dispatcherByGuid;
+    if (!dispatchers) {
+      await this.rootDispatcher.stopPendingOperations(error);
+      return;
+    }
+
+    const controllers = new Set(
+      [...new Set(dispatchers.values())].flatMap((dispatcher) => [
+        ...(dispatcher._activeProgressControllers ?? []),
+      ])
+    );
+    await Promise.all([...controllers].map((controller) => controller.abort(error)));
+  }
+
   async dispose(): Promise<void> {
     if (this.disposed) {
       return;
@@ -63,10 +78,22 @@ export class HostBridge {
     this.disposed = true;
     this.dispatcherConnection.onmessage = () => {};
 
+    let cleanupError: unknown;
+    try {
+      await this.stopPendingOperations(new Error("Sandbox bridge disposed"));
+    } catch (error) {
+      cleanupError = error;
+    }
     try {
       await this.playwrightDispatcher?.cleanup();
+    } catch (error) {
+      cleanupError ??= error;
     } finally {
       this.rootDispatcher._dispose();
+    }
+
+    if (cleanupError) {
+      throw cleanupError;
     }
   }
 }

--- a/daemon/src/sandbox/playwright-internals.ts
+++ b/daemon/src/sandbox/playwright-internals.ts
@@ -23,12 +23,19 @@ export interface ClientConnectionLike {
 }
 
 export interface DispatcherConnectionLike {
+  _dispatcherByGuid?: Map<string, RootDispatcherLike>;
   onmessage: (message: WireMessage) => void;
   dispatch(message: WireMessage): Promise<void>;
 }
 
 export interface RootDispatcherLike {
+  _activeProgressControllers?: Set<ProgressControllerLike>;
   _dispose(): void;
+  stopPendingOperations(error: Error): Promise<void>;
+}
+
+export interface ProgressControllerLike {
+  abort(error: Error): Promise<void>;
 }
 
 export interface PlaywrightDispatcherLike {

--- a/daemon/src/sandbox/quickjs-sandbox.ts
+++ b/daemon/src/sandbox/quickjs-sandbox.ts
@@ -179,10 +179,13 @@ interface QuickJSSandboxOptions {
 export class QuickJSSandbox {
   readonly #options: QuickJSSandboxOptions;
   readonly #anonymousPages = new Set<Page>();
+  readonly #abortWakeup: Promise<void>;
   readonly #pendingHostOperations = new Set<Promise<void>>();
   readonly #transportInbox: string[] = [];
 
   #asyncError?: Error;
+  #abortError?: Error;
+  #resolveAbortWakeup!: () => void;
   #host?: QuickJSHost;
   #hostBridge?: HostBridge;
   #flushPromise?: Promise<void>;
@@ -191,16 +194,21 @@ export class QuickJSSandbox {
 
   constructor(options: QuickJSSandboxOptions) {
     this.#options = options;
+    this.#abortWakeup = new Promise<void>((resolve) => {
+      this.#resolveAbortWakeup = resolve;
+    });
   }
 
   async initialize(): Promise<void> {
     this.#assertAlive();
+    this.#throwIfAborted();
     if (this.#initialized) {
       return;
     }
 
     try {
       await ensureDevBrowserTempDir();
+      this.#throwIfAborted();
 
       this.#host = await QuickJSHost.create({
         memoryLimitBytes: this.#options.memoryLimitBytes ?? DEFAULT_MEMORY_LIMIT_BYTES,
@@ -222,6 +230,7 @@ export class QuickJSSandbox {
           this.#handleTransportSend(message);
         },
       });
+      this.#throwIfAborted();
 
       this.#host.executeScriptSync(
         `
@@ -354,6 +363,7 @@ export class QuickJSSandbox {
       );
 
       const bundleCode = await getSandboxClientBundleCode();
+      this.#throwIfAborted();
       const bundleFactorySource = JSON.stringify(`${bundleCode}\nreturn __PlaywrightClient;`);
       this.#host.executeScriptSync(
         `
@@ -380,6 +390,7 @@ export class QuickJSSandbox {
         sharedBrowser: true,
         denyLaunch: true,
       });
+      this.#throwIfAborted();
 
       await this.#host.executeScript(
         `
@@ -531,8 +542,10 @@ export class QuickJSSandbox {
           filename: "sandbox-init.js",
         }
       );
+      this.#throwIfAborted();
 
       await this.#flushTransportQueue();
+      this.#throwIfAborted();
       this.#throwIfAsyncError();
       this.#initialized = true;
     } catch (error) {
@@ -543,6 +556,7 @@ export class QuickJSSandbox {
 
   async executeScript(script: string): Promise<void> {
     this.#assertInitialized();
+    this.#throwIfAborted();
     let executionError: unknown;
 
     try {
@@ -554,6 +568,7 @@ export class QuickJSSandbox {
           filename: "user-script.js",
         }
       );
+      this.#throwIfAborted();
 
       await this.#flushTransportQueue();
       this.#throwIfAsyncError();
@@ -577,6 +592,12 @@ export class QuickJSSandbox {
       return;
     }
 
+    try {
+      await this.stopPendingOperations(new Error("QuickJS sandbox disposed"));
+    } catch {
+      // Best effort cleanup during sandbox teardown.
+    }
+
     this.#disposed = true;
 
     await this.#cleanupAnonymousPages({
@@ -596,6 +617,18 @@ export class QuickJSSandbox {
       this.#host = undefined;
       this.#flushPromise = undefined;
     }
+  }
+
+  async abort(error: Error): Promise<void> {
+    if (!this.#abortError) {
+      this.#abortError = error;
+      this.#resolveAbortWakeup();
+    }
+    await this.stopPendingOperations(this.#abortError);
+  }
+
+  async stopPendingOperations(error: Error): Promise<void> {
+    await this.#hostBridge?.stopPendingOperations(error);
   }
 
   #routeConsole(level: QuickJSConsoleLevel, args: unknown[]): void {
@@ -627,17 +660,21 @@ export class QuickJSSandbox {
   }
 
   async #drainAsyncOps(): Promise<void> {
+    this.#throwIfAborted();
     this.#throwIfAsyncError();
     await this.#flushTransportQueue();
+    this.#throwIfAborted();
     this.#throwIfAsyncError();
 
     if (this.#pendingHostOperations.size === 0) {
       return;
     }
 
-    await Promise.race(this.#pendingHostOperations);
+    await Promise.race([Promise.race(this.#pendingHostOperations), this.#abortWakeup]);
+    this.#throwIfAborted();
     this.#throwIfAsyncError();
     await this.#flushTransportQueue();
+    this.#throwIfAborted();
     this.#throwIfAsyncError();
   }
 
@@ -737,6 +774,12 @@ export class QuickJSSandbox {
   #throwIfAsyncError(): void {
     if (this.#asyncError) {
       throw this.#asyncError;
+    }
+  }
+
+  #throwIfAborted(): void {
+    if (this.#abortError) {
+      throw this.#abortError;
     }
   }
 

--- a/daemon/src/sandbox/script-runner-quickjs.test.ts
+++ b/daemon/src/sandbox/script-runner-quickjs.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { finalizeSandbox } from "./script-runner-quickjs.js";
+
+describe("finalizeSandbox", () => {
+  it("always disposes the sandbox when pending-operation cancellation rejects", async () => {
+    const dispose = vi.fn(async () => undefined);
+    const abortError = new Error("stopPendingOperations failed");
+
+    await expect(finalizeSandbox({ dispose }, Promise.reject(abortError))).rejects.toBe(abortError);
+
+    expect(dispose).toHaveBeenCalledOnce();
+  });
+});

--- a/daemon/src/sandbox/script-runner-quickjs.ts
+++ b/daemon/src/sandbox/script-runner-quickjs.ts
@@ -6,12 +6,37 @@ interface ScriptOutput {
   onStderr: (data: string) => void;
 }
 
+export async function finalizeSandbox(
+  sandbox: Pick<QuickJSSandbox, "dispose">,
+  abortPromise: Promise<void>
+): Promise<void> {
+  let finalizationError: unknown;
+  try {
+    await abortPromise;
+  } catch (error) {
+    finalizationError = error;
+  }
+
+  try {
+    await sandbox.dispose();
+  } catch (error) {
+    finalizationError ??= error;
+  }
+
+  if (finalizationError instanceof Error) {
+    throw finalizationError;
+  }
+  if (finalizationError !== undefined) {
+    throw new Error(String(finalizationError));
+  }
+}
+
 export async function runScript(
   script: string,
   manager: BrowserManager,
   browserName: string,
   output: ScriptOutput,
-  options: { timeout?: number; memoryLimitBytes?: number } = {}
+  options: { timeout?: number; memoryLimitBytes?: number; signal?: AbortSignal } = {}
 ): Promise<void> {
   const sandbox = new QuickJSSandbox({
     manager,
@@ -22,10 +47,25 @@ export async function runScript(
     timeoutMs: options.timeout,
   });
 
+  let abortPromise = Promise.resolve();
+  const onAbort = () => {
+    const reason =
+      options.signal?.reason instanceof Error
+        ? options.signal.reason
+        : new Error(String(options.signal?.reason ?? "Script aborted"));
+    abortPromise = sandbox.abort(reason);
+  };
+  options.signal?.addEventListener("abort", onAbort, { once: true });
+
   try {
+    if (options.signal?.aborted) {
+      onAbort();
+      throw options.signal.reason;
+    }
     await sandbox.initialize();
     await sandbox.executeScript(`(async () => {\n${script}\n})()`);
   } finally {
-    await sandbox.dispose();
+    options.signal?.removeEventListener("abort", onAbort);
+    await finalizeSandbox(sandbox, abortPromise);
   }
 }


### PR DESCRIPTION
## Summary

- enforce one absolute execute-request lifetime across browser-lock queueing, browser setup, sandbox initialization, script execution, and teardown
- cancel on deadline or socket disconnect, suppress late output and duplicate terminal frames, and await each active Playwright progress controller before lock release
- keep cancellation scoped to the per-script bridge so existing named pages and externally connected browsers survive
- make page-title discovery concurrent, add injection-safe snapshot refs including iframe refs, and remove default CUA navigation grace latency
- update the agent guide and add first-class Codex skill installation

## Measured behavior

- Three non-settling page titles previously consumed three serial 1500 ms windows, or 4500 ms total. The fake-timer regression now starts all three title calls together and returns all summaries at exactly one 1500 ms window.
- Non-navigation CUA actions previously paid roughly 1 second of grace on every click. Focused sandbox timings now assert default CUA click, CUA doubleClick, DOM-CUA click, and DOM-CUA doubleClick complete in under 900 ms. Explicit `waitForNavigation: true` still settles the expected main-frame navigation.
- A queued request now expires at its absolute 50 ms test deadline and never starts after the prior lock holder exits.
- A running missing-element Playwright action now aborts within the focused test bound of 2 seconds, emits no late output, and the next request reuses the same named page and existing element without relaunch or content reset.
- Boundary coverage advances the clock to the exact hard deadline without running the timer callback and confirms timeout wins over success.

## Validation

- `cd daemon && pnpm exec tsc --noEmit`
- `cd daemon && pnpm vitest run` — 19 files, 145 tests passed
- focused cancellation, title concurrency, snapshot ref, iframe ref, CUA, DOM-CUA, browser late-return cleanup, and finalization regressions
- `cd daemon && pnpm format:check`
- `cd daemon && pnpm bundle`
- `cd daemon && pnpm bundle:sandbox-client`
- `cd cli && cargo fmt --check`
- `cd cli && cargo build`
- `cd cli && cargo test` — 6 tests passed
- `git diff --check`

## Compatibility notes

- Playwright remains the browser engine; no Puppeteer migration.
- Existing selectors and role locators remain available. `page.getByRef()` only accepts `eN` or `fNeN`, preventing selector injection.
- Named-browser locking remains exclusive. Cancellation does not release the lock until active Playwright controllers stop and cleanup completes.
- The timeout flag now covers total request lifetime, including queue wait and setup, rather than only guest script execution.
- `Cua.click`, `Cua.doubleClick`, `DomCua.click`, and `DomCua.doubleClick` now default `waitForNavigation` to false. Callers can preserve settling with explicit true or pair known navigation with `Promise.all([page.waitForURL(...), click()])`.
- Noninteractive `install-skill` now updates Claude, Agents, and Codex targets. Explicit flags remain available for selecting only desired targets.

## Intentionally deferred

- snapshot depth protocol mismatch
- target-id caching
- daemon/client version handshake
- optional CLI read watchdog

This PR is intentionally left unmerged.
