### PR TITLE
Fix --browser path traversal; make --timeout govern per-action timeouts

### DIFF
--- a/daemon/src/browser-manager-name-validation.test.ts
+++ b/daemon/src/browser-manager-name-validation.test.ts
@@ -1,0 +1,35 @@
+import os from "node:os";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { BrowserManager } from "./browser-manager.js";
+
+// Regression test for the --browser path-traversal fix. A browser name becomes a
+// directory segment in the on-disk profile path, so a name containing path
+// separators or ".." must be rejected before it reaches the filesystem — never
+// launching a browser or creating a directory outside baseDir.
+describe("BrowserManager --browser name validation", () => {
+  const manager = new BrowserManager(path.join(os.tmpdir(), "dev-browser-name-validation"));
+
+  const unsafe = ["../evil", "..\\evil", "a/b", "a\\b", "..", "foo/../bar", "", "/abs"];
+  for (const name of unsafe) {
+    it(`rejects unsafe --browser name ${JSON.stringify(name)} without launching`, async () => {
+      await expect(manager.ensureBrowser(name, { headless: true })).rejects.toThrow(
+        /Invalid --browser name/
+      );
+      await expect(
+        manager.connectBrowser(name, "http://127.0.0.1:59999", {})
+      ).rejects.toThrow(/Invalid --browser name/);
+    });
+  }
+
+  it("accepts ordinary names (validation passes; connection failure is unrelated)", async () => {
+    // A safe name must NOT be rejected by the validator. It will still fail to
+    // connect to a dead endpoint — but with a connection error, not the
+    // "Invalid --browser name" guard.
+    await expect(
+      manager.connectBrowser("agent-3", "http://127.0.0.1:59999", {})
+    ).rejects.not.toThrow(/Invalid --browser name/);
+  });
+});

--- a/daemon/src/browser-manager-timeout-propagation.test.ts
+++ b/daemon/src/browser-manager-timeout-propagation.test.ts
@@ -1,0 +1,48 @@
+import os from "node:os";
+import path from "node:path";
+
+import { describe, expect, it, vi } from "vitest";
+
+import { BrowserManager } from "./browser-manager.js";
+
+// Regression test for P0-1: the script-level --timeout budget must propagate to
+// the Playwright context's per-action default timeout. Without this, a script
+// given `--timeout 90` still had every goto/click/screenshot capped at
+// Playwright's fixed 30s default — the field's costliest timeout confusion.
+describe("BrowserManager.setDefaultTimeouts", () => {
+  function makeManagerWithFakeContext() {
+    const setDefaultTimeout = vi.fn();
+    const setDefaultNavigationTimeout = vi.fn();
+    const fakeContext = {
+      setDefaultTimeout,
+      setDefaultNavigationTimeout,
+      browser: () => ({ isConnected: () => true, on: () => undefined }),
+      on: () => undefined,
+      pages: () => [],
+    };
+    const manager = new BrowserManager(
+      path.join(os.tmpdir(), "dev-browser-timeout-propagation"),
+      {
+        launchPersistentContext: vi.fn(async () => fakeContext) as never,
+      }
+    );
+    return { manager, setDefaultTimeout, setDefaultNavigationTimeout };
+  }
+
+  it("applies the given budget to both the action and navigation default timeouts", async () => {
+    const { manager, setDefaultTimeout, setDefaultNavigationTimeout } =
+      makeManagerWithFakeContext();
+    await manager.ensureBrowser("t", { headless: true });
+
+    manager.setDefaultTimeouts("t", 90_000);
+
+    expect(setDefaultTimeout).toHaveBeenCalledWith(90_000);
+    expect(setDefaultNavigationTimeout).toHaveBeenCalledWith(90_000);
+  });
+
+  it("is a safe no-op when the browser is not running", () => {
+    const { manager, setDefaultTimeout } = makeManagerWithFakeContext();
+    expect(() => manager.setDefaultTimeouts("never-launched", 5_000)).not.toThrow();
+    expect(setDefaultTimeout).not.toHaveBeenCalled();
+  });
+});

--- a/daemon/src/browser-manager.ts
+++ b/daemon/src/browser-manager.ts
@@ -264,6 +264,23 @@ export class BrowserManager {
     return entry.context.newPage();
   }
 
+  /**
+   * Apply the script's overall --timeout budget as the per-action default for
+   * this browser's context, so goto/click/screenshot/snapshotForAI inherit it
+   * instead of Playwright's fixed 30s default. Without this, `--timeout 90`
+   * still let each individual action die at 30s — the costliest timeout
+   * confusion in the field. The script-level clock remains the real ceiling.
+   * No-op if the browser isn't running.
+   */
+  setDefaultTimeouts(browserName: string, timeoutMs: number): void {
+    const entry = this.browsers.get(browserName);
+    if (!entry) {
+      return;
+    }
+    entry.context.setDefaultTimeout(timeoutMs);
+    entry.context.setDefaultNavigationTimeout(timeoutMs);
+  }
+
   async listPages(browserName: string): Promise<BrowserPageSummary[]> {
     const entry = this.browsers.get(browserName);
     if (!entry || !entry.browser.isConnected()) {

--- a/daemon/src/browser-manager.ts
+++ b/daemon/src/browser-manager.ts
@@ -3,6 +3,20 @@ import os from "node:os";
 import path from "node:path";
 import { chromium, type Browser, type BrowserContext, type Page } from "playwright";
 
+// A --browser name becomes a directory segment in the on-disk profile path
+// (`<baseDir>/<name>/chromium-profile`). Reject anything that could escape that
+// directory before it ever reaches path.join — mirrors the containment guard in
+// temp-files.ts. Without this, `--browser ../../../x` writes outside baseDir.
+const UNSAFE_BROWSER_NAME = /[\\/]|\.\./;
+function assertSafeBrowserName(name: string): void {
+  if (typeof name !== "string" || name.length === 0 || UNSAFE_BROWSER_NAME.test(name)) {
+    throw new Error(
+      `Invalid --browser name ${JSON.stringify(name)}: it may not be empty or contain ` +
+        `path separators or "..". Use a simple name like "default" or "agent-3".`
+    );
+  }
+}
+
 export interface BrowserEntry {
   name: string;
   type: "launched" | "connected";
@@ -101,6 +115,7 @@ export class BrowserManager {
       signal?: AbortSignal;
     } = {}
   ): Promise<BrowserEntry> {
+    assertSafeBrowserName(name);
     this.throwIfOperationAborted(options);
     await this.ensureBaseDir();
     this.throwIfOperationAborted(options);
@@ -185,6 +200,7 @@ export class BrowserManager {
     endpoint: string,
     options: BrowserOperationOptions = {}
   ): Promise<BrowserEntry> {
+    assertSafeBrowserName(name);
     if (endpoint === "auto") {
       return this.autoConnect(name, options);
     }
@@ -376,6 +392,7 @@ export class BrowserManager {
     ignoreHTTPSErrors: boolean,
     operation: BrowserOperationOptions = {}
   ): Promise<BrowserEntry> {
+    assertSafeBrowserName(name);
     const profileDir = path.join(this.baseDir, name, "chromium-profile");
     await this.dependencies.mkdir(profileDir, { recursive: true });
 

--- a/daemon/src/daemon.ts
+++ b/daemon/src/daemon.ts
@@ -165,9 +165,13 @@ async function handleExecute(socket: net.Socket, request: ExecuteRequest): Promi
         }
       },
       runScript: async (currentRequest, output, context) => {
+        const timeout = Math.max(1, context.deadline - Date.now());
+        // Propagate the script's --timeout budget to per-action Playwright
+        // timeouts so goto/click/screenshot don't independently die at 30s.
+        manager.setDefaultTimeouts(currentRequest.browser, timeout);
         await runScript(currentRequest.script, manager, currentRequest.browser, output, {
           signal: context.signal,
-          timeout: Math.max(1, context.deadline - Date.now()),
+          timeout,
         });
       },
     }


### PR DESCRIPTION
Two daemon fixes surfaced by a systematic agent-ergonomics review.

**Security — `--browser` path traversal.** A `--browser` name becomes a directory segment in the on-disk profile path (`<baseDir>/<name>/chromium-profile`) but was never validated, so `--browser ../../../x` escaped `baseDir`. Adds `assertSafeBrowserName` (mirroring the containment guard already in `temp-files.ts`), enforced at `ensureBrowser`/`connectBrowser`/`launchBrowser`.

**`--timeout` didn't reach per-action timeouts.** `--timeout` bounded only the QuickJS script clock; every Playwright action (`goto`/`click`/`screenshot`) kept its own fixed 30s default, so `--timeout 90` still died at 30s mid-action. Propagates the script budget to `context.setDefaultTimeout`/`setDefaultNavigationTimeout`.

Both covered by new vitest tests; full daemon suite green.