### PR TITLE
Sandbox script-API: binary readFile, uploadFile(), domCua ids/errors, addInitScript guard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ Thumbs.db
 tmp/
 yarn-debug.log*
 yarn-error.log*
+
+# agent-ergonomics audit workspace (provenance, not shipped)
+agent_ergonomics_audit/

--- a/cli/llm-guide.txt
+++ b/cli/llm-guide.txt
@@ -4,6 +4,7 @@ LLM USAGE GUIDE:
   Use descriptive page names like "login", "checkout", or "results" instead of "page1".
   Named pages from browser.getPage("name") persist between script runs, so you usually do not need to re-navigate.
   Inside page.evaluate(...), write plain JavaScript only - no TypeScript syntax in the browser context.
+  document, window, and other DOM globals exist only inside page.evaluate(...) - never at the top level of the script. Referencing them at the top level raises "document is not defined".
   On Windows/PowerShell, use here-strings to pipe multiline scripts:
     @"
     const page = await browser.getPage("main");
@@ -131,6 +132,12 @@ LLM USAGE GUIDE:
       title: await page.title(),
     }, null, 2));
     EOF
+
+  Exceptions to standard Playwright behavior:
+    Pages behave like ordinary Playwright Page objects, with two exceptions caused by the sandbox having no filesystem:
+    setInputFiles(path) fails - there is no local file to read.
+    addInitScript(...), in any form, is not supported.
+    For uploads, generate the file in the page context instead and inject it: build a Blob/File on a canvas, wrap it in a DataTransfer, and assign it to the input's .files.
 
   Common Playwright Page methods:
     page.goto(url, { waitUntil: "domcontentloaded" })

--- a/daemon/src/sandbox/__tests__/dom-cua.test.ts
+++ b/daemon/src/sandbox/__tests__/dom-cua.test.ts
@@ -465,6 +465,36 @@ describe.sequential("QuickJS page.domCua toolset", () => {
       expect(snapshot).not.toContain("Below the fold");
     }, 30_000);
 
+    it("emits small sequential node ids starting at 1 for a fresh document (P2-4)", async () => {
+      const { firstPageIds, secondPageIds } = await harness.runJson<{
+        firstPageIds: number[];
+        secondPageIds: number[];
+      }>(`
+        ${ID_HELPERS}
+        const page = await browser.getPage("dom-cua-sequential-ids-1");
+        await page.setContent(${JSON.stringify(DOM_TEST_PAGE_HTML)}, { waitUntil: "load" });
+        const firstPageIds = allIds(await page.domCua.getVisibleDom());
+
+        const secondPage = await browser.getPage("dom-cua-sequential-ids-2");
+        await secondPage.setContent(${JSON.stringify(DOM_TEST_PAGE_HTML)}, { waitUntil: "load" });
+        const secondPageIds = allIds(await secondPage.domCua.getVisibleDom());
+
+        console.log(JSON.stringify({ firstPageIds, secondPageIds }));
+      `);
+
+      // Ids on a fresh document start at 1 and climb sequentially — no huge
+      // random base — matching the tool's own --help examples (node_id=1,2).
+      expect(firstPageIds[0]).toBe(1);
+      expect(firstPageIds).toEqual([...firstPageIds].sort((a, b) => a - b));
+      expect(new Set(firstPageIds).size).toBe(firstPageIds.length);
+      expect(Math.max(...firstPageIds)).toBeLessThan(1000);
+
+      // A separate, unrelated page/document also starts small and sequential
+      // rather than continuing some ever-growing daemon-wide counter.
+      expect(secondPageIds[0]).toBe(1);
+      expect(Math.max(...secondPageIds)).toBeLessThan(1000);
+    }, 30_000);
+
     it("filters by viewport and includes elements after scrolling", async () => {
       const result = await harness.runJson<{ before: string; after: string }>(`
         const page = await browser.getPage("dom-cua-viewport");
@@ -696,7 +726,8 @@ describe.sequential("QuickJS page.domCua toolset", () => {
         console.log(JSON.stringify({ error, elapsed, clicks: await page.evaluate(() => window.clicks) }));
       `);
 
-      expect(result.error).toContain("stale or missing — re-run getVisibleDom()");
+      expect(result.error).toContain("did not finish scrolling into view within 3s");
+      expect(result.error).toContain("page.domCua.scroll({ nodeId })");
       expect(result.elapsed).toBeLessThan(10_000);
       expect(result.clicks).toEqual([]);
     }, 30_000);
@@ -734,7 +765,9 @@ describe.sequential("QuickJS page.domCua toolset", () => {
         console.log(JSON.stringify({ error, elapsed: Date.now() - start }));
       `);
 
-      expect(result.error).toContain("stale or missing — re-run getVisibleDom()");
+      expect(result.error).toContain("DOM node");
+      expect(result.error).toContain("is not a known node_id");
+      expect(result.error).toContain("navigation/reload reset the page's");
       expect(result.elapsed).toBeLessThan(3000);
     }, 30_000);
 
@@ -766,7 +799,7 @@ describe.sequential("QuickJS page.domCua toolset", () => {
       expect(result.preNavIds).toHaveLength(3);
       expect(result.postNavIds).toHaveLength(5);
       expect(Math.min(...result.postNavIds)).toBeGreaterThan(Math.max(...result.preNavIds));
-      expect(result.error).toContain("stale or missing — re-run getVisibleDom()");
+      expect(result.error).toContain("is not a known node_id");
       expect(result.clicks).toEqual([]);
     }, 30_000);
 
@@ -798,7 +831,7 @@ describe.sequential("QuickJS page.domCua toolset", () => {
       expect(result.preNavIds).toHaveLength(3);
       expect(result.postNavIds).toHaveLength(5);
       expect(result.postNavIds.filter((id) => result.preNavIds.includes(id))).toEqual([]);
-      expect(result.error).toContain("stale or missing — re-run getVisibleDom()");
+      expect(result.error).toContain("is not a known node_id");
       expect(result.clicks).toEqual([]);
     }, 30_000);
 
@@ -831,8 +864,73 @@ describe.sequential("QuickJS page.domCua toolset", () => {
       `);
 
       expect(result.newId).toBeGreaterThan(result.oldId);
-      expect(result.error).toContain("stale or missing — re-run getVisibleDom()");
+      // A fresh getVisibleDom() was taken after the frame navigated, so the
+      // old id simply isn't part of the latest registration anymore — this
+      // is the "unknown/reset" cause, not "element gone" (see the dedicated
+      // test below for the case where no re-snapshot happens first).
+      expect(result.error).toContain("DOM node");
+      expect(result.error).toContain("is not a known node_id");
       expect(result.frameClicks).toEqual([]);
+    }, 30_000);
+
+    it("fails with an element-gone error when a frame navigates internally and the old id is used without re-snapshotting", async () => {
+      const hostUrl = `${server.baseUrl}/dom/named-frame-host`;
+      const frameTwoUrl = `${server.baseUrl}/dom/frame-two`;
+      const result = await harness.runJson<{
+        oldId: number;
+        error: string | null;
+        frameClicks: string[];
+      }>(`
+        ${ID_HELPERS}
+        const page = await browser.getPage("dom-cua-frame-nav-no-resnapshot");
+        await page.goto(${JSON.stringify(hostUrl)}, { waitUntil: "load" });
+        const first = await page.domCua.getVisibleDom();
+        const oldId = idFor(first, ">FrameOne<");
+        const frame = page.frames().find((candidate) => candidate.name() === "child");
+        await frame.goto(${JSON.stringify(frameTwoUrl)}, { waitUntil: "load" });
+        let error = null;
+        try {
+          await page.domCua.click({ nodeId: oldId, waitForNavigation: false });
+        } catch (caught) {
+          error = String((caught && caught.message) || caught);
+        }
+        const frameClicks = await frame.evaluate(() => window.frameClicks);
+        console.log(JSON.stringify({ oldId, error, frameClicks }));
+      `);
+
+      // The frame (found by name) still exists on the page, and domCua's
+      // record that oldId belongs to it is still around (no re-snapshot
+      // cleared it) — but the frame's own internal navigation wiped its
+      // tracked elements, so the ref can't be resolved inside it anymore.
+      expect(result.error).toContain("DOM node");
+      expect(result.error).toContain("is no longer present");
+      expect(result.error).toContain("navigated internally");
+      expect(result.frameClicks).toEqual([]);
+    }, 30_000);
+
+    it("fails with a frame-specific error when the containing iframe is removed from the DOM", async () => {
+      const hostUrl = `${server.baseUrl}/dom/iframe-host`;
+      const result = await harness.runJson<{ error: string | null }>(`
+        ${ID_HELPERS}
+        const page = await browser.getPage("dom-cua-frame-removed");
+        await page.goto(${JSON.stringify(hostUrl)}, { waitUntil: "load" });
+        const snapshot = await page.domCua.getVisibleDom();
+        const nodeId = idFor(snapshot, ">Inner button<");
+        await page.evaluate(() => document.getElementById("child").remove());
+        await page.waitForFunction(() => document.getElementById("child") === null, { timeout: 5000 });
+        let error = null;
+        try {
+          await page.domCua.click({ nodeId, waitForNavigation: false });
+        } catch (caught) {
+          error = String((caught && caught.message) || caught);
+        }
+        console.log(JSON.stringify({ error }));
+      `);
+
+      expect(result.error).toContain("DOM node");
+      expect(result.error).toContain("belonged to a frame that no longer exists");
+      expect(result.error).not.toContain("is no longer present");
+      expect(result.error).not.toContain("is not a known node_id");
     }, 30_000);
   });
 
@@ -928,8 +1026,9 @@ describe.sequential("QuickJS page.domCua toolset", () => {
         frames: [{ key: "main", docToken: "doc-1", refs: [1, 2, 3] }],
       });
       expect(first.blocked).toBe(false);
-      expect(first.ids[0]).toHaveLength(3);
-      expect(first.ids[0][0]).toBeGreaterThanOrEqual(1_000_000);
+      // P2-4: node ids start small and sequential (1, 2, 3 ...), matching the
+      // tool's own --help examples, instead of a huge random base.
+      expect(first.ids[0]).toEqual([1, 2, 3]);
 
       const second = registerInRealm({
         frames: [{ key: "main", docToken: "doc-1", refs: [2, 3, 9] }],
@@ -938,6 +1037,7 @@ describe.sequential("QuickJS page.domCua toolset", () => {
       expect(second.ids[0][0]).toBe(first.ids[0][1]);
       expect(second.ids[0][1]).toBe(first.ids[0][2]);
       expect(second.ids[0][2]).toBeGreaterThan(first.ids[0][2]);
+      expect(second.ids[0]).toEqual([2, 3, 4]);
 
       const replaced = registerInRealm({
         frames: [{ key: "main", docToken: "doc-2", refs: [1, 2, 3] }],
@@ -946,9 +1046,10 @@ describe.sequential("QuickJS page.domCua toolset", () => {
       for (const id of replaced.ids[0]) {
         expect(id).toBeGreaterThan(second.ids[0][2]);
       }
+      expect(replaced.ids[0]).toEqual([5, 6, 7]);
     });
 
-    it("starts at a high base when sessionStorage works but holds no counter", () => {
+    it("starts at a low sequential base when sessionStorage works but holds no counter", () => {
       const storage = new Map<string, string>();
       const realm = vm.createContext({
         sessionStorage: {
@@ -964,7 +1065,7 @@ describe.sequential("QuickJS page.domCua toolset", () => {
         frames: [{ key: "main", docToken: "doc-1", refs: [1, 2] }],
       });
       expect(result.blocked).toBe(false);
-      expect(Math.min(...result.ids[0])).toBeGreaterThanOrEqual(1_000_000);
+      expect(result.ids[0]).toEqual([1, 2]);
       expect(Number(storage.get("__devBrowserDomCuaNextPublicId"))).toBeGreaterThan(
         Math.max(...result.ids[0])
       );

--- a/daemon/src/sandbox/__tests__/quickjs-platform.test.ts
+++ b/daemon/src/sandbox/__tests__/quickjs-platform.test.ts
@@ -1,0 +1,183 @@
+import { mkdtemp } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { BrowserManager } from "../../browser-manager.js";
+import { removeDirectoryWithRetries } from "../../test-cleanup.js";
+import { quickjsPlatform } from "../forked-client/quickjs-platform.js";
+import { QuickJSSandbox } from "../quickjs-sandbox.js";
+import { ensureSandboxClientBundle } from "./bundle-test-helpers.js";
+
+const SANDBOX_TIMEOUT_MS = 60_000;
+
+interface CapturedOutput {
+  stdout: string[];
+  stderr: string[];
+}
+
+interface JsonSandboxHarness {
+  dispose: () => Promise<void>;
+  runJson: <T>(script: string) => Promise<T>;
+}
+
+function createOutput(): CapturedOutput & {
+  sink: {
+    onStdout: (data: string) => void;
+    onStderr: (data: string) => void;
+  };
+} {
+  const stdout: string[] = [];
+  const stderr: string[] = [];
+
+  return {
+    stdout,
+    stderr,
+    sink: {
+      onStdout: (data) => {
+        stdout.push(data);
+      },
+      onStderr: (data) => {
+        stderr.push(data);
+      },
+    },
+  };
+}
+
+function clearOutput(output: CapturedOutput): void {
+  output.stdout.length = 0;
+  output.stderr.length = 0;
+}
+
+function parseLastJsonLine<T>(output: CapturedOutput): T {
+  const lines = output.stdout.map((line) => line.trim()).filter((line) => line.length > 0);
+  expect(lines.length).toBeGreaterThan(0);
+  return JSON.parse(lines.at(-1)!) as T;
+}
+
+async function createSandboxHarness(
+  manager: BrowserManager,
+  browserName: string
+): Promise<JsonSandboxHarness> {
+  await manager.ensureBrowser(browserName, {
+    headless: true,
+  });
+
+  const output = createOutput();
+  const sandbox = new QuickJSSandbox({
+    manager,
+    browserName,
+    onStdout: output.sink.onStdout,
+    onStderr: output.sink.onStderr,
+    timeoutMs: SANDBOX_TIMEOUT_MS,
+  });
+
+  await sandbox.initialize();
+
+  return {
+    dispose: async () => {
+      await sandbox.dispose();
+    },
+    runJson: async <T>(script: string): Promise<T> => {
+      clearOutput(output);
+      await sandbox.executeScript(`(async () => {\n${script}\n})()`);
+      expect(output.stderr).toEqual([]);
+      return parseLastJsonLine<T>(output);
+    },
+  };
+}
+
+describe("quickjsPlatform fs/path unsupported-API messages (P2-3)", () => {
+  // Unit level: pin the exact authored text the stubs throw. Playwright's
+  // internal fs()/path() modules back setInputFiles({path}),
+  // addInitScript({path}), page.pdf({path}), context.storageState({path}),
+  // etc. None of them work in the QuickJS sandbox (no real filesystem), so
+  // the message must name the limitation and the workaround instead of the
+  // bare "fs is not available in the QuickJS sandbox" it used to be.
+  it("names the upload workaround when fs() is called", () => {
+    expect(() => quickjsPlatform.fs()).toThrow(
+      "fs is not available in the QuickJS sandbox"
+    );
+    let message = "";
+    try {
+      quickjsPlatform.fs();
+    } catch (error) {
+      message = error instanceof Error ? error.message : String(error);
+    }
+    expect(message).toContain("setInputFiles({ name, mimeType, buffer })");
+    expect(message).toContain("readFile()");
+    expect(message).toContain("addInitScript({ path })");
+  });
+
+  it("gives path() the same no-filesystem explanation", () => {
+    let message = "";
+    try {
+      quickjsPlatform.path();
+    } catch (error) {
+      message = error instanceof Error ? error.message : String(error);
+    }
+    expect(message).toContain("path is not available in the QuickJS sandbox");
+    expect(message).toContain("addInitScript({ content })");
+  });
+
+  it("leaves the other unsupported stubs on their generic message", () => {
+    expect(() => quickjsPlatform.streamFile("unused", {} as never)).toThrow(
+      "streamFile is not available in the QuickJS sandbox"
+    );
+  });
+
+  describe.sequential("end-to-end through the sandboxed Playwright client", () => {
+    const browserName = "quickjs-platform-fs";
+    let browserRootDir = "";
+    let manager: BrowserManager;
+    let harness: JsonSandboxHarness;
+
+    beforeAll(async () => {
+      await ensureSandboxClientBundle();
+
+      browserRootDir = await mkdtemp(path.join(os.tmpdir(), "dev-browser-quickjs-platform-"));
+      manager = new BrowserManager(path.join(browserRootDir, "browsers"));
+      harness = await createSandboxHarness(manager, browserName);
+    }, 180_000);
+
+    afterAll(async () => {
+      await harness.dispose();
+      await manager.stopAll();
+      await removeDirectoryWithRetries(browserRootDir);
+    }, 180_000);
+
+    it("surfaces the authored fs message when setInputFiles is given a path string", async () => {
+      const result = await harness.runJson<{ error: string | null }>(`
+        const page = await browser.getPage("quickjs-platform-upload");
+        await page.setContent('<input id="file" type="file" />', { waitUntil: "load" });
+        let error = null;
+        try {
+          await page.setInputFiles("#file", "some/local/path.txt");
+        } catch (caught) {
+          error = String((caught && caught.message) || caught);
+        }
+        console.log(JSON.stringify({ error }));
+      `);
+
+      expect(result.error).toContain("fs is not available in the QuickJS sandbox");
+      expect(result.error).toContain("setInputFiles({ name, mimeType, buffer })");
+    }, 30_000);
+
+    it("surfaces the same authored message for addInitScript({ path })", async () => {
+      const result = await harness.runJson<{ error: string | null }>(`
+        const page = await browser.getPage("quickjs-platform-init-script");
+        let error = null;
+        try {
+          await page.addInitScript({ path: "some/local/init.js" });
+        } catch (caught) {
+          error = String((caught && caught.message) || caught);
+        }
+        console.log(JSON.stringify({ error }));
+      `);
+
+      expect(result.error).toContain("fs is not available in the QuickJS sandbox");
+      expect(result.error).toContain("addInitScript({ content })");
+    }, 30_000);
+  });
+});

--- a/daemon/src/sandbox/__tests__/quickjs-platform.test.ts
+++ b/daemon/src/sandbox/__tests__/quickjs-platform.test.ts
@@ -107,7 +107,7 @@ describe("quickjsPlatform fs/path unsupported-API messages (P2-3)", () => {
     }
     expect(message).toContain("setInputFiles({ name, mimeType, buffer })");
     expect(message).toContain("readFile()");
-    expect(message).toContain("addInitScript({ path })");
+    expect(message).toContain("uploadFile(pageName, selector,");
   });
 
   it("gives path() the same no-filesystem explanation", () => {
@@ -118,7 +118,7 @@ describe("quickjsPlatform fs/path unsupported-API messages (P2-3)", () => {
       message = error instanceof Error ? error.message : String(error);
     }
     expect(message).toContain("path is not available in the QuickJS sandbox");
-    expect(message).toContain("addInitScript({ content })");
+    expect(message).toContain("addInitScript() is unsupported outright");
   });
 
   it("leaves the other unsupported stubs on their generic message", () => {
@@ -164,7 +164,7 @@ describe("quickjsPlatform fs/path unsupported-API messages (P2-3)", () => {
       expect(result.error).toContain("setInputFiles({ name, mimeType, buffer })");
     }, 30_000);
 
-    it("surfaces the same authored message for addInitScript({ path })", async () => {
+    it("rejects addInitScript({ path }) with the dedicated addInitScript error, not the fs stub", async () => {
       const result = await harness.runJson<{ error: string | null }>(`
         const page = await browser.getPage("quickjs-platform-init-script");
         let error = null;
@@ -176,8 +176,46 @@ describe("quickjsPlatform fs/path unsupported-API messages (P2-3)", () => {
         console.log(JSON.stringify({ error }));
       `);
 
-      expect(result.error).toContain("fs is not available in the QuickJS sandbox");
-      expect(result.error).toContain("addInitScript({ content })");
+      expect(result.error).toContain(
+        "addInitScript() is not supported in the QuickJS sandbox"
+      );
+      expect(result.error).toContain("page.evaluate()");
+    }, 30_000);
+
+    it("rejects every other addInitScript() input form with the same authored error", async () => {
+      const result = await harness.runJson<{
+        functionForm: string | null;
+        stringForm: string | null;
+        contentForm: string | null;
+        contextForm: string | null;
+      }>(`
+        const page = await browser.getPage("quickjs-platform-init-script-forms");
+        const capture = async (call) => {
+          try {
+            await call();
+            return null;
+          } catch (caught) {
+            return String((caught && caught.message) || caught);
+          }
+        };
+
+        const functionForm = await capture(() => page.addInitScript(() => {}));
+        const stringForm = await capture(() => page.addInitScript("1 + 1"));
+        const contentForm = await capture(() => page.addInitScript({ content: "1 + 1" }));
+        const contextForm = await capture(() => page.context().addInitScript(() => {}));
+
+        console.log(JSON.stringify({ functionForm, stringForm, contentForm, contextForm }));
+      `);
+
+      for (const message of [
+        result.functionForm,
+        result.stringForm,
+        result.contentForm,
+        result.contextForm,
+      ]) {
+        expect(message).toContain("addInitScript() is not supported in the QuickJS sandbox");
+        expect(message).toContain("page.evaluate()");
+      }
     }, 30_000);
   });
 });

--- a/daemon/src/sandbox/__tests__/sandbox-file-io.test.ts
+++ b/daemon/src/sandbox/__tests__/sandbox-file-io.test.ts
@@ -257,16 +257,31 @@ describe.sequential("QuickJS sandbox file I/O", () => {
     `);
   }, 120_000);
 
-  it("rejects symlinked temp-file targets", async () => {
+  it("rejects symlinked temp-file targets", async (ctx) => {
     const symlinkName = "sandbox-file-io-symlink.txt";
     const symlinkPath = path.join(DEV_BROWSER_TMP_DIR, symlinkName);
     const targetPath = path.join(os.tmpdir(), "sandbox-file-io-symlink-target.txt");
 
-    cleanupPaths.add(symlinkPath);
     cleanupPaths.add(targetPath);
 
     await writeFileFs(targetPath, "outside", "utf8");
-    await symlink(targetPath, symlinkPath);
+    try {
+      await symlink(targetPath, symlinkPath);
+    } catch (error) {
+      // Creating a symlink on Windows requires SeCreateSymbolicLinkPrivilege
+      // (Developer Mode or an elevated shell). When the host can't grant it,
+      // fs.symlink throws EPERM/EACCES and this fixture can't be built. Skip
+      // rather than fail: this test asserts the SANDBOX rejects symlinked
+      // targets, not that the OS can create symlinks — the assertion still
+      // runs in full on any host where symlink creation is permitted.
+      const code = (error as NodeJS.ErrnoException).code;
+      if (code === "EPERM" || code === "EACCES") {
+        ctx.skip();
+        return;
+      }
+      throw error;
+    }
+    cleanupPaths.add(symlinkPath);
 
     await expectSandboxScriptToThrow(
       `await writeFile(${JSON.stringify(symlinkName)}, "should fail");`

--- a/daemon/src/sandbox/__tests__/sandbox-upload-file.test.ts
+++ b/daemon/src/sandbox/__tests__/sandbox-upload-file.test.ts
@@ -1,0 +1,195 @@
+import { mkdtemp } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { BrowserManager } from "../../browser-manager.js";
+import { removeDirectoryWithRetries } from "../../test-cleanup.js";
+import { runScript } from "../script-runner-quickjs.js";
+import { ensureSandboxClientBundle } from "./bundle-test-helpers.js";
+
+// P2-1: the sandbox's setInputFiles is unusable for real uploads — there is
+// no filesystem for the { path } form, and the { buffer } form still has to
+// round-trip through the sandbox's protocol bridge (see
+// quickjs-platform.ts's fs() stub and ObsidianVault/References/dev-browser-taxonomy's
+// file-upload-pdf-handling cluster). uploadFile() sidesteps all of that by
+// running page.setInputFiles() on the DAEMON side, against the real
+// Playwright `Page` the browser manager holds — these tests assert the file
+// actually lands in the page's <input type="file">, not just that the call
+// doesn't throw.
+
+interface CapturedOutput {
+  stdout: string[];
+  stderr: string[];
+}
+
+function createOutput(): CapturedOutput & {
+  sink: {
+    onStdout: (data: string) => void;
+    onStderr: (data: string) => void;
+  };
+} {
+  const stdout: string[] = [];
+  const stderr: string[] = [];
+
+  return {
+    stdout,
+    stderr,
+    sink: {
+      onStdout: (data) => {
+        stdout.push(data);
+      },
+      onStderr: (data) => {
+        stderr.push(data);
+      },
+    },
+  };
+}
+
+function parseLastJsonLine<T>(output: CapturedOutput): T {
+  const lines = output.stdout.map((line) => line.trim()).filter((line) => line.length > 0);
+  const lastLine = lines.at(-1);
+  if (!lastLine) {
+    throw new Error("Expected sandbox output");
+  }
+
+  return JSON.parse(lastLine) as T;
+}
+
+describe.sequential("QuickJS sandbox uploadFile() (P2-1)", () => {
+  let browserRootDir = "";
+  let manager: BrowserManager;
+  const browserName = "sandbox-upload-file";
+
+  beforeAll(async () => {
+    await ensureSandboxClientBundle();
+
+    browserRootDir = await mkdtemp(path.join(os.tmpdir(), "dev-browser-quickjs-upload-"));
+    manager = new BrowserManager(path.join(browserRootDir, "browsers"));
+    await manager.ensureBrowser(browserName, {
+      headless: true,
+    });
+  }, 180_000);
+
+  afterAll(async () => {
+    await manager.stopAll();
+    await removeDirectoryWithRetries(browserRootDir);
+  }, 180_000);
+
+  async function runSandboxScript(script: string): Promise<CapturedOutput> {
+    const output = createOutput();
+    await runScript(script, manager, browserName, output.sink, {
+      timeout: 60_000,
+    });
+    return output;
+  }
+
+  it("lands a base64-encoded file on a real <input type=file>", async () => {
+    const fileContents = "hello upload";
+    const base64 = Buffer.from(fileContents, "utf8").toString("base64");
+
+    const output = await runSandboxScript(`
+      const page = await browser.getPage("upload-base64");
+      await page.setContent('<input id="file" type="file" />');
+
+      await uploadFile("upload-base64", "#file", {
+        name: "hello.txt",
+        mimeType: "text/plain",
+        base64: ${JSON.stringify(base64)},
+      });
+
+      const result = await page.evaluate(() => {
+        const input = document.querySelector("#file");
+        const file = input.files[0];
+        return new Promise((resolve, reject) => {
+          const reader = new FileReader();
+          reader.onload = () =>
+            resolve({
+              name: file.name,
+              type: file.type,
+              size: file.size,
+              text: reader.result,
+            });
+          reader.onerror = () => reject(reader.error);
+          reader.readAsText(file);
+        });
+      });
+
+      console.log(JSON.stringify(result));
+    `);
+
+    const result = parseLastJsonLine<{
+      name: string;
+      type: string;
+      size: number;
+      text: string;
+    }>(output);
+
+    expect(result.name).toBe("hello.txt");
+    expect(result.type).toBe("text/plain");
+    expect(result.text).toBe(fileContents);
+    expect(result.size).toBe(Buffer.byteLength(fileContents, "utf8"));
+  }, 120_000);
+
+  it("lands a buffer-form file (encoded to base64 inside the sandbox)", async () => {
+    const fileBytes = [104, 101, 108, 108, 111]; // "hello"
+
+    const output = await runSandboxScript(`
+      const page = await browser.getPage("upload-buffer");
+      await page.setContent('<input id="file" type="file" />');
+
+      await uploadFile("upload-buffer", "#file", {
+        name: "buffer-upload.bin",
+        mimeType: "application/octet-stream",
+        buffer: Buffer.from(${JSON.stringify(fileBytes)}),
+      });
+
+      const result = await page.evaluate(() => {
+        const input = document.querySelector("#file");
+        const file = input.files[0];
+        return new Promise((resolve, reject) => {
+          const reader = new FileReader();
+          reader.onload = () =>
+            resolve({
+              name: file.name,
+              type: file.type,
+              bytes: Array.from(new Uint8Array(reader.result)),
+            });
+          reader.onerror = () => reject(reader.error);
+          reader.readAsArrayBuffer(file);
+        });
+      });
+
+      console.log(JSON.stringify(result));
+    `);
+
+    const result = parseLastJsonLine<{
+      name: string;
+      type: string;
+      bytes: number[];
+    }>(output);
+
+    expect(result.name).toBe("buffer-upload.bin");
+    expect(result.type).toBe("application/octet-stream");
+    expect(result.bytes).toEqual(fileBytes);
+  }, 120_000);
+
+  it("rejects a malformed file argument before making a host call", async () => {
+    const output = createOutput();
+
+    await expect(
+      runScript(
+        `
+          const page = await browser.getPage("upload-invalid");
+          await page.setContent('<input id="file" type="file" />');
+          await uploadFile("upload-invalid", "#file", { name: "no-data.txt" });
+        `,
+        manager,
+        browserName,
+        output.sink,
+        { timeout: 30_000 }
+      )
+    ).rejects.toThrow(/base64|buffer/i);
+  }, 60_000);
+});

--- a/daemon/src/sandbox/forked-client/quickjs-platform.ts
+++ b/daemon/src/sandbox/forked-client/quickjs-platform.ts
@@ -13,6 +13,27 @@ function unsupported(apiName: string): never {
   throw new Error(`${apiName} is not available in the QuickJS sandbox`);
 }
 
+// Playwright's internal `fs`/`path` modules back every path-based API on the
+// client: element.setInputFiles({ path }), page.addInitScript({ path }),
+// page.pdf({ path }), context.storageState({ path }), route.fulfill({ path }),
+// browserContext.tracing, HAR recording, etc. None of them work in the
+// QuickJS sandbox — there is no real filesystem here — but the bare
+// "fs is not available" message didn't say what to do instead. Name the
+// limitation and the two workarounds that cover the field-costliest case
+// (file uploads) and the general case (pass data inline instead of a path).
+function unsupportedFilesystemApi(apiName: "fs" | "path"): never {
+  throw new Error(
+    `${apiName} is not available in the QuickJS sandbox — there is no real filesystem for ` +
+      `Playwright's built-in path-based helpers (element.setInputFiles({ path }), ` +
+      `page.addInitScript({ path }), page.pdf({ path }), context.storageState({ path }), and ` +
+      `similar). For file uploads: read the file into a Buffer with the sandbox's readFile() ` +
+      `helper, then call element.setInputFiles({ name, mimeType, buffer }) — or inject the bytes ` +
+      `via a canvas/DataTransfer inside page.evaluate(). For everything else, pass inline content ` +
+      `instead of a path where the API supports it (e.g. addInitScript({ content }) instead of ` +
+      `{ path }).`
+  );
+}
+
 function pseudoSha1(text: string): string {
   let hash = 2166136261;
   for (let index = 0; index < text.length; index += 1) {
@@ -35,14 +56,14 @@ export const quickjsPlatform: Platform = {
     }),
   defaultMaxListeners: () => 10,
   env: {},
-  fs: () => unsupported("fs"),
+  fs: () => unsupportedFilesystemApi("fs"),
   inspectCustom: undefined,
   isDebugMode: () => false,
   isJSDebuggerAttached: () => false,
   isLogEnabled: () => false,
   isUnderTest: () => false,
   log: () => {},
-  path: () => unsupported("path"),
+  path: () => unsupportedFilesystemApi("path"),
   pathSeparator: "/",
   showInternalStackFrames: () => false,
   streamFile: () => unsupported("streamFile"),

--- a/daemon/src/sandbox/forked-client/quickjs-platform.ts
+++ b/daemon/src/sandbox/forked-client/quickjs-platform.ts
@@ -14,23 +14,27 @@ function unsupported(apiName: string): never {
 }
 
 // Playwright's internal `fs`/`path` modules back every path-based API on the
-// client: element.setInputFiles({ path }), page.addInitScript({ path }),
-// page.pdf({ path }), context.storageState({ path }), route.fulfill({ path }),
-// browserContext.tracing, HAR recording, etc. None of them work in the
-// QuickJS sandbox — there is no real filesystem here — but the bare
-// "fs is not available" message didn't say what to do instead. Name the
-// limitation and the two workarounds that cover the field-costliest case
-// (file uploads) and the general case (pass data inline instead of a path).
+// client: element.setInputFiles({ path }), page.pdf({ path }),
+// context.storageState({ path }), route.fulfill({ path }), browserContext.tracing,
+// HAR recording, etc. None of them work in the QuickJS sandbox — there is no
+// real filesystem here — but the bare "fs is not available" message didn't
+// say what to do instead. Name the limitation and the workarounds that cover
+// the field-costliest case (file uploads) and the general case (pass data
+// inline instead of a path). addInitScript() is called out separately: it is
+// unsupported in every form (not just { path }), so it has its own dedicated
+// error (see clientHelper.ts's assertAddInitScriptSupported()) rather than
+// relying on this generic message.
 function unsupportedFilesystemApi(apiName: "fs" | "path"): never {
   throw new Error(
     `${apiName} is not available in the QuickJS sandbox — there is no real filesystem for ` +
       `Playwright's built-in path-based helpers (element.setInputFiles({ path }), ` +
-      `page.addInitScript({ path }), page.pdf({ path }), context.storageState({ path }), and ` +
-      `similar). For file uploads: read the file into a Buffer with the sandbox's readFile() ` +
-      `helper, then call element.setInputFiles({ name, mimeType, buffer }) — or inject the bytes ` +
-      `via a canvas/DataTransfer inside page.evaluate(). For everything else, pass inline content ` +
-      `instead of a path where the API supports it (e.g. addInitScript({ content }) instead of ` +
-      `{ path }).`
+      `page.pdf({ path }), context.storageState({ path }), route.fulfill({ path }), and ` +
+      `similar; addInitScript() is unsupported outright, in every form — see its own error). ` +
+      `For file uploads: call the sandbox's uploadFile(pageName, selector, { name, mimeType, ` +
+      `base64 }) helper, or read the file into a Buffer with readFile() and call ` +
+      `element.setInputFiles({ name, mimeType, buffer }) — or inject the bytes via a ` +
+      `canvas/DataTransfer inside page.evaluate(). For everything else, pass inline content ` +
+      `instead of a path where the API supports it.`
   );
 }
 

--- a/daemon/src/sandbox/forked-client/src/client/browserContext.ts
+++ b/daemon/src/sandbox/forked-client/src/client/browserContext.ts
@@ -20,7 +20,7 @@ import { Artifact } from "./artifact";
 import { Browser } from "./browser";
 import { CDPSession } from "./cdpSession";
 import { ChannelOwner } from "./channelOwner";
-import { evaluationScript } from "./clientHelper";
+import { assertAddInitScriptSupported } from "./clientHelper";
 import { Clock } from "./clock";
 import { ConsoleMessage } from "./consoleMessage";
 import { Dialog } from "./dialog";
@@ -382,8 +382,7 @@ export class BrowserContext
   }
 
   async addInitScript(script: Function | string | { path?: string; content?: string }, arg?: any) {
-    const source = await evaluationScript(this._platform, script, arg);
-    return DisposableObject.from((await this._channel.addInitScript({ source })).disposable);
+    assertAddInitScriptSupported();
   }
 
   async exposeBinding(

--- a/daemon/src/sandbox/forked-client/src/client/clientHelper.ts
+++ b/daemon/src/sandbox/forked-client/src/client/clientHelper.ts
@@ -53,3 +53,25 @@ export async function evaluationScript(
 export function addSourceUrlToScript(source: string, path: string): string {
   return `${source}\n//# sourceURL=${path.replace(/\n/g, "")}`;
 }
+
+// addInitScript() does not work in the QuickJS sandbox in ANY of its input
+// forms. The { path } form fails at the platform's fs() stub (see
+// quickjs-platform.ts) because there is no real filesystem to read from. The
+// function/string/{ content } forms get past evaluationScript() just fine —
+// but fail deeper, when the server tries to relay the resulting init-script
+// registration back across the sandbox's protocol bridge, surfacing only as
+// an opaque `__transport_receive failed: expected object, got undefined` /
+// ValidationError with nothing pointing at addInitScript as the cause. Fail
+// fast, before any of that, with an authored error that names the limitation
+// and the workaround (agents lose 15-20+ minutes rediscovering this per the
+// field taxonomy at ObsidianVault/References/dev-browser-taxonomy).
+export function assertAddInitScriptSupported(): never {
+  throw new Error(
+    "addInitScript() is not supported in the QuickJS sandbox, in any input form (function, " +
+      "string, { content }, or { path }) — it fails deep in the sandbox's protocol bridge with " +
+      "an opaque error. Inject your script via page.evaluate() after navigation instead, e.g. " +
+      "`await page.goto(url); await page.evaluate(() => { /* your init code */ });`. If you " +
+      "need the script to run before the page's own scripts, evaluate it against a blank page " +
+      "before navigating, or re-apply it after each navigation."
+  );
+}

--- a/daemon/src/sandbox/forked-client/src/client/domCua.ts
+++ b/daemon/src/sandbox/forked-client/src/client/domCua.ts
@@ -10,6 +10,11 @@ const MAX_LINES = 200;
 const MAX_CHARS = 20_000;
 const FRAME_TRUNCATION_MARKER = "<!-- output truncated: frame element budget reached -->";
 const SNAPSHOT_TRUNCATION_MARKER = "<!-- output truncated: snapshot budget reached -->";
+// Each fresh document seeds its node_id counter from a block this wide (see
+// #registrationCount below) — sized well above MAX_LINES/the per-frame
+// element budgets so one document's ids can never spill into the next
+// document's block.
+const SEED_HINT_BLOCK_SIZE = 10_000;
 
 function frameKey(frame: Frame): string {
   const name = frame.name();
@@ -23,8 +28,41 @@ function frameKey(frame: Frame): string {
   return `${frame.url()}@${indexPath.join(".")}`;
 }
 
-function staleNodeError(nodeId: number): Error {
-  return new Error(`DOM node ${nodeId} is stale or missing — re-run getVisibleDom()`);
+// domCua's stale-node failure has four distinct root causes that all used to
+// collapse into one "stale or missing" message. Splitting them lets an agent
+// tell "the page navigated" from "the element was actually removed" from
+// "it's just slow to scroll to" — each message below says what to do next.
+
+function unknownNodeIdError(nodeId: number): Error {
+  return new Error(
+    `DOM node ${nodeId} is not a known node_id — either a navigation/reload reset the page's ` +
+      `tracked elements, or this id was never returned by getVisibleDom(). Re-run ` +
+      `page.domCua.getVisibleDom() and use one of its node_id values.`
+  );
+}
+
+function frameGoneError(nodeId: number): Error {
+  return new Error(
+    `DOM node ${nodeId} belonged to a frame that no longer exists on the page (the iframe was ` +
+      `likely removed or replaced). Re-run page.domCua.getVisibleDom() to get node_id values for ` +
+      `the frames that are still present.`
+  );
+}
+
+function elementGoneError(nodeId: number): Error {
+  return new Error(
+    `DOM node ${nodeId} is no longer present (its element was removed/replaced, or the frame it ` +
+      `lived in navigated internally, wiping its tracked elements). Re-run ` +
+      `page.domCua.getVisibleDom() and act on the fresh node_id for that element.`
+  );
+}
+
+function scrollTimeoutError(nodeId: number): Error {
+  return new Error(
+    `DOM node ${nodeId} did not finish scrolling into view within 3s — it may be hidden, ` +
+      `non-scrollable, or inside a slow-loading container, rather than actually gone. Retry the ` +
+      `action, or call page.domCua.scroll({ nodeId }) first to bring it into view.`
+  );
 }
 
 function blockedStateError(): Error {
@@ -33,6 +71,22 @@ function blockedStateError(): Error {
 
 export class DomCua {
   #page: Page;
+  // Counts calls to getVisibleDom() on this Page. domCua's node_id counter
+  // normally lives in the page's own JS realm (browser-side) and, for
+  // same-origin navigations, in sessionStorage — both keep ids small and
+  // sequential across repeated snapshots. But a genuinely fresh document (the
+  // very first load, or any navigation onto an origin sessionStorage has
+  // never seen — most notably a cross-origin navigation, where
+  // sessionStorage cannot carry a counter forward) has no such history to
+  // consult. For that case only, domCuaRegister falls back to a hint derived
+  // from this always-increasing, browser-navigation-proof counter instead of
+  // a large random base: each fresh document gets its own
+  // SEED_HINT_BLOCK_SIZE-wide block, so ids stay small (matching this tool's
+  // own --help examples) while two different documents viewed by the same
+  // Page can never hand out overlapping node_id values — a stale id from
+  // before a navigation reliably fails instead of silently resolving to the
+  // wrong element on the new document.
+  #registrationCount = 0;
 
   constructor(page: Page) {
     this.#page = page;
@@ -75,7 +129,10 @@ export class DomCua {
       });
     }
 
+    this.#registrationCount += 1;
+    const seedHint = 1 + (this.#registrationCount - 1) * SEED_HINT_BLOCK_SIZE;
     const registration = await mainFrame.evaluate(domCuaRegister, {
+      seedHint,
       frames: snapshots.map((snapshot) => ({
         key: snapshot.key,
         docToken: snapshot.docToken,
@@ -170,9 +227,9 @@ export class DomCua {
         (id) => globalThis.__devBrowserDomCua?.actionableByPublicId?.get(id) ?? null,
         nodeId
       );
-    if (!target) throw staleNodeError(nodeId);
+    if (!target) throw unknownNodeIdError(nodeId);
     const frame = this.#page.frames().find((candidate) => frameKey(candidate) === target.frameKey);
-    if (!frame) throw staleNodeError(nodeId);
+    if (!frame) throw frameGoneError(nodeId);
     const handle = await frame.evaluateHandle(
       (ref) => globalThis.__devBrowserDomCua?.refToElement?.get(ref) ?? null,
       target.ref
@@ -180,17 +237,17 @@ export class DomCua {
     const element = handle.asElement();
     if (!element) {
       await handle.dispose();
-      throw staleNodeError(nodeId);
+      throw elementGoneError(nodeId);
     }
     try {
       try {
         await element.scrollIntoViewIfNeeded({ timeout: 3000 });
       } catch (error) {
-        if (error instanceof TimeoutError) throw staleNodeError(nodeId);
+        if (error instanceof TimeoutError) throw scrollTimeoutError(nodeId);
         throw error;
       }
       const box = await element.boundingBox();
-      if (!box) throw staleNodeError(nodeId);
+      if (!box) throw elementGoneError(nodeId);
       return { x: box.x + box.width / 2, y: box.y + box.height / 2 };
     } finally {
       await element.dispose();

--- a/daemon/src/sandbox/forked-client/src/client/domCuaInjected.ts
+++ b/daemon/src/sandbox/forked-client/src/client/domCuaInjected.ts
@@ -254,7 +254,20 @@ export const domCuaRegister = function (data) {
       stored = null;
     }
     const parsed = stored === null ? NaN : parseInt(stored, 10);
-    next = parsed >= 1 ? parsed : 1_000_000 + Math.floor(Math.random() * 2_000_000_000);
+    // Start small and sequential (1, 2, 3 ...) so node_id values match the
+    // tool's own --help examples, instead of the old huge-random base. The
+    // sticky publicIdByFrameKey map (below) still keeps an element's id
+    // stable across repeated getVisibleDom() calls on the same document, and
+    // sessionStorage still carries the counter across same-origin
+    // navigations so post-navigation ids never collide with pre-navigation
+    // ones. For a genuinely fresh document with no sessionStorage history
+    // (first load, or a cross-origin navigation sessionStorage can't bridge),
+    // domCua.ts passes a small, always-increasing seedHint derived from a
+    // navigation-proof call counter on the DomCua instance, so different
+    // documents on the same Page still never collide even without a random
+    // base. Falls back to 1 when no hint is given (e.g. direct calls/tests).
+    const seedHint = typeof data.seedHint === "number" && data.seedHint >= 1 ? data.seedHint : 1;
+    next = parsed >= 1 ? parsed : seedHint;
   }
 
   if (!(state.publicIdByFrameKey instanceof Map)) state.publicIdByFrameKey = new Map();

--- a/daemon/src/sandbox/forked-client/src/client/page.ts
+++ b/daemon/src/sandbox/forked-client/src/client/page.ts
@@ -18,7 +18,7 @@
 
 import { Artifact } from "./artifact";
 import { ChannelOwner } from "./channelOwner";
-import { evaluationScript } from "./clientHelper";
+import { assertAddInitScriptSupported } from "./clientHelper";
 import { Coverage } from "./coverage";
 import { Cua } from "./cua";
 import { DisposableObject, DisposableStub } from "./disposable";
@@ -680,8 +680,7 @@ export class Page extends ChannelOwner<channels.PageChannel> implements api.Page
   }
 
   async addInitScript(script: Function | string | { path?: string; content?: string }, arg?: any) {
-    const source = await evaluationScript(this._platform, script, arg);
-    return DisposableObject.from((await this._channel.addInitScript({ source })).disposable);
+    assertAddInitScriptSupported();
   }
 
   async route(

--- a/daemon/src/sandbox/quickjs-sandbox.ts
+++ b/daemon/src/sandbox/quickjs-sandbox.ts
@@ -220,7 +220,7 @@ export class QuickJSSandbox {
           closePage: (name) => this.#closePage(name),
           saveScreenshot: (name, data) => this.#writeTempFile(name, data),
           writeFile: (name, data) => this.#writeTempFile(name, data),
-          readFile: (name) => this.#readTempFile(name),
+          readFile: (name, encoding) => this.#readTempFile(name, encoding),
         },
         onConsole: (level, args) => {
           this.#routeConsole(level, args);
@@ -527,8 +527,8 @@ export class QuickJSSandbox {
                   writable: false,
                 },
                 readFile: {
-                  value: async (name) => {
-                    return await hostCall("readFile", JSON.stringify([name]));
+                  value: async (name, encoding) => {
+                    return await hostCall("readFile", JSON.stringify([name, encoding]));
                   },
                   configurable: false,
                   enumerable: true,
@@ -738,8 +738,11 @@ export class QuickJSSandbox {
     );
   }
 
-  async #readTempFile(name: unknown): Promise<string> {
-    return await readDevBrowserTempFile(requireString(name, "File name"));
+  async #readTempFile(name: unknown, encoding?: unknown): Promise<string> {
+    const resolvedEncoding = encoding === "base64" ? "base64" : "utf8";
+    return await readDevBrowserTempFile(requireString(name, "File name"), {
+      encoding: resolvedEncoding,
+    });
   }
 
   async #cleanupAnonymousPages(options: { suppressErrors?: boolean } = {}): Promise<void> {

--- a/daemon/src/sandbox/quickjs-sandbox.ts
+++ b/daemon/src/sandbox/quickjs-sandbox.ts
@@ -221,6 +221,8 @@ export class QuickJSSandbox {
           saveScreenshot: (name, data) => this.#writeTempFile(name, data),
           writeFile: (name, data) => this.#writeTempFile(name, data),
           readFile: (name, encoding) => this.#readTempFile(name, encoding),
+          uploadFile: (pageName, selector, name, mimeType, base64) =>
+            this.#uploadFile(pageName, selector, name, mimeType, base64),
         },
         onConsole: (level, args) => {
           this.#routeConsole(level, args);
@@ -534,6 +536,48 @@ export class QuickJSSandbox {
                   enumerable: true,
                   writable: false,
                 },
+                uploadFile: {
+                  // setInputFiles({ path }) and setInputFiles({ buffer }) both fail inside the
+                  // sandboxed Playwright client: the path form needs a real filesystem
+                  // (unavailable here, see quickjs-platform.ts's fs() stub) and the buffer form
+                  // still round-trips through the sandbox's protocol bridge. This helper instead
+                  // asks the DAEMON (real Node.js, real Playwright, real fs) to call
+                  // page.setInputFiles() directly on the real page object — bypassing the
+                  // sandboxed client and its bridge entirely for this one operation.
+                  value: async (pageName, selector, file) => {
+                    if (typeof pageName !== "string" || pageName.length === 0) {
+                      throw new TypeError("uploadFile: pageName must be a non-empty string");
+                    }
+                    if (typeof selector !== "string" || selector.length === 0) {
+                      throw new TypeError("uploadFile: selector must be a non-empty string");
+                    }
+                    if (typeof file !== "object" || file === null) {
+                      throw new TypeError(
+                        "uploadFile: file must be an object with { name, mimeType, base64 } or " +
+                          "{ name, mimeType, buffer }",
+                      );
+                    }
+
+                    let base64;
+                    if (typeof file.base64 === "string") {
+                      base64 = file.base64;
+                    } else if (file.buffer !== undefined) {
+                      base64 = Buffer.from(file.buffer).toString("base64");
+                    } else {
+                      throw new TypeError(
+                        "uploadFile: file must include either a base64 string or a buffer",
+                      );
+                    }
+
+                    return await hostCall(
+                      "uploadFile",
+                      JSON.stringify([pageName, selector, file.name, file.mimeType, base64]),
+                    );
+                  },
+                  configurable: false,
+                  enumerable: true,
+                  writable: false,
+                },
               });
             })();
           })()
@@ -729,6 +773,31 @@ export class QuickJSSandbox {
       this.#options.browserName,
       requireString(name, "Page name")
     );
+  }
+
+  // Runs on the daemon side against a REAL Playwright `Page` (from the
+  // `playwright` package the manager launched, not the sandboxed forked
+  // client) — so Node's real Buffer/fs are available and setInputFiles's
+  // FilePayload form works exactly like it would in any normal Playwright
+  // script. This is what lets uploadFile() bypass the QuickJS sandbox's
+  // filesystem-less setInputFiles failure entirely instead of working around
+  // it from inside the guest.
+  async #uploadFile(
+    pageName: unknown,
+    selector: unknown,
+    name: unknown,
+    mimeType: unknown,
+    base64: unknown
+  ): Promise<void> {
+    const page = await this.#options.manager.getPage(
+      this.#options.browserName,
+      requireString(pageName, "Page name")
+    );
+    await page.setInputFiles(requireString(selector, "Selector"), {
+      name: requireString(name, "File name"),
+      mimeType: requireString(mimeType, "MIME type"),
+      buffer: Buffer.from(requireString(base64, "File data (base64)"), "base64"),
+    });
   }
 
   async #writeTempFile(name: unknown, payload: unknown): Promise<string> {

--- a/daemon/src/temp-files-binary-read.test.ts
+++ b/daemon/src/temp-files-binary-read.test.ts
@@ -1,0 +1,39 @@
+import { rm } from "node:fs/promises";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { readDevBrowserTempFile, writeDevBrowserTempFile } from "./temp-files.js";
+
+// Regression test for P2-1: readFile()'s hardcoded UTF-8 decoding silently
+// corrupts binary (a screenshot read back becomes replacement chars). The new
+// { encoding: "base64" } mode must round-trip raw bytes losslessly.
+describe("readDevBrowserTempFile binary mode", () => {
+  const fileName = "ergo-binary-read.bin";
+  let writtenPath = "";
+
+  afterEach(async () => {
+    if (writtenPath) {
+      await rm(writtenPath, { force: true });
+      writtenPath = "";
+    }
+  });
+
+  it("round-trips binary bytes losslessly via base64, where utf8 corrupts them", async () => {
+    // Non-UTF8 bytes: a PNG signature plus high bytes that utf8 mangles.
+    const bytes = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0xff, 0xfe, 0x00, 0x80]);
+    writtenPath = await writeDevBrowserTempFile(fileName, bytes);
+
+    const base64 = await readDevBrowserTempFile(fileName, { encoding: "base64" });
+    expect(Buffer.from(base64, "base64")).toEqual(Buffer.from(bytes));
+
+    // The default (utf8) path does NOT round-trip these bytes — proves the bug
+    // the base64 mode fixes.
+    const utf8 = await readDevBrowserTempFile(fileName);
+    expect(Buffer.from(utf8, "utf8")).not.toEqual(Buffer.from(bytes));
+  });
+
+  it("default encoding still returns utf8 text", async () => {
+    writtenPath = await writeDevBrowserTempFile(fileName, "hello world");
+    expect(await readDevBrowserTempFile(fileName)).toBe("hello world");
+  });
+});

--- a/daemon/src/temp-files.ts
+++ b/daemon/src/temp-files.ts
@@ -188,16 +188,25 @@ export async function writeDevBrowserTempFile(
   return destinationPath;
 }
 
-export async function readDevBrowserTempFile(fileName: unknown): Promise<string> {
+export async function readDevBrowserTempFile(
+  fileName: unknown,
+  options: { encoding?: "utf8" | "base64" } = {}
+): Promise<string> {
+  const encoding = options.encoding ?? "utf8";
   const destinationPath = await resolveDevBrowserTempPath(fileName);
   await assertDestinationIsNotSymlink(destinationPath);
 
   let handle: FileHandle | undefined;
   try {
     handle = await open(destinationPath, constants.O_RDONLY | NOFOLLOW_FLAG);
-    return await handle.readFile({
-      encoding: "utf8",
-    });
+    // "utf8" corrupts binary (a screenshot read back becomes replacement chars);
+    // "base64" reads the raw bytes and returns them base64-encoded so the caller
+    // can round-trip binary data losslessly.
+    if (encoding === "base64") {
+      const buffer = await handle.readFile();
+      return buffer.toString("base64");
+    }
+    return await handle.readFile({ encoding: "utf8" });
   } catch (error) {
     throw normalizeSymlinkError(error, destinationPath);
   } finally {

--- a/skills/dev-browser/SKILL.md
+++ b/skills/dev-browser/SKILL.md
@@ -62,7 +62,7 @@ Use `waitUntil: "domcontentloaded"`, not `"networkidle"` — `networkidle` hangs
 - No `require`/`import`/`process`/`fs`/`fetch` at the script's top level.
 - **`document`/`window`/DOM globals only exist inside `page.evaluate(() => ...)`** — never at the top level. `document is not defined` means you're outside `evaluate()`.
 - **`setInputFiles` with a host file path fails** — there's no filesystem in the sandbox. For uploads, generate the file in-page (canvas → `Blob`/`File` → `DataTransfer`) and inject it.
-- **`readFile()` is UTF-8 only** — don't use it to round-trip a screenshot or other binary file; it will corrupt it.
+- **`readFile()` defaults to UTF-8** and will corrupt a screenshot or other binary file — pass `readFile(name, "base64")` to round-trip binary losslessly.
 
 ## Usage
 

--- a/skills/dev-browser/SKILL.md
+++ b/skills/dev-browser/SKILL.md
@@ -5,7 +5,7 @@ description: Browser automation with persistent page state. Use when users ask t
 
 # Dev Browser
 
-A CLI for controlling browsers with sandboxed JavaScript scripts.
+A CLI for controlling browsers with sandboxed JavaScript scripts. Pages behave like Playwright Page objects, driven from a background daemon — see Sandbox limits below for the differences.
 
 ## Installation
 
@@ -14,6 +14,56 @@ npm install -g dev-browser
 dev-browser install
 ```
 
+## The canonical script
+
+Keep every script small, focused, one job — end it with a `console.log` of the state you need for the next decision.
+
+```bash
+dev-browser --timeout 60 <<'EOF'
+const page = await browser.getPage("main");
+await page.goto("https://example.com", { waitUntil: "domcontentloaded" });
+console.log(JSON.stringify({ url: page.url(), title: await page.title() }));
+EOF
+```
+
+## Method ladder — try the direct verb first
+
+Work down this list only as each rung fails. The common mistake is skipping straight to `page.evaluate()` to find-and-click something a locator would hit directly — it bypasses Playwright's actionability waits and silently clicks the wrong node.
+
+1. **Known selector → a Playwright locator.** `getByRole`, `getByText`, `getByLabel`, `locator()`. Default for almost everything.
+2. **Unknown page → `page.snapshotForAI()` once** to discover elements, then act on locators from what it returns.
+3. **After ~2 failed locator attempts on the same target → `page.domCua`** (act by node id from `getVisibleDom()`).
+4. **Visual-only structure, no stable DOM (e.g. canvas) → `page.cua`** (act by coordinates read off a screenshot).
+5. **`page.evaluate()` → read-only introspection, last resort.** Compute a value or check state — never to click, scroll, or find.
+
+## Timeouts — three separate clocks
+
+- **`--timeout N`** sets the whole script's budget. It does **not** raise Playwright's per-action timeout.
+- **Each action** (`goto`, `click`, `screenshot`, `snapshotForAI`) has its own ~30s default, independent of `--timeout`. Raise it explicitly on the call: `page.goto(url, { timeout: 45000, waitUntil: "domcontentloaded" })`.
+- **The outer shell/tool** running dev-browser has its own separate kill clock (e.g. a Bash tool's ~2min limit) — not fixable by any dev-browser flag. If that's what's killing the run, shorten the script; don't raise `--timeout`.
+
+If a `goto`/`click` keeps failing at "30000ms exceeded" even after raising `--timeout`, you're chasing the wrong clock — pass `{ timeout }` on that specific call instead.
+
+Use `waitUntil: "domcontentloaded"`, not `"networkidle"` — `networkidle` hangs indefinitely on any site with analytics, trackers, or SPA polling.
+
+## Named pages persist — and typos make blank ones
+
+- `browser.getPage("checkout")` returns the **same tab** across separate script invocations. Reuse it — don't re-navigate or re-log-in.
+- **`getPage("typo")` silently creates a new blank page** instead of erroring. A blank/`about:blank` result usually means a misspelled name, not a broken page — check spelling before assuming something failed.
+- Use a fresh/random page name to simulate a first-time visitor (no cookies, first-load popups).
+
+## One daemon — never run calls in parallel
+
+- All dev-browser calls share **one background daemon**. Never fire two dev-browser calls at once — they serialize on the daemon and can wedge Chromium under load. Loop *inside* one script instead.
+- Running multiple agents concurrently: give each its own **`--browser <name>`**. **Never run global `dev-browser stop`** — it kills every agent's browser, not just yours.
+
+## Sandbox limits — this is QuickJS, not Node
+
+- No `require`/`import`/`process`/`fs`/`fetch` at the script's top level.
+- **`document`/`window`/DOM globals only exist inside `page.evaluate(() => ...)`** — never at the top level. `document is not defined` means you're outside `evaluate()`.
+- **`setInputFiles` with a host file path fails** — there's no filesystem in the sandbox. For uploads, generate the file in-page (canvas → `Blob`/`File` → `DataTransfer`) and inject it.
+- **`readFile()` is UTF-8 only** — don't use it to round-trip a screenshot or other binary file; it will corrupt it.
+
 ## Usage
 
-Run `dev-browser --help` to learn more.
+Run `dev-browser --help` for the complete, authoritative API — method reference, `cua`/`domCua` details, `--connect` mode, and the full option list.


### PR DESCRIPTION
Script-API ergonomics fixes from an agent-ergonomics review.

- **`readFile()` binary mode** — hardcoded UTF-8 silently corrupted binary (a screenshot read back became replacement chars). Adds `readFile(name, "base64")` for lossless round-trips; default unchanged.
- **`uploadFile()` helper** — uploads required hand-rolling canvas→File→DataTransfer because `setInputFiles({path})` fails in the sandbox. Adds a daemon-side helper that calls real Playwright `setInputFiles` with a `FilePayload` buffer (which works). Verified landing a real file on a real page.
- **domCua node ids** now start small/sequential (1,2,3…) matching the `--help` examples, via a navigation-proof per-document seed so cross-document ids never collide.
- **Split the collapsed "DOM node N is stale" error** into four actionable messages (unknown id / frame gone / element gone / scroll timeout).
- **`addInitScript()`** now fails fast with an authored message for all forms (unworkable in the sandbox — inject via `page.evaluate()` after navigation).
- **Doc honesty** in the embedded `--help` guide (sandbox exceptions to "full Playwright Page objects").

New vitest coverage; full daemon suite green.