### PR TITLE
CLI: --json, capabilities, --version, stop --browser, exit-code dictionary, doctor, crash logging

### DIFF
--- a/cli/src/connection.rs
+++ b/cli/src/connection.rs
@@ -93,11 +93,51 @@ pub fn read_line<R: BufRead>(reader: &mut R) -> io::Result<String> {
     let bytes_read = reader.read_line(&mut line)?;
 
     if bytes_read == 0 {
+        let hint = match crate::daemon::daemon_log_path() {
+            Ok(path) => format!(" Check the daemon log for details: {}", path.display()),
+            Err(_) => String::new(),
+        };
+
         return Err(io::Error::new(
             io::ErrorKind::UnexpectedEof,
-            "Daemon connection closed unexpectedly",
+            format!("Daemon connection closed unexpectedly.{hint}"),
         ));
     }
 
     Ok(line)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::read_line;
+    use std::io::Cursor;
+
+    #[test]
+    fn read_line_reports_closed_connection_with_log_hint() {
+        let mut reader = Cursor::new(Vec::<u8>::new());
+        let error = read_line(&mut reader).expect_err("an empty stream should report EOF");
+        let message = error.to_string();
+
+        assert!(
+            message.starts_with("Daemon connection closed unexpectedly"),
+            "unexpected message: {message}"
+        );
+
+        // The log-path hint is only appended when the home directory
+        // resolves (it always should in a normal test/CI environment), but
+        // don't hard-fail the test if a sandbox lacks HOME entirely.
+        if let Ok(path) = crate::daemon::daemon_log_path() {
+            assert!(
+                message.contains(&path.display().to_string()),
+                "expected the daemon log path in: {message}"
+            );
+        }
+    }
+
+    #[test]
+    fn read_line_returns_the_line_when_data_is_present() {
+        let mut reader = Cursor::new(b"hello\n".to_vec());
+        let line = read_line(&mut reader).expect("a non-empty stream should read a line");
+        assert_eq!(line, "hello\n");
+    }
 }

--- a/cli/src/daemon.rs
+++ b/cli/src/daemon.rs
@@ -342,7 +342,7 @@ fn open_daemon_log_file() -> io::Result<fs::File> {
         .open(&log_path)
 }
 
-fn daemon_logs_dir() -> io::Result<PathBuf> {
+pub(crate) fn daemon_logs_dir() -> io::Result<PathBuf> {
     dirs::home_dir()
         .map(|path| path.join(DEV_BROWSER_DIR).join("logs"))
         .ok_or_else(|| {
@@ -351,6 +351,21 @@ fn daemon_logs_dir() -> io::Result<PathBuf> {
                 "Could not determine the home directory for daemon logs.",
             )
         })
+}
+
+/// Path to `~/.dev-browser/tmp/` — the sandbox script API's scratch
+/// directory (`saveScreenshot`/`writeFile`/`readFile`, documented in
+/// `CLI_LONG_ABOUT`). Exposed for `doctor`'s disk-usage report and GC plan.
+pub(crate) fn tmp_dir() -> Result<PathBuf, Box<dyn Error>> {
+    Ok(daemon_base_dir()?.join("tmp"))
+}
+
+/// Path to `~/.dev-browser/browsers/` — per-name Chromium profile storage
+/// (`browsers/<name>/chromium-profile`, matching `browser-manager.ts`'s
+/// default `baseDir`). Exposed for `doctor`'s disk-usage report, stale
+/// profile listing, and (opt-in) GC plan.
+pub(crate) fn browsers_dir() -> Result<PathBuf, Box<dyn Error>> {
+    Ok(daemon_base_dir()?.join("browsers"))
 }
 
 /// Path to the daemon's stdout/stderr log file. Referenced from the
@@ -446,7 +461,7 @@ fn find_tsx_cli(entry: &Path) -> Result<PathBuf, Box<dyn Error>> {
     )
 }
 
-fn daemon_base_dir() -> Result<PathBuf, Box<dyn Error>> {
+pub(crate) fn daemon_base_dir() -> Result<PathBuf, Box<dyn Error>> {
     dirs::home_dir()
         .map(|path| path.join(DEV_BROWSER_DIR))
         .ok_or_else(|| {
@@ -640,5 +655,21 @@ mod tests {
     fn tool_environment_error_displays_its_message() {
         let error = ToolEnvironmentError("boom".to_string());
         assert_eq!(error.to_string(), "boom");
+    }
+
+    // --- P3-6: doctor's path helpers ---------------------------------------
+
+    #[test]
+    fn tmp_dir_is_under_base_dir() {
+        let base = daemon_base_dir().expect("home dir should resolve in tests");
+        let tmp = tmp_dir().expect("tmp dir should resolve");
+        assert_eq!(tmp, base.join("tmp"));
+    }
+
+    #[test]
+    fn browsers_dir_is_under_base_dir() {
+        let base = daemon_base_dir().expect("home dir should resolve in tests");
+        let browsers = browsers_dir().expect("browsers dir should resolve");
+        assert_eq!(browsers, base.join("browsers"));
     }
 }

--- a/cli/src/daemon.rs
+++ b/cli/src/daemon.rs
@@ -32,6 +32,23 @@ struct DaemonCommand {
     requires_runtime_install: bool,
 }
 
+/// Marks an error as caused by the local tool environment — a missing
+/// runtime dependency, the daemon failing to start/stop, or Chromium failing
+/// to actually launch after `install` — rather than a generic CLI-side
+/// failure or an upstream/script failure reported by the daemon itself.
+/// `main.rs` downcasts to this type to select exit code 3 (tool-environment)
+/// instead of the generic exit code 1.
+#[derive(Debug)]
+pub struct ToolEnvironmentError(pub String);
+
+impl std::fmt::Display for ToolEnvironmentError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl Error for ToolEnvironmentError {}
+
 pub fn ensure_daemon() -> Result<(), Box<dyn Error>> {
     if is_daemon_running() {
         return Ok(());
@@ -47,9 +64,11 @@ pub fn ensure_daemon() -> Result<(), Box<dyn Error>> {
 
     let command = find_daemon_command()?;
     if command.requires_runtime_install && !embedded_runtime_installed(&command.current_dir) {
-        return Err(
-            "Embedded daemon dependencies are missing. Run `dev-browser install` first.".into(),
-        );
+        return Err(ToolEnvironmentError(
+            "Embedded daemon dependencies are missing. Run `dev-browser install` first."
+                .to_string(),
+        )
+        .into());
     }
 
     spawn_daemon(&command)?;
@@ -62,7 +81,11 @@ pub fn ensure_daemon() -> Result<(), Box<dyn Error>> {
         }
     }
 
-    Err("Daemon failed to start within 5 seconds".into())
+    Err(ToolEnvironmentError(format!(
+        "Daemon failed to start within 5 seconds. Check the daemon log for details: {}",
+        daemon_log_path_display()
+    ))
+    .into())
 }
 
 pub fn ensure_daemon_extracted() -> Result<PathBuf, Box<dyn Error>> {
@@ -88,7 +111,68 @@ pub fn install_daemon_runtime() -> Result<(), Box<dyn Error>> {
         &["exec", "--", "playwright", "install", "chromium"],
         &base_dir,
     )?;
+    // npm/playwright exiting 0 doesn't guarantee Chromium can actually
+    // launch (missing system libs, corrupted download, etc. have all
+    // previously reported success here). Probe a real launch before telling
+    // the caller `install` succeeded.
+    verify_chromium_launches(&base_dir)?;
     Ok(())
+}
+
+const CHROMIUM_LAUNCH_PROBE: &str = r#"import { chromium } from "playwright-core";
+
+try {
+  const browser = await chromium.launch({ headless: true });
+  await browser.close();
+  process.exit(0);
+} catch (error) {
+  process.stderr.write(String((error && error.stack) || error) + "\n");
+  process.exit(1);
+}
+"#;
+
+fn verify_chromium_launches(base_dir: &Path) -> Result<(), Box<dyn Error>> {
+    let probe_path = base_dir.join(format!(".chromium-launch-probe.{}.mjs", std::process::id()));
+    fs::write(&probe_path, CHROMIUM_LAUNCH_PROBE)?;
+
+    let run_result = Command::new("node")
+        .arg(&probe_path)
+        .current_dir(base_dir)
+        .output();
+
+    let _ = fs::remove_file(&probe_path);
+
+    let output = run_result.map_err(|error| -> Box<dyn Error> {
+        match error.kind() {
+            io::ErrorKind::NotFound => ToolEnvironmentError(
+                "Could not find `node` in PATH while verifying the Chromium install.".to_string(),
+            )
+            .into(),
+            _ => format!("Failed to run the Chromium launch probe: {error}").into(),
+        }
+    })?;
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    interpret_chromium_probe_result(output.status.success(), &stderr)
+        .map_err(|message| ToolEnvironmentError(message).into())
+}
+
+/// Pure decision logic split out from `verify_chromium_launches` so it can
+/// be unit tested without actually spawning `node`/Chromium.
+fn interpret_chromium_probe_result(success: bool, stderr: &str) -> Result<(), String> {
+    if success {
+        return Ok(());
+    }
+
+    let detail = stderr.trim();
+    Err(format!(
+        "`dev-browser install` finished, but Chromium failed to actually launch.{}\nThis usually means a system dependency is missing (see https://playwright.dev/docs/browsers#install-system-dependencies) or the Chromium binary is corrupted — try running `dev-browser install` again.",
+        if detail.is_empty() {
+            String::new()
+        } else {
+            format!("\n{detail}")
+        }
+    ))
 }
 
 pub fn is_daemon_running() -> bool {
@@ -133,20 +217,91 @@ pub fn wait_for_daemon_exit(pid: i32, timeout: Duration) -> Result<(), Box<dyn E
         thread::sleep(Duration::from_millis(100));
     }
 
-    Err(format!("Daemon failed to stop within {} seconds", timeout.as_secs()).into())
+    Err(ToolEnvironmentError(format!(
+        "Daemon failed to stop within {} seconds. Check the daemon log for details: {}",
+        timeout.as_secs(),
+        daemon_log_path_display()
+    ))
+    .into())
 }
 
-fn daemon_has_exited(_pid: i32, daemon_unreachable: bool) -> bool {
-    daemon_unreachable
+/// A daemon is considered gone only once BOTH signals agree: its control
+/// socket is unreachable AND its recorded pid is no longer a live process.
+/// Socket-unreachability alone is not sufficient — it can also mean the
+/// daemon is mid-shutdown (still tearing down browsers) or, in principle,
+/// that a stale pid file points at an unrelated process. Consulting the pid
+/// closes both gaps.
+fn daemon_has_exited(pid: i32, daemon_unreachable: bool) -> bool {
+    daemon_unreachable && !pid_is_running(pid)
+}
+
+#[cfg(unix)]
+fn pid_is_running(pid: i32) -> bool {
+    if pid <= 0 {
+        return false;
+    }
+
+    // SAFETY: signal 0 sends no actual signal; kill(2) only performs its
+    // existence/permission checks and reports the result via the return
+    // value / errno.
+    unsafe { libc::kill(pid, 0) == 0 }
+}
+
+#[cfg(windows)]
+fn pid_is_running(pid: i32) -> bool {
+    use std::ffi::c_void;
+
+    // Minimal raw bindings to avoid pulling in an extra crate just for a
+    // liveness check. Mirrors the standard OpenProcess/GetExitCodeProcess
+    // pattern used to check whether a pid is still alive on Windows.
+    #[link(name = "kernel32")]
+    extern "system" {
+        fn OpenProcess(
+            dw_desired_access: u32,
+            b_inherit_handle: i32,
+            dw_process_id: u32,
+        ) -> *mut c_void;
+        fn CloseHandle(h_object: *mut c_void) -> i32;
+        fn GetExitCodeProcess(h_process: *mut c_void, lp_exit_code: *mut u32) -> i32;
+    }
+
+    const PROCESS_QUERY_LIMITED_INFORMATION: u32 = 0x1000;
+    const STILL_ACTIVE: u32 = 259;
+
+    if pid <= 0 {
+        return false;
+    }
+
+    unsafe {
+        let handle = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, 0, pid as u32);
+        if handle.is_null() {
+            return false;
+        }
+
+        let mut exit_code: u32 = 0;
+        let got_exit_code = GetExitCodeProcess(handle, &mut exit_code as *mut u32);
+        CloseHandle(handle);
+
+        got_exit_code != 0 && exit_code == STILL_ACTIVE
+    }
 }
 
 fn spawn_daemon(command: &DaemonCommand) -> io::Result<()> {
+    // Daemon stdout/stderr are redirected to a log file rather than
+    // discarded: a daemon crash (uncaught exception, disk-full, etc.) used
+    // to be structurally invisible, surfacing only as a generic "Daemon
+    // connection closed unexpectedly" on the client side. See
+    // daemon_log_path() / the hints threaded through connection.rs and the
+    // start/stop-timeout errors above.
+    let stdout_log = open_daemon_log_file()?;
+    let stderr_log = stdout_log.try_clone()?;
+
     let mut process = Command::new(&command.program);
     process.args(&command.args);
     process.current_dir(&command.current_dir);
     process.stdin(Stdio::null());
-    process.stdout(Stdio::null());
-    process.stderr(Stdio::null());
+    process.stdout(Stdio::from(stdout_log));
+    process.stderr(Stdio::from(stderr_log));
 
     #[cfg(unix)]
     unsafe {
@@ -160,6 +315,59 @@ fn spawn_daemon(command: &DaemonCommand) -> io::Result<()> {
 
     let _child = process.spawn()?;
     Ok(())
+}
+
+/// Cap on the daemon log before it gets rotated on the next spawn. Kept
+/// simple (single `.1` backup, checked at spawn time) rather than a full
+/// rotation scheme — the daemon spawns rarely (only on cold start), so this
+/// is enough to bound disk usage without adding a background rotation task.
+const DAEMON_LOG_MAX_BYTES: u64 = 5 * 1024 * 1024;
+
+fn open_daemon_log_file() -> io::Result<fs::File> {
+    let logs_dir = daemon_logs_dir()?;
+    fs::create_dir_all(&logs_dir)?;
+    let log_path = logs_dir.join("daemon.log");
+
+    if let Ok(metadata) = fs::metadata(&log_path) {
+        if metadata.len() > DAEMON_LOG_MAX_BYTES {
+            let rotated_path = logs_dir.join("daemon.log.1");
+            let _ = fs::remove_file(&rotated_path);
+            let _ = fs::rename(&log_path, &rotated_path);
+        }
+    }
+
+    fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&log_path)
+}
+
+fn daemon_logs_dir() -> io::Result<PathBuf> {
+    dirs::home_dir()
+        .map(|path| path.join(DEV_BROWSER_DIR).join("logs"))
+        .ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::NotFound,
+                "Could not determine the home directory for daemon logs.",
+            )
+        })
+}
+
+/// Path to the daemon's stdout/stderr log file. Referenced from the
+/// connection-closed error (connection.rs) and the start/stop-timeout
+/// errors above so an agent hitting an opaque daemon failure has a concrete
+/// next step instead of just "Daemon connection closed unexpectedly".
+pub fn daemon_log_path() -> io::Result<PathBuf> {
+    Ok(daemon_logs_dir()?.join("daemon.log"))
+}
+
+/// `daemon_log_path()` with a best-effort display fallback for error
+/// messages that can't propagate an inner io::Error (e.g. because they're
+/// already being constructed as a `String` inside a `ToolEnvironmentError`).
+fn daemon_log_path_display() -> String {
+    daemon_log_path()
+        .map(|path| path.display().to_string())
+        .unwrap_or_else(|_| "~/.dev-browser/logs/daemon.log".to_string())
 }
 
 fn daemon_pid() -> Option<i32> {
@@ -229,14 +437,24 @@ fn find_tsx_cli(entry: &Path) -> Result<PathBuf, Box<dyn Error>> {
         }
     }
 
-    Err("Could not locate the tsx runtime required to launch the TypeScript daemon.".into())
+    Err(
+        ToolEnvironmentError(
+            "Could not locate the tsx runtime required to launch the TypeScript daemon."
+                .to_string(),
+        )
+        .into(),
+    )
 }
 
 fn daemon_base_dir() -> Result<PathBuf, Box<dyn Error>> {
     dirs::home_dir()
         .map(|path| path.join(DEV_BROWSER_DIR))
         .ok_or_else(|| {
-            "Could not determine the home directory for the embedded daemon runtime.".into()
+            ToolEnvironmentError(
+                "Could not determine the home directory for the embedded daemon runtime."
+                    .to_string(),
+            )
+            .into()
         })
 }
 
@@ -294,16 +512,16 @@ fn run_install_command(
         .status()
         .map_err(|error| -> Box<dyn Error> {
             match error.kind() {
-                io::ErrorKind::NotFound => format!(
+                io::ErrorKind::NotFound => ToolEnvironmentError(format!(
                     "Could not find `{program}` in PATH while setting up the embedded daemon runtime in {}. Install Node.js/npm and run `dev-browser install` again.",
                     current_dir.display()
-                )
+                ))
                 .into(),
-                _ => format!(
+                _ => ToolEnvironmentError(format!(
                     "Failed to run `{program} {}` in {}: {error}",
                     args.join(" "),
                     current_dir.display()
-                )
+                ))
                 .into(),
             }
         })?;
@@ -320,5 +538,107 @@ fn run_install_command(
         None => format!("`{program} {}` terminated by signal", args.join(" ")),
     };
 
-    Err(reason.into())
+    Err(ToolEnvironmentError(reason).into())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // --- CLI-03: daemon_has_exited must actually consult the pid ----------
+
+    #[test]
+    fn daemon_has_exited_false_for_a_live_pid_even_if_socket_unreachable() {
+        // Regression test for the bug: the old implementation ignored `pid`
+        // entirely and returned `daemon_unreachable` verbatim, so `stop`
+        // could report success purely because the socket was momentarily
+        // unreachable while the daemon was still alive/mid-shutdown.
+        let live_pid = std::process::id() as i32;
+        assert!(!daemon_has_exited(live_pid, true));
+    }
+
+    #[test]
+    fn daemon_has_exited_false_while_socket_is_still_reachable() {
+        assert!(!daemon_has_exited(i32::MAX, false));
+    }
+
+    #[test]
+    fn daemon_has_exited_true_when_socket_unreachable_and_pid_gone() {
+        assert!(daemon_has_exited(i32::MAX, true));
+    }
+
+    #[test]
+    fn pid_is_running_true_for_own_process() {
+        assert!(pid_is_running(std::process::id() as i32));
+    }
+
+    #[test]
+    fn pid_is_running_false_for_non_positive_pid() {
+        assert!(!pid_is_running(0));
+        assert!(!pid_is_running(-1));
+    }
+
+    // --- P1-3: daemon crash logging ----------------------------------------
+
+    #[test]
+    fn daemon_log_path_is_under_dev_browser_logs_dir() {
+        let path = daemon_log_path().expect("home dir should resolve in the test environment");
+        assert_eq!(
+            path.file_name().and_then(|name| name.to_str()),
+            Some("daemon.log")
+        );
+
+        let parent = path.parent().expect("daemon.log should have a parent dir");
+        assert_eq!(
+            parent.file_name().and_then(|name| name.to_str()),
+            Some("logs")
+        );
+
+        let grandparent = parent
+            .parent()
+            .expect("logs dir should have a parent dir");
+        assert_eq!(
+            grandparent.file_name().and_then(|name| name.to_str()),
+            Some(DEV_BROWSER_DIR)
+        );
+    }
+
+    #[test]
+    fn daemon_log_path_display_never_panics_and_mentions_daemon_log() {
+        let display = daemon_log_path_display();
+        assert!(display.ends_with("daemon.log"));
+    }
+
+    // --- P3-4: Chromium launch verification (pure decision logic) ---------
+
+    #[test]
+    fn chromium_probe_success_returns_ok() {
+        assert!(interpret_chromium_probe_result(true, "").is_ok());
+    }
+
+    #[test]
+    fn chromium_probe_failure_names_hint_and_includes_stderr_detail() {
+        let error =
+            interpret_chromium_probe_result(false, "libnss3.so: cannot open shared object file")
+                .expect_err("a failed probe must be Err");
+        assert!(error.contains("Chromium failed to actually launch"));
+        assert!(error.contains("libnss3.so"));
+        assert!(error.contains("dev-browser install"));
+    }
+
+    #[test]
+    fn chromium_probe_failure_without_stderr_still_names_the_hint() {
+        let error = interpret_chromium_probe_result(false, "")
+            .expect_err("a failed probe must be Err even with empty stderr");
+        assert!(error.contains("Chromium failed to actually launch"));
+        assert!(error.contains("install-system-dependencies"));
+    }
+
+    // --- P0-4: ToolEnvironmentError is a real std::error::Error -----------
+
+    #[test]
+    fn tool_environment_error_displays_its_message() {
+        let error = ToolEnvironmentError("boom".to_string());
+        assert_eq!(error.to_string(), "boom");
+    }
 }

--- a/cli/src/doctor.rs
+++ b/cli/src/doctor.rs
@@ -1,0 +1,903 @@
+//! `dev-browser doctor` — read-only diagnostics for the on-disk state under
+//! `~/.dev-browser/` (daemon status, disk usage, stale named-browser
+//! profiles), plus an opt-in, dry-run-by-default garbage collector for that
+//! same directory tree.
+//!
+//! Closes the field finding that `~/.dev-browser/tmp/` (163 MB / 531 files
+//! observed) and `~/.dev-browser/browsers/` (1.4 GB / 25 stale profiles
+//! observed) have no GC path, which has forced agents into a blocked
+//! `rm -rf` (P3-6 in `agent_ergonomics_audit/audit/playbook.md`).
+//!
+//! Safety model: `doctor --gc` only ever *plans* deletion — it prints what
+//! would be removed and never touches disk — until `--yes` is also passed.
+//! Named browser profiles (which can hold logged-in session state) are never
+//! GC candidates unless `--include-browser-profiles` is passed too. Every
+//! delete is re-verified with [`is_contained`] immediately before it runs,
+//! so nothing outside `~/.dev-browser` is ever touched even if a plan were
+//! reused after the filesystem changed underneath it.
+
+use std::error::Error;
+use std::fs;
+use std::path::{Component, Path, PathBuf};
+use std::time::SystemTime;
+
+use serde_json::{json, Value};
+
+use crate::daemon::{
+    browsers_dir, current_daemon_pid, daemon_base_dir, daemon_log_path, daemon_logs_dir,
+    is_daemon_running, tmp_dir,
+};
+
+/// Default staleness threshold, in days of inactivity, before a named
+/// browser profile is flagged in `doctor` output and becomes a GC candidate
+/// when `--gc --include-browser-profiles` is passed.
+pub const DEFAULT_STALE_DAYS: u64 = 30;
+
+/// Default minimum age, in days, before a `tmp/` entry is eligible for GC.
+/// Conservative on purpose: `doctor --gc` still only *plans* deletion until
+/// `--yes` is also passed, but the age floor avoids ever listing a file an
+/// agent wrote moments ago in a concurrent session.
+pub const DEFAULT_MIN_AGE_DAYS: u64 = 1;
+
+const SECONDS_PER_DAY: u64 = 24 * 60 * 60;
+
+pub struct DoctorOptions {
+    pub json: bool,
+    pub gc: bool,
+    pub confirm: bool,
+    pub include_browser_profiles: bool,
+    pub stale_days: u64,
+    pub min_age_days: u64,
+}
+
+/// Disk-usage snapshot for one directory under `~/.dev-browser/`.
+#[derive(Debug, Clone)]
+struct DirReport {
+    label: &'static str,
+    path: PathBuf,
+    exists: bool,
+    total_bytes: u64,
+    file_count: u64,
+}
+
+/// One named browser profile directory under `~/.dev-browser/browsers/`.
+#[derive(Debug, Clone)]
+struct BrowserProfileReport {
+    name: String,
+    path: PathBuf,
+    total_bytes: u64,
+    file_count: u64,
+    age_days: Option<u64>,
+    stale: bool,
+}
+
+/// A single GC candidate — a `tmp/` entry or (opt-in) a stale browser
+/// profile — with the size that would be reclaimed if deleted.
+#[derive(Debug, Clone)]
+struct GcCandidate {
+    kind: &'static str,
+    path: PathBuf,
+    bytes: u64,
+    age_days: Option<u64>,
+}
+
+struct GcResult {
+    deleted: Vec<GcCandidate>,
+    failed: Vec<(PathBuf, String)>,
+    reclaimed_bytes: u64,
+}
+
+struct DoctorReport {
+    base_dir: PathBuf,
+    base_dir_exists: bool,
+    daemon_running: bool,
+    daemon_pid: Option<i32>,
+    log_path: Option<PathBuf>,
+    dirs: Vec<DirReport>,
+    browser_profiles: Vec<BrowserProfileReport>,
+    stale_days: u64,
+}
+
+pub fn run_doctor(options: DoctorOptions) -> Result<i32, Box<dyn Error>> {
+    if options.confirm && !options.gc {
+        eprintln!("Warning: --yes has no effect without --gc; nothing was planned to delete.");
+    }
+    if options.include_browser_profiles && !options.gc {
+        eprintln!("Warning: --include-browser-profiles has no effect without --gc.");
+    }
+
+    let report = build_report(options.stale_days)?;
+
+    let gc_plan = if options.gc {
+        Some(build_gc_plan(&report, &options))
+    } else {
+        None
+    };
+
+    let gc_result = match (&gc_plan, options.confirm) {
+        (Some(plan), true) => Some(execute_gc_plan(&report.base_dir, plan)),
+        _ => None,
+    };
+
+    if options.json {
+        print_json(&report, gc_plan.as_deref(), gc_result.as_ref(), &options);
+    } else {
+        print_human(&report, gc_plan.as_deref(), gc_result.as_ref(), &options);
+    }
+
+    Ok(0)
+}
+
+fn build_report(stale_days: u64) -> Result<DoctorReport, Box<dyn Error>> {
+    let base_dir = daemon_base_dir()?;
+    let base_dir_exists = base_dir.is_dir();
+
+    let daemon_running = is_daemon_running();
+    let daemon_pid = current_daemon_pid();
+    let log_path = daemon_log_path().ok();
+
+    let tmp_path = tmp_dir()?;
+    let browsers_path = browsers_dir()?;
+    let logs_path = daemon_logs_dir().unwrap_or_else(|_| base_dir.join("logs"));
+
+    let dirs = vec![
+        dir_report("tmp", tmp_path),
+        dir_report("browsers", browsers_path.clone()),
+        dir_report("logs", logs_path),
+    ];
+
+    let browser_profiles = list_browser_profiles(&browsers_path, stale_days);
+
+    Ok(DoctorReport {
+        base_dir,
+        base_dir_exists,
+        daemon_running,
+        daemon_pid,
+        log_path,
+        dirs,
+        browser_profiles,
+        stale_days,
+    })
+}
+
+fn dir_report(label: &'static str, path: PathBuf) -> DirReport {
+    if !path.is_dir() {
+        return DirReport {
+            label,
+            path,
+            exists: false,
+            total_bytes: 0,
+            file_count: 0,
+        };
+    }
+
+    let walk = walk_dir(&path);
+    DirReport {
+        label,
+        path,
+        exists: true,
+        total_bytes: walk.total_bytes,
+        file_count: walk.file_count,
+    }
+}
+
+fn list_browser_profiles(browsers_path: &Path, stale_days: u64) -> Vec<BrowserProfileReport> {
+    let mut profiles = Vec::new();
+    let entries = match fs::read_dir(browsers_path) {
+        Ok(entries) => entries,
+        Err(_) => return profiles,
+    };
+
+    let now = SystemTime::now();
+
+    for entry in entries.flatten() {
+        let is_dir = entry.file_type().map(|ft| ft.is_dir()).unwrap_or(false);
+        if !is_dir {
+            continue;
+        }
+
+        let path = entry.path();
+        let name = entry.file_name().to_string_lossy().into_owned();
+        let walk = walk_dir(&path);
+        let age_days = age_in_days(walk.newest_modified, now);
+        let stale = age_days.map(|days| days >= stale_days).unwrap_or(false);
+
+        profiles.push(BrowserProfileReport {
+            name,
+            path,
+            total_bytes: walk.total_bytes,
+            file_count: walk.file_count,
+            age_days,
+            stale,
+        });
+    }
+
+    profiles.sort_by(|a, b| b.total_bytes.cmp(&a.total_bytes));
+    profiles
+}
+
+fn age_in_days(modified: Option<SystemTime>, now: SystemTime) -> Option<u64> {
+    modified
+        .and_then(|modified| now.duration_since(modified).ok())
+        .map(|elapsed| elapsed.as_secs() / SECONDS_PER_DAY)
+}
+
+struct DirWalk {
+    total_bytes: u64,
+    file_count: u64,
+    newest_modified: Option<SystemTime>,
+}
+
+/// Recursively sums file sizes/counts under `root` and tracks the newest
+/// file-modification time seen, used as a lightweight "last used" signal for
+/// staleness. Symlinks are skipped rather than followed (`entry.file_type()`
+/// does not follow symlinks), avoiding both double-counting and the
+/// possibility of an infinite cycle from a symlink loop.
+fn walk_dir(root: &Path) -> DirWalk {
+    let mut total_bytes = 0u64;
+    let mut file_count = 0u64;
+    let mut newest_modified: Option<SystemTime> = None;
+    let mut stack = vec![root.to_path_buf()];
+
+    while let Some(dir) = stack.pop() {
+        let entries = match fs::read_dir(&dir) {
+            Ok(entries) => entries,
+            Err(_) => continue,
+        };
+
+        for entry in entries.flatten() {
+            let file_type = match entry.file_type() {
+                Ok(file_type) => file_type,
+                Err(_) => continue,
+            };
+
+            if file_type.is_dir() {
+                stack.push(entry.path());
+                continue;
+            }
+
+            if !file_type.is_file() {
+                continue;
+            }
+
+            if let Ok(metadata) = entry.metadata() {
+                total_bytes += metadata.len();
+                file_count += 1;
+
+                if let Ok(modified) = metadata.modified() {
+                    newest_modified = Some(match newest_modified {
+                        Some(current) if current >= modified => current,
+                        _ => modified,
+                    });
+                }
+            }
+        }
+    }
+
+    DirWalk {
+        total_bytes,
+        file_count,
+        newest_modified,
+    }
+}
+
+/// True only if `candidate` is lexically inside `root`, with no `..`
+/// component anywhere that could walk it back outside — the guard every GC
+/// deletion path is required to pass before touching disk.
+/// `Path::starts_with` alone is not sufficient: it compares components
+/// without resolving `..`, so e.g. `root.join("browsers/../../etc")` still
+/// satisfies `starts_with(root)`.
+fn is_contained(root: &Path, candidate: &Path) -> bool {
+    candidate.starts_with(root)
+        && !candidate
+            .components()
+            .any(|component| matches!(component, Component::ParentDir))
+}
+
+fn build_gc_plan(report: &DoctorReport, options: &DoctorOptions) -> Vec<GcCandidate> {
+    let mut candidates = Vec::new();
+    let now = SystemTime::now();
+
+    if let Some(tmp_report) = report.dirs.iter().find(|dir| dir.label == "tmp") {
+        if tmp_report.exists {
+            candidates.extend(tmp_gc_candidates(
+                &report.base_dir,
+                &tmp_report.path,
+                options.min_age_days,
+                now,
+            ));
+        }
+    }
+
+    if options.include_browser_profiles {
+        for profile in &report.browser_profiles {
+            if profile.stale && is_contained(&report.base_dir, &profile.path) {
+                candidates.push(GcCandidate {
+                    kind: "browser-profile",
+                    path: profile.path.clone(),
+                    bytes: profile.total_bytes,
+                    age_days: profile.age_days,
+                });
+            }
+        }
+    }
+
+    candidates
+}
+
+/// Lists direct children of `tmp/` (files or subdirectories) whose newest
+/// contained file is at least `min_age_days` old. Each direct child is a
+/// single GC unit — the whole subtree deletes together — since agents
+/// address `tmp/` entries by their top-level name (`saveScreenshot`,
+/// `writeFile`). Every candidate is re-checked with [`is_contained`] against
+/// `base_dir`, so even a caller bug that pointed `tmp_path` outside
+/// `base_dir` could never surface a candidate outside it.
+fn tmp_gc_candidates(
+    base_dir: &Path,
+    tmp_path: &Path,
+    min_age_days: u64,
+    now: SystemTime,
+) -> Vec<GcCandidate> {
+    let mut candidates = Vec::new();
+    let entries = match fs::read_dir(tmp_path) {
+        Ok(entries) => entries,
+        Err(_) => return candidates,
+    };
+
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if !is_contained(base_dir, &path) {
+            continue;
+        }
+
+        let (bytes, age_days) = match entry.file_type() {
+            Ok(file_type) if file_type.is_dir() => {
+                let walk = walk_dir(&path);
+                (walk.total_bytes, age_in_days(walk.newest_modified, now))
+            }
+            _ => {
+                let metadata = match entry.metadata() {
+                    Ok(metadata) => metadata,
+                    Err(_) => continue,
+                };
+                let age = age_in_days(metadata.modified().ok(), now);
+                (metadata.len(), age)
+            }
+        };
+
+        let eligible = age_days.map(|days| days >= min_age_days).unwrap_or(false);
+        if eligible {
+            candidates.push(GcCandidate {
+                kind: "tmp-entry",
+                path,
+                bytes,
+                age_days,
+            });
+        }
+    }
+
+    candidates
+}
+
+/// Deletes every candidate in `plan`. Every path is re-verified against
+/// [`is_contained`] immediately before the delete call (not just when the
+/// plan was built) — belt-and-suspenders against a plan being reused after
+/// on-disk state changed. Only ever called when the caller has already
+/// confirmed `--gc --yes`.
+fn execute_gc_plan(base_dir: &Path, plan: &[GcCandidate]) -> GcResult {
+    let mut deleted = Vec::new();
+    let mut failed = Vec::new();
+    let mut reclaimed_bytes = 0u64;
+
+    for candidate in plan {
+        if !is_contained(base_dir, &candidate.path) {
+            failed.push((
+                candidate.path.clone(),
+                "refused: path is not contained within ~/.dev-browser".to_string(),
+            ));
+            continue;
+        }
+
+        let result = if candidate.path.is_dir() {
+            fs::remove_dir_all(&candidate.path)
+        } else {
+            fs::remove_file(&candidate.path)
+        };
+
+        match result {
+            Ok(()) => {
+                reclaimed_bytes += candidate.bytes;
+                deleted.push(candidate.clone());
+            }
+            Err(error) => failed.push((candidate.path.clone(), error.to_string())),
+        }
+    }
+
+    GcResult {
+        deleted,
+        failed,
+        reclaimed_bytes,
+    }
+}
+
+/// Formats a byte count for humans (`1536` -> `"1.5 KB"`). Kept as a pure
+/// function so it's independently unit-testable.
+fn human_size(bytes: u64) -> String {
+    const UNITS: [&str; 5] = ["B", "KB", "MB", "GB", "TB"];
+
+    if bytes < 1024 {
+        return format!("{bytes} B");
+    }
+
+    let mut size = bytes as f64;
+    let mut unit_index = 0usize;
+    while size >= 1024.0 && unit_index < UNITS.len() - 1 {
+        size /= 1024.0;
+        unit_index += 1;
+    }
+
+    format!("{size:.1} {}", UNITS[unit_index])
+}
+
+fn print_human(
+    report: &DoctorReport,
+    gc_plan: Option<&[GcCandidate]>,
+    gc_result: Option<&GcResult>,
+    options: &DoctorOptions,
+) {
+    println!("dev-browser doctor");
+    println!();
+    println!("Base dir: {}", report.base_dir.display());
+    if !report.base_dir_exists {
+        println!("  (does not exist yet -- nothing has run that touches ~/.dev-browser)");
+    }
+    println!(
+        "Daemon: {}",
+        match (report.daemon_running, report.daemon_pid) {
+            (true, Some(pid)) => format!("running (pid {pid})"),
+            (true, None) => "running (pid unknown)".to_string(),
+            (false, _) => "not running".to_string(),
+        }
+    );
+    if let Some(log_path) = &report.log_path {
+        println!("Daemon log: {}", log_path.display());
+    }
+    println!();
+
+    println!("Disk usage:");
+    for dir in &report.dirs {
+        if dir.exists {
+            println!(
+                "  {:<10} {:>10}  ({} files)  {}",
+                dir.label,
+                human_size(dir.total_bytes),
+                dir.file_count,
+                dir.path.display()
+            );
+        } else {
+            println!("  {:<10} (missing)  {}", dir.label, dir.path.display());
+        }
+    }
+    println!();
+
+    if report.browser_profiles.is_empty() {
+        println!("Browser profiles: none.");
+    } else {
+        println!(
+            "Browser profiles ({} total, stale threshold {} days):",
+            report.browser_profiles.len(),
+            report.stale_days
+        );
+        for profile in &report.browser_profiles {
+            let age = profile
+                .age_days
+                .map(|days| format!("{days}d idle"))
+                .unwrap_or_else(|| "age unknown".to_string());
+            let flag = if profile.stale { "  [STALE]" } else { "" };
+            println!(
+                "  {:<20} {:>10}  {}{}",
+                profile.name,
+                human_size(profile.total_bytes),
+                age,
+                flag
+            );
+        }
+    }
+
+    if let Some(plan) = gc_plan {
+        println!();
+        if plan.is_empty() {
+            println!("GC plan: nothing eligible (nothing older than the configured age thresholds).");
+        } else {
+            let total_bytes: u64 = plan.iter().map(|candidate| candidate.bytes).sum();
+            let verb = if options.confirm { "Deleted" } else { "Would delete" };
+            println!(
+                "GC plan ({} items, {} reclaimable):",
+                plan.len(),
+                human_size(total_bytes)
+            );
+            for candidate in plan {
+                println!(
+                    "  {verb}: [{}] {}  ({})",
+                    candidate.kind,
+                    candidate.path.display(),
+                    human_size(candidate.bytes)
+                );
+            }
+
+            if !options.confirm {
+                println!();
+                println!(
+                    "This was a DRY RUN. Re-run with `--gc --yes` to actually delete these {} items.",
+                    plan.len()
+                );
+            }
+        }
+    }
+
+    if let Some(result) = gc_result {
+        println!();
+        println!(
+            "GC result: deleted {} items, reclaimed {}.",
+            result.deleted.len(),
+            human_size(result.reclaimed_bytes)
+        );
+        for (path, message) in &result.failed {
+            eprintln!("  failed to delete {}: {message}", path.display());
+        }
+    }
+}
+
+fn print_json(
+    report: &DoctorReport,
+    gc_plan: Option<&[GcCandidate]>,
+    gc_result: Option<&GcResult>,
+    options: &DoctorOptions,
+) {
+    let document = json!({
+        "base_dir": report.base_dir.display().to_string(),
+        "base_dir_exists": report.base_dir_exists,
+        "daemon": {
+            "running": report.daemon_running,
+            "pid": report.daemon_pid,
+        },
+        "log_path": report.log_path.as_ref().map(|path| path.display().to_string()),
+        "dirs": report.dirs.iter().map(|dir| json!({
+            "label": dir.label,
+            "path": dir.path.display().to_string(),
+            "exists": dir.exists,
+            "total_bytes": dir.total_bytes,
+            "total_human": human_size(dir.total_bytes),
+            "file_count": dir.file_count,
+        })).collect::<Vec<Value>>(),
+        "browser_profiles": report.browser_profiles.iter().map(|profile| json!({
+            "name": profile.name,
+            "path": profile.path.display().to_string(),
+            "total_bytes": profile.total_bytes,
+            "total_human": human_size(profile.total_bytes),
+            "file_count": profile.file_count,
+            "age_days": profile.age_days,
+            "stale": profile.stale,
+        })).collect::<Vec<Value>>(),
+        "stale_days_threshold": report.stale_days,
+        "gc": gc_plan.map(|plan| {
+            json!({
+                "requested": true,
+                "confirmed": options.confirm,
+                "min_age_days": options.min_age_days,
+                "include_browser_profiles": options.include_browser_profiles,
+                "candidates": plan.iter().map(|candidate| json!({
+                    "kind": candidate.kind,
+                    "path": candidate.path.display().to_string(),
+                    "bytes": candidate.bytes,
+                    "age_days": candidate.age_days,
+                })).collect::<Vec<Value>>(),
+                "reclaimable_bytes": plan.iter().map(|candidate| candidate.bytes).sum::<u64>(),
+                "result": gc_result.map(|result| json!({
+                    "deleted_count": result.deleted.len(),
+                    "reclaimed_bytes": result.reclaimed_bytes,
+                    "failed": result.failed.iter().map(|(path, message)| json!({
+                        "path": path.display().to_string(),
+                        "error": message,
+                    })).collect::<Vec<Value>>(),
+                })),
+            })
+        }),
+    });
+
+    println!(
+        "{}",
+        serde_json::to_string_pretty(&document).unwrap_or_else(|_| "{}".to_string())
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::path::PathBuf;
+    use std::time::UNIX_EPOCH;
+
+    fn unique_temp_dir(label: &str) -> PathBuf {
+        let mut path = std::env::temp_dir();
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos();
+        path.push(format!(
+            "dev-browser-doctor-test-{label}-{nonce}-{}",
+            std::process::id()
+        ));
+        fs::create_dir_all(&path).expect("create temp test dir");
+        path
+    }
+
+    // --- human_size ----------------------------------------------------
+
+    #[test]
+    fn human_size_formats_bytes() {
+        assert_eq!(human_size(0), "0 B");
+        assert_eq!(human_size(512), "512 B");
+    }
+
+    #[test]
+    fn human_size_formats_kilobytes() {
+        assert_eq!(human_size(1536), "1.5 KB");
+    }
+
+    #[test]
+    fn human_size_formats_megabytes_and_gigabytes() {
+        assert_eq!(human_size(1_572_864), "1.5 MB");
+        assert_eq!(human_size(1_610_612_736), "1.5 GB");
+    }
+
+    // --- is_contained ----------------------------------------------------
+
+    #[test]
+    fn is_contained_accepts_a_direct_child() {
+        let root = Path::new("/home/user/.dev-browser");
+        let candidate = root.join("tmp").join("screenshot.png");
+        assert!(is_contained(root, &candidate));
+    }
+
+    #[test]
+    fn is_contained_rejects_a_sibling_directory() {
+        let root = Path::new("/home/user/.dev-browser");
+        let candidate = Path::new("/home/user/other-dir/file.txt");
+        assert!(!is_contained(root, &candidate));
+    }
+
+    #[test]
+    fn is_contained_rejects_parent_dir_traversal_even_when_lexically_prefixed() {
+        let root = Path::new("/home/user/.dev-browser");
+        // Lexically this still starts with `root`'s components, which is
+        // exactly why `starts_with` alone is not a safe containment check.
+        let candidate = root
+            .join("browsers")
+            .join("..")
+            .join("..")
+            .join("etc")
+            .join("passwd");
+        assert!(!is_contained(root, &candidate));
+    }
+
+    // --- walk_dir against a real temp dir ---------------------------------
+
+    #[test]
+    fn walk_dir_sums_nested_file_sizes() {
+        let root = unique_temp_dir("walk");
+        fs::write(root.join("a.txt"), b"12345").unwrap();
+        let sub = root.join("sub");
+        fs::create_dir_all(&sub).unwrap();
+        fs::write(sub.join("b.txt"), b"1234567890").unwrap();
+
+        let walk = walk_dir(&root);
+        assert_eq!(walk.total_bytes, 15);
+        assert_eq!(walk.file_count, 2);
+        assert!(walk.newest_modified.is_some());
+
+        fs::remove_dir_all(&root).ok();
+    }
+
+    #[test]
+    fn walk_dir_on_missing_dir_returns_zeroes() {
+        let missing = std::env::temp_dir().join("dev-browser-doctor-test-missing-nonexistent");
+        let walk = walk_dir(&missing);
+        assert_eq!(walk.total_bytes, 0);
+        assert_eq!(walk.file_count, 0);
+        assert!(walk.newest_modified.is_none());
+    }
+
+    // --- tmp_gc_candidates: age-gating -------------------------------------
+
+    #[test]
+    fn tmp_gc_candidates_skips_entries_newer_than_min_age() {
+        let base = unique_temp_dir("gc-fresh");
+        let tmp = base.join("tmp");
+        fs::create_dir_all(&tmp).unwrap();
+        fs::write(tmp.join("fresh.png"), b"data").unwrap();
+
+        let candidates = tmp_gc_candidates(&base, &tmp, 30, SystemTime::now());
+        assert!(
+            candidates.is_empty(),
+            "a just-written file must not be GC-eligible at a 30-day floor"
+        );
+
+        fs::remove_dir_all(&base).ok();
+    }
+
+    #[test]
+    fn tmp_gc_candidates_includes_entries_older_than_min_age() {
+        let base = unique_temp_dir("gc-stale");
+        let tmp = base.join("tmp");
+        fs::create_dir_all(&tmp).unwrap();
+        fs::write(tmp.join("stale.png"), b"data").unwrap();
+
+        // min_age_days = 0 means "anything not newer than right now" is
+        // eligible, without needing to fabricate an old mtime.
+        let candidates = tmp_gc_candidates(&base, &tmp, 0, SystemTime::now());
+        assert_eq!(candidates.len(), 1);
+        assert_eq!(candidates[0].kind, "tmp-entry");
+
+        fs::remove_dir_all(&base).ok();
+    }
+
+    #[test]
+    fn tmp_gc_candidates_never_escapes_base_dir() {
+        // Defense in depth: even if tmp_path were pointed outside base_dir
+        // (a caller bug), tmp_gc_candidates must not surface it as a
+        // candidate, because every entry is re-checked with is_contained.
+        let base = unique_temp_dir("gc-outside-base");
+        let outside_tmp = unique_temp_dir("gc-outside-tmp");
+        fs::write(outside_tmp.join("escaped.png"), b"data").unwrap();
+
+        let candidates = tmp_gc_candidates(&base, &outside_tmp, 0, SystemTime::now());
+        assert!(
+            candidates.is_empty(),
+            "entries outside base_dir must never be GC candidates"
+        );
+
+        fs::remove_dir_all(&base).ok();
+        fs::remove_dir_all(&outside_tmp).ok();
+    }
+
+    // --- execute_gc_plan: containment guard is enforced at delete time ---
+
+    #[test]
+    fn execute_gc_plan_refuses_to_delete_outside_base_dir() {
+        let base = unique_temp_dir("exec-base");
+        let outside = unique_temp_dir("exec-outside");
+        let victim = outside.join("do-not-delete.png");
+        fs::write(&victim, b"data").unwrap();
+
+        let plan = vec![GcCandidate {
+            kind: "tmp-entry",
+            path: victim.clone(),
+            bytes: 4,
+            age_days: Some(10),
+        }];
+
+        let result = execute_gc_plan(&base, &plan);
+        assert_eq!(result.deleted.len(), 0);
+        assert_eq!(result.failed.len(), 1);
+        assert!(
+            victim.exists(),
+            "path outside base_dir must survive execute_gc_plan"
+        );
+
+        fs::remove_dir_all(&base).ok();
+        fs::remove_dir_all(&outside).ok();
+    }
+
+    #[test]
+    fn execute_gc_plan_deletes_contained_candidates_and_reports_reclaimed_bytes() {
+        let base = unique_temp_dir("exec-contained");
+        let tmp = base.join("tmp");
+        fs::create_dir_all(&tmp).unwrap();
+        let victim = tmp.join("old.png");
+        fs::write(&victim, b"12345").unwrap();
+
+        let plan = vec![GcCandidate {
+            kind: "tmp-entry",
+            path: victim.clone(),
+            bytes: 5,
+            age_days: Some(10),
+        }];
+
+        let result = execute_gc_plan(&base, &plan);
+        assert_eq!(result.deleted.len(), 1);
+        assert_eq!(result.reclaimed_bytes, 5);
+        assert!(!victim.exists());
+
+        fs::remove_dir_all(&base).ok();
+    }
+
+    // --- build_gc_plan: dry-run-by-default — a plan alone never deletes --
+
+    #[test]
+    fn build_gc_plan_is_pure_and_never_touches_disk() {
+        let base = unique_temp_dir("plan-only");
+        let tmp = base.join("tmp");
+        fs::create_dir_all(&tmp).unwrap();
+        fs::write(tmp.join("old.png"), b"12345").unwrap();
+
+        let report = DoctorReport {
+            base_dir: base.clone(),
+            base_dir_exists: true,
+            daemon_running: false,
+            daemon_pid: None,
+            log_path: None,
+            dirs: vec![DirReport {
+                label: "tmp",
+                path: tmp.clone(),
+                exists: true,
+                total_bytes: 5,
+                file_count: 1,
+            }],
+            browser_profiles: Vec::new(),
+            stale_days: DEFAULT_STALE_DAYS,
+        };
+        let options = DoctorOptions {
+            json: false,
+            gc: true,
+            confirm: false,
+            include_browser_profiles: false,
+            stale_days: DEFAULT_STALE_DAYS,
+            min_age_days: 0,
+        };
+
+        let plan = build_gc_plan(&report, &options);
+        assert_eq!(plan.len(), 1);
+        assert!(
+            tmp.join("old.png").exists(),
+            "building a plan must never delete"
+        );
+
+        fs::remove_dir_all(&base).ok();
+    }
+
+    #[test]
+    fn build_gc_plan_includes_stale_browser_profiles_only_when_opted_in() {
+        let base = unique_temp_dir("plan-profiles");
+        let profile_path = base.join("browsers").join("stale-one");
+        fs::create_dir_all(&profile_path).unwrap();
+
+        let report = DoctorReport {
+            base_dir: base.clone(),
+            base_dir_exists: true,
+            daemon_running: false,
+            daemon_pid: None,
+            log_path: None,
+            dirs: Vec::new(),
+            browser_profiles: vec![BrowserProfileReport {
+                name: "stale-one".to_string(),
+                path: profile_path,
+                total_bytes: 1024,
+                file_count: 3,
+                age_days: Some(90),
+                stale: true,
+            }],
+            stale_days: DEFAULT_STALE_DAYS,
+        };
+
+        let opted_out = DoctorOptions {
+            json: false,
+            gc: true,
+            confirm: false,
+            include_browser_profiles: false,
+            stale_days: DEFAULT_STALE_DAYS,
+            min_age_days: DEFAULT_MIN_AGE_DAYS,
+        };
+        assert!(build_gc_plan(&report, &opted_out).is_empty());
+
+        let opted_in = DoctorOptions {
+            include_browser_profiles: true,
+            ..opted_out
+        };
+        let plan = build_gc_plan(&report, &opted_in);
+        assert_eq!(plan.len(), 1);
+        assert_eq!(plan[0].kind, "browser-profile");
+
+        fs::remove_dir_all(&base).ok();
+    }
+}

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,5 +1,6 @@
 mod connection;
 mod daemon;
+mod doctor;
 mod skill;
 
 use clap::{CommandFactory, Parser, Subcommand};
@@ -8,6 +9,7 @@ use daemon::{
     current_daemon_pid, ensure_daemon, install_daemon_runtime, is_daemon_running,
     wait_for_daemon_exit,
 };
+use doctor::{run_doctor, DoctorOptions, DEFAULT_MIN_AGE_DAYS, DEFAULT_STALE_DAYS};
 use serde::Deserialize;
 use serde_json::{json, Value};
 use skill::install_skill;
@@ -51,6 +53,9 @@ Structured / agent-facing surfaces:
   dev-browser browsers --json        Managed browser list as JSON instead of a table.
   dev-browser --version / -V         Print the installed CLI version and exit.
   dev-browser stop --browser <NAME>  Stop one named browser instead of the whole daemon.
+  dev-browser doctor                 Diagnose ~/.dev-browser disk usage (daemon status,
+                                      tmp/ and browsers/ size, stale profiles). Add --gc
+                                      to plan cleanup (dry run) or --gc --yes to execute it.
 
 Primary invocation styles:
   dev-browser <<'EOF'
@@ -255,6 +260,47 @@ enum Command {
         long_about = "Print the full agent usage guide in-tool, with no need to scroll past --help.\n\nThis is the same content shown after `dev-browser --help`, but `-h` and truncated `--help` output (e.g. piped through `head`) don't reliably surface it. `robot-docs` always prints the whole guide to stdout regardless of terminal size or truncation."
     )]
     RobotDocs,
+    #[command(
+        about = "Diagnose ~/.dev-browser disk usage and (opt-in) garbage-collect stale data",
+        long_about = "Diagnose the on-disk state under ~/.dev-browser/: daemon status, disk usage for tmp/, browsers/, and logs/, and any named browser profiles that look stale.\n\nWith --gc, also compute a garbage-collection plan for tmp/ entries (and, with --include-browser-profiles, stale named browser profiles). The plan is printed as a DRY RUN by default -- nothing is deleted. Pass --yes together with --gc to actually delete the planned items.\n\nEvery delete is re-checked to be inside ~/.dev-browser immediately before it runs; nothing outside that directory is ever touched."
+    )]
+    Doctor {
+        #[arg(
+            long,
+            help = "Emit machine-readable JSON instead of a human-readable report"
+        )]
+        json: bool,
+        #[arg(
+            long,
+            help = "Compute a garbage-collection plan (dry run unless --yes is also passed)",
+            long_help = "Compute a garbage-collection plan for stale data under ~/.dev-browser/.\n\nWithout --yes, this only prints what WOULD be deleted (a dry run) -- nothing is touched. Add --yes to actually delete. Add --include-browser-profiles to also consider stale named browser profiles (off by default, since those can hold logged-in session state)."
+        )]
+        gc: bool,
+        #[arg(
+            long,
+            help = "Actually delete the GC plan's candidates (requires --gc; otherwise a no-op)",
+            long_help = "Actually delete the items in the --gc plan instead of only printing them.\n\nHas no effect without --gc. Every path is re-verified to be inside ~/.dev-browser immediately before deletion."
+        )]
+        yes: bool,
+        #[arg(
+            long,
+            help = "Also consider stale named browser profiles for GC (requires --gc)",
+            long_help = "Include stale named browser profiles (older than --stale-days) in the --gc plan.\n\nOff by default: deleting a browser profile discards any logged-in session state stored in it, which is more destructive than clearing tmp/ scratch files. Has no effect without --gc."
+        )]
+        include_browser_profiles: bool,
+        #[arg(
+            long,
+            value_name = "DAYS",
+            help = "Days of inactivity before a browser profile is flagged/GC'd as stale (default 30)"
+        )]
+        stale_days: Option<u64>,
+        #[arg(
+            long,
+            value_name = "DAYS",
+            help = "Minimum age in days before a tmp/ entry is GC-eligible (default 1)"
+        )]
+        min_age_days: Option<u64>,
+    },
 }
 
 #[derive(Debug, Deserialize)]
@@ -387,6 +433,7 @@ fn classify_error_exit_code(error: &(dyn Error + 'static)) -> i32 {
 
 fn run() -> Result<i32, Box<dyn Error>> {
     let cli = Cli::parse();
+    warn_if_browser_flag_ignored(&cli);
 
     match &cli.command {
         Some(Command::Run { file }) => {
@@ -483,6 +530,21 @@ fn run() -> Result<i32, Box<dyn Error>> {
             print!("{CLI_AFTER_LONG_HELP}");
             Ok(0)
         }
+        Some(Command::Doctor {
+            json,
+            gc,
+            yes,
+            include_browser_profiles,
+            stale_days,
+            min_age_days,
+        }) => run_doctor(DoctorOptions {
+            json: *json,
+            gc: *gc,
+            confirm: *yes,
+            include_browser_profiles: *include_browser_profiles,
+            stale_days: stale_days.unwrap_or(DEFAULT_STALE_DAYS),
+            min_age_days: min_age_days.unwrap_or(DEFAULT_MIN_AGE_DAYS),
+        }),
         None => {
             if stdin_is_tty() {
                 let mut command = Cli::command();
@@ -507,7 +569,54 @@ fn known_subcommand_names() -> &'static [&'static str] {
         "stop",
         "capabilities",
         "robot-docs",
+        "doctor",
     ]
+}
+
+/// Must match the top-level `browser` field's `default_value = "default"`.
+/// Kept as a separate named constant (rather than re-deriving from clap)
+/// so the ignored-flag check below stays simple; a test pins the two in
+/// sync (`browser_flag_default_name_matches_clap_default`).
+const DEFAULT_BROWSER_NAME: &str = "default";
+
+/// `--browser <NAME>` is a top-level flag but only affects script execution
+/// (`run` / stdin) and `stop --browser <NAME>` (which has its own
+/// subcommand-level `--browser`, wired directly to the daemon's
+/// per-instance stop). For `status`, `browsers`, and a bare `stop` (no
+/// subcommand-level `--browser`), the top-level flag has no effect -- those
+/// either report on every managed browser, or (for `stop`) intentionally
+/// target the whole daemon. Returns the hint to print, or `None` if the
+/// flag is at its default or the command actually honors it.
+fn browser_flag_ignored_hint(cli: &Cli) -> Option<&'static str> {
+    if cli.browser == DEFAULT_BROWSER_NAME {
+        return None;
+    }
+
+    match &cli.command {
+        Some(Command::Browsers { .. }) => Some(
+            "`browsers` always lists every managed browser; there is no per-browser filter yet.",
+        ),
+        Some(Command::Status { .. }) => Some(
+            "`status` always reports on the whole daemon; there is no per-browser filter yet.",
+        ),
+        Some(Command::Stop { browser: None }) => Some(
+            "`stop` with no subcommand-level flag stops the whole daemon. Use `stop --browser <NAME>` (not the top-level --browser) to target one instance.",
+        ),
+        _ => None,
+    }
+}
+
+/// Prints a stderr warning when a non-default top-level `--browser` was
+/// passed to a subcommand that silently ignores it (P3-3). Rather than
+/// letting an agent assume `--browser <name> status` filtered the output,
+/// name the mismatch and point at the actual mechanism.
+fn warn_if_browser_flag_ignored(cli: &Cli) {
+    if let Some(hint) = browser_flag_ignored_hint(cli) {
+        eprintln!(
+            "Warning: top-level --browser '{}' has no effect here. {hint}",
+            cli.browser
+        );
+    }
 }
 
 /// Validates `--connect`'s optional value. `--connect` uses `num_args = 0..=1`
@@ -546,12 +655,21 @@ fn capabilities_document() -> Value {
             { "name": "stop", "about": "Stop the daemon and all browsers, or one named browser with --browser <NAME>" },
             { "name": "capabilities", "about": "Print this machine-readable capabilities document", "json_flag": true },
             { "name": "robot-docs", "about": "Print the full agent usage guide to stdout" },
+            { "name": "doctor", "about": "Diagnose ~/.dev-browser disk usage and (opt-in, dry-run-by-default) garbage-collect stale tmp/ and browser-profile data", "json_flag": true },
         ],
         "exit_codes": exit_codes,
         "env_vars": [
             {
                 "name": "DEV_BROWSER_DAEMON",
                 "description": "Override the daemon entrypoint (.js/.mjs/.cjs/.ts file, or a native executable) instead of the CLI's embedded daemon bundle."
+            },
+            {
+                "name": "PW_CHROMIUM_ATTACH_TO_OTHER",
+                "description": "Playwright/Chromium env var read by the embedded daemon. Defaulted to \"1\" automatically when unset, so `--connect` (CDP attach) to Chrome's built-in remote debugging doesn't hang. Set it to \"0\" explicitly before launching dev-browser to restore Playwright's non-attaching default."
+            },
+            {
+                "name": "USERNAME / USER",
+                "description": "(Windows only) Read to derive a per-user named-pipe identity for the daemon's control socket, so different Windows users on the same machine get separate daemons. Not meant to be set by agents to change behavior; falls back to the home-directory folder name if neither is set."
             }
         ],
         "flags": {
@@ -1018,5 +1136,151 @@ mod tests {
     fn classify_error_exit_code_defaults_to_generic() {
         let error: Box<dyn Error> = "boom".into();
         assert_eq!(classify_error_exit_code(&*error), ExitCode::GenericError.code());
+    }
+
+    // --- P3-3: --browser silently ignored by status/browsers/stop --------
+
+    #[test]
+    fn browser_flag_default_name_matches_clap_default() {
+        // Pins DEFAULT_BROWSER_NAME against the actual clap default so the
+        // two can never silently drift apart.
+        let cli = Cli::try_parse_from(["dev-browser", "status"]).unwrap();
+        assert_eq!(cli.browser, DEFAULT_BROWSER_NAME);
+    }
+
+    #[test]
+    fn browser_flag_ignored_hint_warns_for_status_with_non_default_browser() {
+        let cli = Cli::try_parse_from(["dev-browser", "--browser", "myproj", "status"]).unwrap();
+        assert!(browser_flag_ignored_hint(&cli).is_some());
+    }
+
+    #[test]
+    fn browser_flag_ignored_hint_warns_for_browsers_with_non_default_browser() {
+        let cli = Cli::try_parse_from(["dev-browser", "--browser", "myproj", "browsers"]).unwrap();
+        assert!(browser_flag_ignored_hint(&cli).is_some());
+    }
+
+    #[test]
+    fn browser_flag_ignored_hint_warns_for_bare_stop_with_non_default_browser() {
+        let cli = Cli::try_parse_from(["dev-browser", "--browser", "myproj", "stop"]).unwrap();
+        assert!(browser_flag_ignored_hint(&cli).is_some());
+    }
+
+    #[test]
+    fn browser_flag_ignored_hint_silent_for_stop_with_subcommand_browser_flag() {
+        let cli = Cli::try_parse_from([
+            "dev-browser",
+            "--browser",
+            "myproj",
+            "stop",
+            "--browser",
+            "myproj",
+        ])
+        .unwrap();
+        assert!(browser_flag_ignored_hint(&cli).is_none());
+    }
+
+    #[test]
+    fn browser_flag_ignored_hint_silent_when_browser_flag_left_at_default() {
+        let cli = Cli::try_parse_from(["dev-browser", "status"]).unwrap();
+        assert!(browser_flag_ignored_hint(&cli).is_none());
+    }
+
+    #[test]
+    fn browser_flag_ignored_hint_silent_for_run_command() {
+        let cli =
+            Cli::try_parse_from(["dev-browser", "--browser", "myproj", "run", "script.js"])
+                .unwrap();
+        assert!(browser_flag_ignored_hint(&cli).is_none());
+    }
+
+    // --- P3-8: env vars documented in capabilities --------------------------
+
+    #[test]
+    fn capabilities_document_lists_pw_chromium_attach_to_other_env_var() {
+        let document = capabilities_document();
+        let env_vars: Vec<&str> = document["env_vars"]
+            .as_array()
+            .expect("env_vars should be an array")
+            .iter()
+            .map(|entry| entry["name"].as_str().expect("env var name"))
+            .collect();
+        assert!(env_vars.contains(&"PW_CHROMIUM_ATTACH_TO_OTHER"));
+        assert!(env_vars.contains(&"USERNAME / USER"));
+        assert!(env_vars.contains(&"DEV_BROWSER_DAEMON"));
+    }
+
+    // --- P3-6: doctor subcommand ---------------------------------------------
+
+    #[test]
+    fn doctor_subcommand_parses_with_defaults() {
+        let cli = Cli::try_parse_from(["dev-browser", "doctor"]).unwrap();
+        match cli.command {
+            Some(Command::Doctor {
+                json,
+                gc,
+                yes,
+                include_browser_profiles,
+                stale_days,
+                min_age_days,
+            }) => {
+                assert!(!json);
+                assert!(!gc);
+                assert!(!yes);
+                assert!(!include_browser_profiles);
+                assert_eq!(stale_days, None);
+                assert_eq!(min_age_days, None);
+            }
+            _ => panic!("expected Doctor command"),
+        }
+    }
+
+    #[test]
+    fn doctor_subcommand_parses_all_flags() {
+        let cli = Cli::try_parse_from([
+            "dev-browser",
+            "doctor",
+            "--json",
+            "--gc",
+            "--yes",
+            "--include-browser-profiles",
+            "--stale-days",
+            "10",
+            "--min-age-days",
+            "2",
+        ])
+        .unwrap();
+        match cli.command {
+            Some(Command::Doctor {
+                json,
+                gc,
+                yes,
+                include_browser_profiles,
+                stale_days,
+                min_age_days,
+            }) => {
+                assert!(json);
+                assert!(gc);
+                assert!(yes);
+                assert!(include_browser_profiles);
+                assert_eq!(stale_days, Some(10));
+                assert_eq!(min_age_days, Some(2));
+            }
+            _ => panic!("expected Doctor command"),
+        }
+    }
+
+    #[test]
+    fn doctor_is_a_known_subcommand_name_for_connect_swallow_guard() {
+        assert!(known_subcommand_names().contains(&"doctor"));
+    }
+
+    #[test]
+    fn connect_rejects_doctor_subcommand_name_as_url() {
+        let result = Cli::try_parse_from(["dev-browser", "--connect", "doctor"]);
+        let err = result
+            .err()
+            .expect("`--connect doctor` should be rejected");
+        assert!(err.to_string().contains("looks like a dev-browser subcommand"));
     }
 }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -42,6 +42,16 @@ SANDBOX ENVIRONMENT:
 
   Memory and CPU limits are enforced. Infinite loops will be interrupted.
 
+Structured / agent-facing surfaces:
+  dev-browser capabilities --json    Machine-readable contract: version, commands,
+                                      exit-code dictionary, environment variables.
+  dev-browser robot-docs             Print the full agent usage guide to stdout,
+                                      unaffected by --help truncation or -h's brevity.
+  dev-browser status --json          Daemon status as JSON instead of a table.
+  dev-browser browsers --json        Managed browser list as JSON instead of a table.
+  dev-browser --version / -V         Print the installed CLI version and exit.
+  dev-browser stop --browser <NAME>  Stop one named browser instead of the whole daemon.
+
 Primary invocation styles:
   dev-browser <<'EOF'
     const page = await browser.getPage("main");
@@ -98,6 +108,7 @@ const DEFAULT_SCRIPT_TIMEOUT_SECS: u32 = 30;
 
 #[derive(Parser)]
 #[command(name = "dev-browser")]
+#[command(version)]
 #[command(about = "Control browsers with JavaScript automation scripts")]
 #[command(long_about = CLI_LONG_ABOUT)]
 #[command(after_long_help = CLI_AFTER_LONG_HELP)]
@@ -116,8 +127,9 @@ struct Cli {
         num_args = 0..=1,
         default_missing_value = "auto",
         value_name = "URL",
+        value_parser = parse_connect_value,
         help = "Connect to a running Chrome instance",
-        long_help = "Connect to a running Chrome instance.\n\nWithout a URL: auto-discovers Chrome with debugging enabled.\nWorks with Chrome's built-in remote debugging\n(chrome://inspect/#remote-debugging) and classic\n--remote-debugging-port mode.\n\nWith a URL: connects to the specified CDP endpoint.\nAccepts HTTP or WebSocket CDP endpoints such as `http://localhost:9222` or `ws://host:9222/devtools/browser/...`.\n\nTo launch Chrome with debugging, use a command such as:\n  chrome.exe --remote-debugging-port=9222\n  google-chrome --remote-debugging-port=9222\n\nOr visit chrome://inspect/#remote-debugging to configure."
+        long_help = "Connect to a running Chrome instance.\n\nWithout a URL: auto-discovers Chrome with debugging enabled.\nWorks with Chrome's built-in remote debugging\n(chrome://inspect/#remote-debugging) and classic\n--remote-debugging-port mode.\n\nWith a URL: connects to the specified CDP endpoint.\nAccepts HTTP or WebSocket CDP endpoints such as `http://localhost:9222` or `ws://host:9222/devtools/browser/...`.\n\nTo launch Chrome with debugging, use a command such as:\n  chrome.exe --remote-debugging-port=9222\n  google-chrome --remote-debugging-port=9222\n\nOr visit chrome://inspect/#remote-debugging to configure.\n\nNOTE: `--connect` greedily takes the next word as its value, which can swallow\na following subcommand name (e.g. `--connect run` is parsed as connecting to\na CDP URL literally named \"run\"). Use `--connect=auto run script.js` (with an\n`=`) when you want to auto-connect and still invoke a subcommand."
     )]
     connect: Option<String>,
 
@@ -193,17 +205,56 @@ enum Command {
         about = "List all managed browser instances",
         long_about = "List all managed browser instances.\n\nShows the browser name, whether it is daemon-launched or externally connected, its status, and any named pages currently registered."
     )]
-    Browsers,
+    Browsers {
+        #[arg(
+            long,
+            help = "Emit machine-readable JSON instead of a table",
+            long_help = "Emit the browser list as JSON instead of a hand-formatted table.\n\nSchema: an array of {name, type, status, pages: [string]} objects."
+        )]
+        json: bool,
+    },
     #[command(
         about = "Show daemon status",
         long_about = "Show daemon status.\n\nPrints daemon process details, socket path, uptime, and the current set of managed browsers."
     )]
-    Status,
+    Status {
+        #[arg(
+            long,
+            help = "Emit machine-readable JSON instead of a table",
+            long_help = "Emit daemon status as JSON instead of formatted text.\n\nSchema: {pid, uptimeMs, browserCount, socketPath, browsers: [...]}."
+        )]
+        json: bool,
+    },
     #[command(
         about = "Stop the daemon and all browsers",
-        long_about = "Stop the daemon and all browsers.\n\nThis stops the background daemon process and closes every browser instance it currently manages."
+        long_about = "Stop the daemon and all browsers, or a single named browser.\n\nWithout --browser, this stops the background daemon process and closes every browser instance it currently manages. With --browser <NAME>, only that browser instance is closed; the daemon and any other managed browsers keep running."
     )]
-    Stop,
+    Stop {
+        #[arg(
+            long,
+            value_name = "NAME",
+            help = "Stop only the named browser instance instead of the whole daemon",
+            long_help = "Stop only the named browser instance instead of the whole daemon.\n\nThe daemon and any other managed browsers keep running. Use this instead of a bare `stop` when other agents or sessions share the daemon.\n\nWithout this flag, `stop` shuts down the daemon and closes every managed browser."
+        )]
+        browser: Option<String>,
+    },
+    #[command(
+        about = "Print the CLI's machine-readable capabilities document",
+        long_about = "Print the CLI's machine-readable capabilities document: version, command list, exit-code dictionary, and environment variables.\n\nIntended for agents to introspect the tool's contract instead of parsing --help."
+    )]
+    Capabilities {
+        #[arg(
+            long,
+            help = "Emit the full capabilities document as JSON (recommended for agents)",
+            long_help = "Emit the full capabilities document as JSON instead of a human-readable summary.\n\nThis is the canonical form for agents: `dev-browser capabilities --json`."
+        )]
+        json: bool,
+    },
+    #[command(
+        about = "Print the full agent usage guide (also shown after --help)",
+        long_about = "Print the full agent usage guide in-tool, with no need to scroll past --help.\n\nThis is the same content shown after `dev-browser --help`, but `-h` and truncated `--help` output (e.g. piped through `head`) don't reliably surface it. `robot-docs` always prints the whole guide to stdout regardless of terminal size or truncation."
+    )]
+    RobotDocs,
 }
 
 #[derive(Debug, Deserialize)]
@@ -234,16 +285,104 @@ enum ResultMode {
     Status,
 }
 
+/// Documented exit-code dictionary. Exit 2 is reserved for clap's own usage
+/// errors (bad flags) and is also used by our own "printed help instead of
+/// running a script" case; it is intentionally not constructed via this enum
+/// at every call site, but it IS listed here so `capabilities --json` stays
+/// the single source of truth for the whole dictionary.
+#[derive(Clone, Copy)]
+#[repr(i32)]
+enum ExitCode {
+    Success = 0,
+    GenericError = 1,
+    Usage = 2,
+    ToolEnvironment = 3,
+    Upstream = 4,
+}
+
+impl ExitCode {
+    const fn code(self) -> i32 {
+        self as i32
+    }
+
+    const fn label(self) -> &'static str {
+        match self {
+            ExitCode::Success => "success",
+            ExitCode::GenericError => "generic-error",
+            ExitCode::Usage => "usage-error",
+            ExitCode::ToolEnvironment => "tool-environment-error",
+            ExitCode::Upstream => "upstream-failure",
+        }
+    }
+
+    const fn description(self) -> &'static str {
+        match self {
+            ExitCode::Success => "The command completed successfully.",
+            ExitCode::GenericError => "An unclassified CLI-side error occurred (I/O, connection, or parsing failure). See the printed `Error:` line for detail.",
+            ExitCode::Usage => "Invalid arguments/flags (raised by clap), or a bare invocation with no piped script on an interactive stdin (help was printed instead of running a script).",
+            ExitCode::ToolEnvironment => "A local environment problem: missing runtime dependency, `dev-browser install` not run yet, Chromium failed to launch, or the daemon could not start/stop.",
+            ExitCode::Upstream => "The daemon reported a failure from the script, browser, or CDP connection itself (not a CLI-side problem).",
+        }
+    }
+
+    fn dictionary() -> [(i32, &'static str, &'static str); 5] {
+        [
+            (
+                ExitCode::Success.code(),
+                ExitCode::Success.label(),
+                ExitCode::Success.description(),
+            ),
+            (
+                ExitCode::GenericError.code(),
+                ExitCode::GenericError.label(),
+                ExitCode::GenericError.description(),
+            ),
+            (
+                ExitCode::Usage.code(),
+                ExitCode::Usage.label(),
+                ExitCode::Usage.description(),
+            ),
+            (
+                ExitCode::ToolEnvironment.code(),
+                ExitCode::ToolEnvironment.label(),
+                ExitCode::ToolEnvironment.description(),
+            ),
+            (
+                ExitCode::Upstream.code(),
+                ExitCode::Upstream.label(),
+                ExitCode::Upstream.description(),
+            ),
+        ]
+    }
+}
+
 fn main() {
     let exit_code = match run() {
         Ok(code) => code,
         Err(error) => {
             eprintln!("Error: {error}");
-            1
+            classify_error_exit_code(&*error)
         }
     };
 
     process::exit(exit_code);
+}
+
+/// Chooses the exit code for a top-level error. Only one class is currently
+/// distinguished from the generic bucket: errors the daemon-management code
+/// tagged as environment problems (missing runtime, daemon wouldn't
+/// start/stop, Chromium wouldn't launch). Everything else stays the
+/// pre-existing generic-error code so this stays a small, documented
+/// classifier rather than a full error-type hierarchy.
+fn classify_error_exit_code(error: &(dyn Error + 'static)) -> i32 {
+    if error
+        .downcast_ref::<daemon::ToolEnvironmentError>()
+        .is_some()
+    {
+        ExitCode::ToolEnvironment.code()
+    } else {
+        ExitCode::GenericError.code()
+    }
 }
 
 fn run() -> Result<i32, Box<dyn Error>> {
@@ -254,14 +393,18 @@ fn run() -> Result<i32, Box<dyn Error>> {
             let script = fs::read_to_string(file)?;
             run_script(&cli, script)
         }
-        Some(Command::Browsers) => {
+        Some(Command::Browsers { json }) => {
             ensure_daemon()?;
             send_request(
                 json!({
                     "id": request_id("browsers"),
                     "type": "browsers",
                 }),
-                ResultMode::Browsers,
+                if *json {
+                    ResultMode::Json
+                } else {
+                    ResultMode::Browsers
+                },
             )
         }
         Some(Command::Install) => {
@@ -276,20 +419,41 @@ fn run() -> Result<i32, Box<dyn Error>> {
             install_skill(*claude, *agents, *codex)?;
             Ok(0)
         }
-        Some(Command::Status) => {
+        Some(Command::Status { json }) => {
             ensure_daemon()?;
             send_request(
                 json!({
                     "id": request_id("status"),
                     "type": "status",
                 }),
-                ResultMode::Status,
+                if *json {
+                    ResultMode::Json
+                } else {
+                    ResultMode::Status
+                },
             )
         }
-        Some(Command::Stop) => {
+        Some(Command::Stop { browser }) => {
             if !is_daemon_running() {
-                println!("Daemon is not running.");
+                eprintln!("Daemon is not running.");
                 return Ok(0);
+            }
+
+            if let Some(browser_name) = browser {
+                let exit_code = send_request(
+                    json!({
+                        "id": request_id("browser-stop"),
+                        "type": "browser-stop",
+                        "browser": browser_name,
+                    }),
+                    ResultMode::None,
+                )?;
+
+                if exit_code == 0 {
+                    eprintln!("Stopped browser '{browser_name}'. The daemon and other browsers keep running.");
+                }
+
+                return Ok(exit_code);
             }
 
             let daemon_pid = current_daemon_pid();
@@ -306,23 +470,133 @@ fn run() -> Result<i32, Box<dyn Error>> {
                 if let Some(pid) = daemon_pid {
                     wait_for_daemon_exit(pid, Duration::from_secs(10))?;
                 }
-                println!("Daemon stopped.");
+                eprintln!("Stopped the daemon and all managed browsers.");
             }
 
             Ok(exit_code)
+        }
+        Some(Command::Capabilities { json }) => {
+            print_capabilities(*json)?;
+            Ok(0)
+        }
+        Some(Command::RobotDocs) => {
+            print!("{CLI_AFTER_LONG_HELP}");
+            Ok(0)
         }
         None => {
             if stdin_is_tty() {
                 let mut command = Cli::command();
                 command.print_help()?;
                 println!();
-                return Ok(2);
+                return Ok(ExitCode::Usage.code());
             }
 
             let script = read_script_from_stdin()?;
             run_script(&cli, script)
         }
     }
+}
+
+fn known_subcommand_names() -> &'static [&'static str] {
+    &[
+        "run",
+        "install",
+        "install-skill",
+        "browsers",
+        "status",
+        "stop",
+        "capabilities",
+        "robot-docs",
+    ]
+}
+
+/// Validates `--connect`'s optional value. `--connect` uses `num_args = 0..=1`
+/// so it greedily tries to consume the next bare token as its URL, including
+/// a following subcommand name (`dev-browser --connect run` parses "run" as
+/// the CDP URL instead of routing to the `run` subcommand). Rather than
+/// silently doing the wrong thing, reject known-subcommand-shaped values with
+/// an error that names the exact fix.
+fn parse_connect_value(raw: &str) -> Result<String, String> {
+    if raw != "auto" && known_subcommand_names().contains(&raw) {
+        return Err(format!(
+            "'{raw}' looks like a dev-browser subcommand, not a CDP URL. `--connect` greedily takes the next word as its value. Use `--connect=auto {raw}` (with an `=`) to auto-connect and still invoke the `{raw}` subcommand, or `--connect=<url>` to specify a CDP endpoint explicitly."
+        ));
+    }
+
+    Ok(raw.to_string())
+}
+
+fn capabilities_document() -> Value {
+    let exit_codes: Vec<Value> = ExitCode::dictionary()
+        .into_iter()
+        .map(|(code, name, description)| {
+            json!({ "code": code, "name": name, "description": description })
+        })
+        .collect();
+
+    json!({
+        "version": env!("CARGO_PKG_VERSION"),
+        "contract_version": 1,
+        "commands": [
+            { "name": "run", "about": "Run a script file against the browser" },
+            { "name": "install", "about": "Install Playwright browsers (Chromium) and verify Chromium actually launches" },
+            { "name": "install-skill", "about": "Install the dev-browser skill into agent skill directories" },
+            { "name": "browsers", "about": "List all managed browser instances", "json_flag": true },
+            { "name": "status", "about": "Show daemon status", "json_flag": true },
+            { "name": "stop", "about": "Stop the daemon and all browsers, or one named browser with --browser <NAME>" },
+            { "name": "capabilities", "about": "Print this machine-readable capabilities document", "json_flag": true },
+            { "name": "robot-docs", "about": "Print the full agent usage guide to stdout" },
+        ],
+        "exit_codes": exit_codes,
+        "env_vars": [
+            {
+                "name": "DEV_BROWSER_DAEMON",
+                "description": "Override the daemon entrypoint (.js/.mjs/.cjs/.ts file, or a native executable) instead of the CLI's embedded daemon bundle."
+            }
+        ],
+        "flags": {
+            "--json": "Available on `status`, `browsers`, and `capabilities` for machine-readable output.",
+            "--connect": "Optional-value flag: bare `--connect` auto-discovers Chrome; `--connect <url>` or `--connect=<url>` attaches to a specific CDP endpoint. Use `--connect=auto` (with `=`) before a subcommand name to avoid the value swallowing it.",
+            "--timeout": "Maximum script execution time in seconds (default 30).",
+            "--version / -V": "Print the installed CLI version and exit."
+        }
+    })
+}
+
+fn print_capabilities(json_output: bool) -> Result<(), Box<dyn Error>> {
+    let document = capabilities_document();
+
+    if json_output {
+        println!("{}", serde_json::to_string_pretty(&document)?);
+        return Ok(());
+    }
+
+    println!(
+        "dev-browser {}",
+        document["version"].as_str().unwrap_or("unknown")
+    );
+    println!("contract_version: {}", document["contract_version"]);
+    println!();
+    println!("Commands:");
+    if let Some(commands) = document["commands"].as_array() {
+        for command in commands {
+            let name = command["name"].as_str().unwrap_or("?");
+            let about = command["about"].as_str().unwrap_or("");
+            println!("  {name:<16} {about}");
+        }
+    }
+    println!();
+    println!("Exit codes:");
+    if let Some(codes) = document["exit_codes"].as_array() {
+        for entry in codes {
+            let code = entry["code"].as_i64().unwrap_or(-1);
+            let name = entry["name"].as_str().unwrap_or("?");
+            println!("  {code}  {name}");
+        }
+    }
+    println!();
+    println!("Run `dev-browser capabilities --json` for the full machine-readable document.");
+    Ok(())
 }
 
 fn run_script(cli: &Cli, script: String) -> Result<i32, Box<dyn Error>> {
@@ -395,7 +669,7 @@ fn stream_responses<R: BufRead>(
                     .and_then(Value::as_str)
                     .unwrap_or("Unknown daemon error");
                 eprintln!("{error_message}");
-                return Ok(1);
+                return Ok(ExitCode::Upstream.code());
             }
             _ => {}
         }
@@ -527,4 +801,222 @@ fn format_duration_ms(duration_ms: u64) -> String {
     let minutes = total_seconds / 60;
     let seconds = total_seconds % 60;
     format!("{minutes}m {seconds}s")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::error::ErrorKind;
+
+    // --- P0-4: --version -------------------------------------------------
+
+    #[test]
+    fn version_flag_is_recognized_by_clap() {
+        let result = Cli::try_parse_from(["dev-browser", "--version"]);
+        // `Cli` (the Ok type) doesn't derive Debug, so `.expect_err()`/
+        // `.unwrap_err()` can't be used directly (both require T: Debug for
+        // the would-be panic message). Route through `.err()` instead.
+        let err = result.err().expect("--version should short-circuit parsing");
+        assert_eq!(err.kind(), ErrorKind::DisplayVersion);
+    }
+
+    #[test]
+    fn short_version_flag_is_recognized_by_clap() {
+        let result = Cli::try_parse_from(["dev-browser", "-V"]);
+        let err = result.err().expect("-V should short-circuit parsing");
+        assert_eq!(err.kind(), ErrorKind::DisplayVersion);
+    }
+
+    // --- P0-3: --json on status/browsers ----------------------------------
+
+    #[test]
+    fn status_json_flag_parses() {
+        let cli = Cli::try_parse_from(["dev-browser", "status", "--json"]).unwrap();
+        match cli.command {
+            Some(Command::Status { json }) => assert!(json),
+            _ => panic!("expected Status command"),
+        }
+    }
+
+    #[test]
+    fn status_without_json_flag_defaults_false() {
+        let cli = Cli::try_parse_from(["dev-browser", "status"]).unwrap();
+        match cli.command {
+            Some(Command::Status { json }) => assert!(!json),
+            _ => panic!("expected Status command"),
+        }
+    }
+
+    #[test]
+    fn browsers_json_flag_parses() {
+        let cli = Cli::try_parse_from(["dev-browser", "browsers", "--json"]).unwrap();
+        match cli.command {
+            Some(Command::Browsers { json }) => assert!(json),
+            _ => panic!("expected Browsers command"),
+        }
+    }
+
+    #[test]
+    fn browsers_without_json_flag_defaults_false() {
+        let cli = Cli::try_parse_from(["dev-browser", "browsers"]).unwrap();
+        match cli.command {
+            Some(Command::Browsers { json }) => assert!(!json),
+            _ => panic!("expected Browsers command"),
+        }
+    }
+
+    // --- P0-2: stop --browser <name> --------------------------------------
+
+    #[test]
+    fn stop_without_browser_flag_targets_whole_daemon() {
+        let cli = Cli::try_parse_from(["dev-browser", "stop"]).unwrap();
+        match cli.command {
+            Some(Command::Stop { browser }) => assert!(browser.is_none()),
+            _ => panic!("expected Stop command"),
+        }
+    }
+
+    #[test]
+    fn stop_with_browser_flag_targets_named_instance() {
+        let cli = Cli::try_parse_from(["dev-browser", "stop", "--browser", "myproj"]).unwrap();
+        match cli.command {
+            Some(Command::Stop { browser }) => assert_eq!(browser.as_deref(), Some("myproj")),
+            _ => panic!("expected Stop command"),
+        }
+    }
+
+    // --- P0-4: capabilities --json -----------------------------------------
+
+    #[test]
+    fn capabilities_subcommand_parses_with_and_without_json() {
+        let cli = Cli::try_parse_from(["dev-browser", "capabilities"]).unwrap();
+        match cli.command {
+            Some(Command::Capabilities { json }) => assert!(!json),
+            _ => panic!("expected Capabilities command"),
+        }
+
+        let cli = Cli::try_parse_from(["dev-browser", "capabilities", "--json"]).unwrap();
+        match cli.command {
+            Some(Command::Capabilities { json }) => assert!(json),
+            _ => panic!("expected Capabilities command"),
+        }
+    }
+
+    #[test]
+    fn capabilities_document_lists_all_known_commands() {
+        let document = capabilities_document();
+        assert_eq!(document["version"].as_str(), Some(env!("CARGO_PKG_VERSION")));
+
+        let commands: Vec<&str> = document["commands"]
+            .as_array()
+            .expect("commands should be an array")
+            .iter()
+            .map(|entry| entry["name"].as_str().expect("command name"))
+            .collect();
+
+        for expected in known_subcommand_names() {
+            assert!(
+                commands.contains(expected),
+                "capabilities document is missing command '{expected}'"
+            );
+        }
+    }
+
+    #[test]
+    fn capabilities_document_exit_code_dictionary_is_0_through_4() {
+        let document = capabilities_document();
+        let codes: Vec<i64> = document["exit_codes"]
+            .as_array()
+            .expect("exit_codes should be an array")
+            .iter()
+            .map(|entry| entry["code"].as_i64().expect("exit code"))
+            .collect();
+
+        assert_eq!(codes, vec![0, 1, 2, 3, 4]);
+    }
+
+    // --- P3-2: --connect must not silently swallow a subcommand -----------
+
+    #[test]
+    fn connect_rejects_subcommand_name_as_url() {
+        // This is the literal reported repro (CLI-09 / P3-2): `dev-browser
+        // --connect run` with no further tokens used to silently succeed
+        // with connect="run", which the daemon later rejected as "Invalid
+        // URL" — a confusing failure two layers away from the real mistake.
+        // With a trailing file argument (`--connect run script.js`), clap's
+        // tokenizer resolves the ambiguity structurally (treating "run" as
+        // --connect's value up front) before any value_parser ever runs, so
+        // "script.js" is left over and clap reports its own native
+        // "unrecognized subcommand" error instead — that path is unchanged
+        // by this fix and is covered informally by the module docs, not a
+        // separate test.
+        let result = Cli::try_parse_from(["dev-browser", "--connect", "run"]);
+        let err = result
+            .err()
+            .expect("`--connect run` should be rejected, not silently swallowed");
+        let message = err.to_string();
+        assert!(
+            message.contains("looks like a dev-browser subcommand"),
+            "unexpected error message: {message}"
+        );
+    }
+
+    #[test]
+    fn connect_accepts_a_real_url() {
+        let cli =
+            Cli::try_parse_from(["dev-browser", "--connect", "http://localhost:9222"]).unwrap();
+        assert_eq!(cli.connect.as_deref(), Some("http://localhost:9222"));
+    }
+
+    #[test]
+    fn connect_accepts_bare_form_as_auto() {
+        let cli = Cli::try_parse_from(["dev-browser", "--connect"]).unwrap();
+        assert_eq!(cli.connect.as_deref(), Some("auto"));
+    }
+
+    #[test]
+    fn connect_with_explicit_equals_still_routes_to_subcommand() {
+        // The documented escape hatch: `--connect=auto` (with `=`) lets a
+        // following token be treated as the subcommand instead of being
+        // swallowed as --connect's value.
+        let cli =
+            Cli::try_parse_from(["dev-browser", "--connect=auto", "run", "script.js"]).unwrap();
+        assert_eq!(cli.connect.as_deref(), Some("auto"));
+        match cli.command {
+            Some(Command::Run { file }) => assert_eq!(file, "script.js"),
+            _ => panic!("expected Run command"),
+        }
+    }
+
+    // --- P1-1 partial: robot-docs -------------------------------------------
+
+    #[test]
+    fn robot_docs_subcommand_parses() {
+        let cli = Cli::try_parse_from(["dev-browser", "robot-docs"]).unwrap();
+        assert!(matches!(cli.command, Some(Command::RobotDocs)));
+    }
+
+    #[test]
+    fn connect_rejects_robot_docs_subcommand_name_as_url() {
+        let result = Cli::try_parse_from(["dev-browser", "--connect", "robot-docs"]);
+        let err = result
+            .err()
+            .expect("`--connect robot-docs` should be rejected");
+        assert!(err.to_string().contains("looks like a dev-browser subcommand"));
+    }
+
+    // --- classify_error_exit_code -------------------------------------------
+
+    #[test]
+    fn classify_error_exit_code_flags_tool_environment_errors() {
+        let error: Box<dyn Error> =
+            Box::new(daemon::ToolEnvironmentError("boom".to_string()));
+        assert_eq!(classify_error_exit_code(&*error), ExitCode::ToolEnvironment.code());
+    }
+
+    #[test]
+    fn classify_error_exit_code_defaults_to_generic() {
+        let error: Box<dyn Error> = "boom".into();
+        assert_eq!(classify_error_exit_code(&*error), ExitCode::GenericError.code());
+    }
 }

--- a/cli/src/skill.rs
+++ b/cli/src/skill.rs
@@ -60,7 +60,7 @@ pub fn install_skill(
     ) {
         InstallTargetSelection::Prompt => {
             let Some(selections) = prompt_for_install_targets()? else {
-                println!("Cancelled.");
+                eprintln!("Cancelled.");
                 return Ok(());
             };
 
@@ -73,30 +73,32 @@ pub fn install_skill(
         dirs::home_dir().ok_or("Could not determine the home directory for skill installation.")?;
 
     if selections.is_empty() {
-        println!("No install targets selected.");
+        eprintln!("No install targets selected.");
         return Ok(());
     }
 
     for selection in selections {
         let target = &INSTALL_TARGETS[selection];
         let result = install_target(&home_dir, target)?;
-        match result {
-            SyncResult::Installed => {
-                println!("Installed dev-browser skill to {}", target.file_display);
-            }
-            SyncResult::Updated => {
-                println!("Updated dev-browser skill at {}", target.file_display);
-            }
-            SyncResult::AlreadyInstalled => {
-                println!(
-                    "dev-browser skill is already installed at {}",
-                    target.file_display
-                );
-            }
-        }
+        eprintln!("{}", narration_for_result(&result, target));
     }
 
     Ok(())
+}
+
+/// This is prose, not data — `install-skill` has no structured stdout
+/// output, so all of it belongs on stderr (CLI-16). Split into a pure
+/// function so the message text itself stays unit-testable without
+/// capturing stderr.
+fn narration_for_result(result: &SyncResult, target: &InstallTarget) -> String {
+    match result {
+        SyncResult::Installed => format!("Installed dev-browser skill to {}", target.file_display),
+        SyncResult::Updated => format!("Updated dev-browser skill at {}", target.file_display),
+        SyncResult::AlreadyInstalled => format!(
+            "dev-browser skill is already installed at {}",
+            target.file_display
+        ),
+    }
 }
 
 fn resolve_install_target_selection(
@@ -172,7 +174,7 @@ fn ensure_directory(
                 format!("Failed to create {display_path}: {create_error}")
             })?;
             if announce_create {
-                println!("Created {display_path}");
+                eprintln!("Created {display_path}");
             }
             Ok(())
         }
@@ -236,7 +238,10 @@ fn interactive_terminal_available() -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::{resolve_install_target_selection, InstallTargetSelection};
+    use super::{
+        narration_for_result, resolve_install_target_selection, InstallTargetSelection,
+        SyncResult, INSTALL_TARGETS,
+    };
 
     #[test]
     fn explicit_claude_flag_skips_prompt() {
@@ -279,5 +284,27 @@ mod tests {
             InstallTargetSelection::Prompt => panic!("expected explicit selection"),
             InstallTargetSelection::Selected(actual) => assert_eq!(actual, expected),
         }
+    }
+
+    // --- CLI-16: narration text (routing itself is exercised by hand: the
+    // call sites use eprintln!, verified by inspection since println!/
+    // eprintln! destinations aren't practically interceptable from a plain
+    // unit test without a larger refactor to injectable writers). ----------
+
+    #[test]
+    fn narration_messages_reference_the_target_file_and_describe_the_outcome() {
+        let target = &INSTALL_TARGETS[0];
+
+        let installed = narration_for_result(&SyncResult::Installed, target);
+        assert!(installed.contains(target.file_display));
+        assert!(installed.starts_with("Installed"));
+
+        let updated = narration_for_result(&SyncResult::Updated, target);
+        assert!(updated.contains(target.file_display));
+        assert!(updated.starts_with("Updated"));
+
+        let already = narration_for_result(&SyncResult::AlreadyInstalled, target);
+        assert!(already.contains(target.file_display));
+        assert!(already.contains("already installed"));
     }
 }


### PR DESCRIPTION
CLI-surface ergonomics from an agent-ergonomics review. Several are wiring up capabilities the daemon already implements.

- **`--json` on `status`/`browsers`** (wired to the existing `ResultMode::Json`).
- **`stop --browser <name>`** — exposes the daemon's existing per-browser stop; `stop` was global-only. Also fixes `daemon_has_exited` ignoring its pid arg.
- **`--version`, `capabilities --json`** (version/commands/exit-code dictionary/env), and an `ExitCode` dictionary (3=tool-env, 4=upstream) instead of exit-1-absorbs-all.
- **`doctor`** — diagnoses `~/.dev-browser` disk usage + stale profiles; `--gc` is dry-run by default, only `--gc --yes` deletes, browser profiles opt-in, path-containment re-checked before every delete.
- **Daemon crash logging** — child stdout/stderr went to `Stdio::null()` (crashes invisible); now logged to `~/.dev-browser/logs/`, referenced in connection errors.
- Reject `--connect` swallowing a following subcommand; verify Chromium launches after `install`; `robot-docs`; narration to stderr.

`cargo test` green; the Windows target (incl. the `#[cfg(windows)]` pid check) builds+tests in CI.