### PR TITLE
Add configurable idle cleanup for managed browsers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Added configurable per-browser idle cleanup with `--idle-timeout`, `DEV_BROWSER_IDLE_TIMEOUT_MS`, and `~/.dev-browser/config.json` support. Idle cleanup preserves persistent profiles, excludes externally connected Chrome, and safely rechecks activity under the per-browser lock before closing.
+
 ## [0.2.8] - 2026-06-05
 
 - Added the `page.cua.*` pixel/vision toolset: coordinate-based `click`, `doubleClick`, `drag`, `move`, `scroll`, `keypress`, and `type`, plus a JPEG `screenshot()` whose pixels map 1:1 onto click coordinates at any DPR.

--- a/README.md
+++ b/README.md
@@ -92,6 +92,27 @@ dev-browser install-skill --agents  # ~/.agents/skills/dev-browser/SKILL.md
 
 Flags may be combined. With an interactive terminal, `dev-browser install-skill` prompts for targets. In non-interactive environments it updates all three locations, including Codex, so an older copied skill does not survive a CLI upgrade.
 
+### Idle browser cleanup
+
+Daemon-launched named Chromium instances can be closed automatically after they have been idle for a configured duration:
+
+```bash
+dev-browser --idle-timeout 5m < script.js
+DEV_BROWSER_IDLE_TIMEOUT_MS=300000 dev-browser status
+```
+
+The flag accepts `30s`, `5m`, `1h`, or raw milliseconds. You can also set a user default in `~/.dev-browser/config.json`:
+
+```json
+{
+  "idleTimeout": "5m"
+}
+```
+
+Precedence is `--idle-timeout`, then `DEV_BROWSER_IDLE_TIMEOUT_MS`, then `idleTimeout` in the user config, then disabled. Set any source to `0` to disable cleanup. The effective setting is sent to an already-running daemon and shown by `dev-browser status`.
+
+Cleanup is applied independently to each named browser. Activity is measured from both the start and completion of each request, so running requests are never reaped. Only Chromium instances launched by dev-browser are eligible; browsers attached with `--connect` are never closed by idle cleanup. Closing an idle browser does not delete its profile directory, cookies, or login state, and the next request relaunches it from the same persistent profile. `dev-browser stop` keeps its existing behavior of stopping the daemon and all managed browser connections.
+
 <details>
 <summary>Allowing dev-browser in Claude Code without permission prompts</summary>
 

--- a/cli/llm-guide.txt
+++ b/cli/llm-guide.txt
@@ -186,6 +186,7 @@ LLM USAGE GUIDE:
     - Prefer page.snapshotForAI() for structure; use screenshots when visual layout or styling matters.
     - Keep page names stable across scripts so you can resume work after failures.
     - Each --browser name maps to a separate daemon-managed browser instance.
+    - For unattended work, --idle-timeout 5m closes each idle daemon-launched browser while preserving its profile; it never closes --connect browsers. Use 0 to disable.
     - Use --connect to attach to an existing browser; omit the URL to auto-discover Chrome with debugging enabled.
     - Use short timeouts (--timeout 10) so scripts fail fast instead of hanging on missing elements.
     - Add --headless for unattended automation; omit it when you want to watch the browser window.

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -1,0 +1,190 @@
+use serde::Deserialize;
+use std::env;
+use std::error::Error;
+use std::fs;
+use std::io;
+use std::path::Path;
+
+const MAX_SAFE_TIMEOUT_MS: u64 = 9_007_199_254_740_991;
+
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+enum IdleTimeoutValue {
+    String(String),
+    Milliseconds(u64),
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(default, rename_all = "camelCase")]
+struct UserConfig {
+    idle_timeout: Option<IdleTimeoutValue>,
+}
+
+pub fn parse_idle_timeout(value: &str) -> Result<u64, String> {
+    let value = value.trim();
+    if value.is_empty() {
+        return Err("idle timeout cannot be empty".to_string());
+    }
+
+    let (number, multiplier) = match value.as_bytes().last().copied() {
+        Some(b's') => (&value[..value.len() - 1], 1_000_u64),
+        Some(b'm') => (&value[..value.len() - 1], 60_000_u64),
+        Some(b'h') => (&value[..value.len() - 1], 3_600_000_u64),
+        Some(last) if last.is_ascii_alphabetic() => {
+            return Err("invalid unit (use s, m, h, or raw milliseconds)".to_string());
+        }
+        _ => (value, 1_u64),
+    };
+
+    if number.is_empty() {
+        return Err("idle timeout is missing a number".to_string());
+    }
+
+    let amount = number
+        .parse::<u64>()
+        .map_err(|_| "idle timeout must be a non-negative integer".to_string())?;
+    let milliseconds = amount
+        .checked_mul(multiplier)
+        .ok_or_else(|| "idle timeout is too large".to_string())?;
+
+    if milliseconds > MAX_SAFE_TIMEOUT_MS {
+        return Err("idle timeout is too large".to_string());
+    }
+
+    Ok(milliseconds)
+}
+
+pub fn effective_idle_timeout_ms(cli_value: Option<u64>) -> Result<u64, Box<dyn Error>> {
+    let config_path = dirs::home_dir().map(|home| home.join(".dev-browser").join("config.json"));
+    resolve_idle_timeout(
+        cli_value,
+        env::var("DEV_BROWSER_IDLE_TIMEOUT_MS").ok().as_deref(),
+        config_path.as_deref(),
+    )
+}
+
+fn resolve_idle_timeout(
+    cli_value: Option<u64>,
+    environment_value: Option<&str>,
+    config_path: Option<&Path>,
+) -> Result<u64, Box<dyn Error>> {
+    if let Some(milliseconds) = cli_value {
+        return Ok(milliseconds);
+    }
+
+    if let Some(value) = environment_value {
+        return parse_idle_timeout(value)
+            .map_err(|error| format!("Invalid DEV_BROWSER_IDLE_TIMEOUT_MS: {error}").into());
+    }
+
+    let Some(config_path) = config_path else {
+        return Ok(0);
+    };
+
+    let contents = match fs::read_to_string(config_path) {
+        Ok(contents) => contents,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(0),
+        Err(error) => return Err(error.into()),
+    };
+    let config: UserConfig = serde_json::from_str(&contents)
+        .map_err(|error| format!("Invalid user config at {}: {error}", config_path.display()))?;
+
+    match config.idle_timeout {
+        Some(IdleTimeoutValue::String(value)) => parse_idle_timeout(&value).map_err(|error| {
+            format!("Invalid idleTimeout in {}: {error}", config_path.display()).into()
+        }),
+        Some(IdleTimeoutValue::Milliseconds(milliseconds)) => {
+            if milliseconds > MAX_SAFE_TIMEOUT_MS {
+                Err(format!(
+                    "Invalid idleTimeout in {}: idle timeout is too large",
+                    config_path.display()
+                )
+                .into())
+            } else {
+                Ok(milliseconds)
+            }
+        }
+        None => Ok(0),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn temp_config(contents: &str) -> PathBuf {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let dir = env::temp_dir().join(format!(
+            "dev-browser-config-{}-{unique}",
+            std::process::id()
+        ));
+        fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("config.json");
+        fs::write(&path, contents).unwrap();
+        path
+    }
+
+    #[test]
+    fn parses_human_friendly_and_raw_timeouts() {
+        assert_eq!(parse_idle_timeout("30s").unwrap(), 30_000);
+        assert_eq!(parse_idle_timeout("5m").unwrap(), 300_000);
+        assert_eq!(parse_idle_timeout("1h").unwrap(), 3_600_000);
+        assert_eq!(parse_idle_timeout("2500").unwrap(), 2_500);
+        assert_eq!(parse_idle_timeout("0").unwrap(), 0);
+    }
+
+    #[test]
+    fn rejects_invalid_timeouts() {
+        assert!(parse_idle_timeout("").is_err());
+        assert!(parse_idle_timeout("1d").is_err());
+        assert!(parse_idle_timeout("1.5m").is_err());
+        assert!(parse_idle_timeout("-1").is_err());
+    }
+
+    #[test]
+    fn resolves_cli_then_environment_then_config_then_disabled() {
+        let config_path = temp_config(r#"{"idleTimeout":"1h"}"#);
+
+        assert_eq!(
+            resolve_idle_timeout(Some(30_000), Some("5m"), Some(&config_path)).unwrap(),
+            30_000
+        );
+        assert_eq!(
+            resolve_idle_timeout(Some(0), Some("5m"), Some(&config_path)).unwrap(),
+            0
+        );
+        assert_eq!(
+            resolve_idle_timeout(None, Some("5m"), Some(&config_path)).unwrap(),
+            300_000
+        );
+        assert_eq!(
+            resolve_idle_timeout(None, None, Some(&config_path)).unwrap(),
+            3_600_000
+        );
+        assert_eq!(resolve_idle_timeout(None, None, None).unwrap(), 0);
+
+        fs::remove_dir_all(config_path.parent().unwrap()).unwrap();
+    }
+
+    #[test]
+    fn accepts_numeric_config_and_zero_disables_cleanup() {
+        let numeric_path = temp_config(r#"{"idleTimeout":45000}"#);
+        assert_eq!(
+            resolve_idle_timeout(None, None, Some(&numeric_path)).unwrap(),
+            45_000
+        );
+        fs::remove_dir_all(numeric_path.parent().unwrap()).unwrap();
+
+        let zero_path = temp_config(r#"{"idleTimeout":"0s"}"#);
+        assert_eq!(
+            resolve_idle_timeout(None, None, Some(&zero_path)).unwrap(),
+            0
+        );
+        fs::remove_dir_all(zero_path.parent().unwrap()).unwrap();
+    }
+}

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,8 +1,10 @@
+mod config;
 mod connection;
 mod daemon;
 mod skill;
 
 use clap::{CommandFactory, Parser, Subcommand};
+use config::{effective_idle_timeout_ms, parse_idle_timeout};
 use connection::{connect_to_daemon, read_line, send_message};
 use daemon::{
     current_daemon_pid, ensure_daemon, install_daemon_runtime, is_daemon_running,
@@ -145,6 +147,16 @@ struct Cli {
     )]
     timeout: u32,
 
+    #[arg(
+        long,
+        global = true,
+        value_name = "DURATION",
+        value_parser = parse_idle_timeout,
+        help = "Close idle daemon-launched browsers after a duration",
+        long_help = "Close each idle daemon-launched browser after the specified duration.\n\nAccepts human-friendly values such as 30s, 5m, and 1h, or raw milliseconds. The policy is applied per named browser, preserves browser profiles, and never closes externally connected Chrome. Use 0 to disable cleanup.\n\nPrecedence: --idle-timeout, DEV_BROWSER_IDLE_TIMEOUT_MS, ~/.dev-browser/config.json idleTimeout, then disabled."
+    )]
+    idle_timeout: Option<u64>,
+
     #[command(subcommand)]
     command: Option<Command>,
 }
@@ -196,7 +208,7 @@ enum Command {
     Browsers,
     #[command(
         about = "Show daemon status",
-        long_about = "Show daemon status.\n\nPrints daemon process details, socket path, uptime, and the current set of managed browsers."
+        long_about = "Show daemon status.\n\nPrints daemon process details, socket path, uptime, the effective idle timeout, and useful per-browser idle information."
     )]
     Status,
     #[command(
@@ -213,6 +225,12 @@ struct BrowserSummary {
     kind: String,
     status: String,
     pages: Vec<String>,
+    #[serde(default, rename = "idleForMs")]
+    idle_for_ms: Option<u64>,
+    #[serde(default, rename = "idleRemainingMs")]
+    idle_remaining_ms: Option<u64>,
+    #[serde(default, rename = "activeRequests")]
+    active_requests: usize,
 }
 
 #[derive(Debug, Deserialize)]
@@ -224,6 +242,9 @@ struct StatusSummary {
     browser_count: usize,
     #[serde(rename = "socketPath")]
     socket_path: String,
+    #[serde(rename = "idleTimeoutMs")]
+    #[serde(default)]
+    idle_timeout_ms: u64,
     browsers: Vec<BrowserSummary>,
 }
 
@@ -255,11 +276,13 @@ fn run() -> Result<i32, Box<dyn Error>> {
             run_script(&cli, script)
         }
         Some(Command::Browsers) => {
+            let idle_timeout_ms = effective_idle_timeout_ms(cli.idle_timeout)?;
             ensure_daemon()?;
             send_request(
                 json!({
                     "id": request_id("browsers"),
                     "type": "browsers",
+                    "idleTimeoutMs": idle_timeout_ms,
                 }),
                 ResultMode::Browsers,
             )
@@ -277,11 +300,13 @@ fn run() -> Result<i32, Box<dyn Error>> {
             Ok(0)
         }
         Some(Command::Status) => {
+            let idle_timeout_ms = effective_idle_timeout_ms(cli.idle_timeout)?;
             ensure_daemon()?;
             send_request(
                 json!({
                     "id": request_id("status"),
                     "type": "status",
+                    "idleTimeoutMs": idle_timeout_ms,
                 }),
                 ResultMode::Status,
             )
@@ -326,6 +351,7 @@ fn run() -> Result<i32, Box<dyn Error>> {
 }
 
 fn run_script(cli: &Cli, script: String) -> Result<i32, Box<dyn Error>> {
+    let idle_timeout_ms = effective_idle_timeout_ms(cli.idle_timeout)?;
     ensure_daemon()?;
 
     let timeout_ms = u64::from(cli.timeout)
@@ -338,6 +364,7 @@ fn run_script(cli: &Cli, script: String) -> Result<i32, Box<dyn Error>> {
         "browser": cli.browser,
         "script": script,
         "timeoutMs": timeout_ms,
+        "idleTimeoutMs": idle_timeout_ms,
     });
 
     if cli.headless {
@@ -481,13 +508,45 @@ fn print_status(data: &Value) -> Result<(), Box<dyn Error>> {
     println!("PID: {}", status.pid);
     println!("Uptime: {}", format_duration_ms(status.uptime_ms));
     println!("Browsers: {}", status.browser_count);
+    println!(
+        "Idle timeout: {}",
+        if status.idle_timeout_ms == 0 {
+            "disabled".to_string()
+        } else {
+            format_duration_ms(status.idle_timeout_ms)
+        }
+    );
     println!("Socket: {}", status.socket_path);
 
     if !status.browsers.is_empty() {
         let managed = status
             .browsers
             .iter()
-            .map(|browser| format!("{} ({}, {})", browser.name, browser.kind, browser.status))
+            .map(|browser| {
+                let idle = if browser.kind == "connected" {
+                    "idle cleanup exempt".to_string()
+                } else if browser.active_requests > 0 {
+                    format!("{} active request(s)", browser.active_requests)
+                } else if status.idle_timeout_ms == 0 {
+                    match browser.idle_for_ms {
+                        Some(idle_for_ms) => format!("idle {}", format_duration_ms(idle_for_ms)),
+                        None => "idle time unavailable".to_string(),
+                    }
+                } else {
+                    match (browser.idle_for_ms, browser.idle_remaining_ms) {
+                        (Some(idle_for_ms), Some(remaining_ms)) => format!(
+                            "idle {}, closes in {}",
+                            format_duration_ms(idle_for_ms),
+                            format_duration_ms(remaining_ms)
+                        ),
+                        _ => "idle time unavailable".to_string(),
+                    }
+                };
+                format!(
+                    "{} ({}, {}, {})",
+                    browser.name, browser.kind, browser.status, idle
+                )
+            })
             .collect::<Vec<_>>()
             .join(", ");
         println!("Managed: {managed}");
@@ -527,4 +586,26 @@ fn format_duration_ms(duration_ms: u64) -> String {
     let minutes = total_seconds / 60;
     let seconds = total_seconds % 60;
     format!("{minutes}m {seconds}s")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn idle_timeout_is_global_and_accepts_human_friendly_values() {
+        let before =
+            Cli::try_parse_from(["dev-browser", "--idle-timeout", "5m", "status"]).unwrap();
+        assert_eq!(before.idle_timeout, Some(300_000));
+
+        let after =
+            Cli::try_parse_from(["dev-browser", "status", "--idle-timeout", "30s"]).unwrap();
+        assert_eq!(after.idle_timeout, Some(30_000));
+    }
+
+    #[test]
+    fn idle_timeout_zero_is_accepted() {
+        let cli = Cli::try_parse_from(["dev-browser", "--idle-timeout", "0", "status"]).unwrap();
+        assert_eq!(cli.idle_timeout, Some(0));
+    }
 }

--- a/daemon/src/daemon.ts
+++ b/daemon/src/daemon.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import { BrowserManager } from "./browser-manager.js";
 import { executeRequest } from "./execute-request.js";
 import { formatError } from "./format-error.js";
+import { IdleBrowserReaper } from "./idle-browser-reaper.js";
 import { createKeyedLock, createMutex } from "./lock.js";
 import {
   getBrowsersDir,
@@ -52,6 +53,11 @@ const startedAt = Date.now();
 const withBrowserLock = createKeyedLock<string>();
 const withInstallLock = createMutex();
 const clients = new Set<net.Socket>();
+const idleReaper = new IdleBrowserReaper({
+  listBrowsers: () => manager.listBrowsers(),
+  stopBrowser: (name) => manager.stopBrowser(name),
+  withBrowserLock,
+});
 
 let server: net.Server | null = null;
 let shuttingDown: Promise<void> | null = null;
@@ -132,46 +138,51 @@ function createMessageQueue(socket: net.Socket) {
 }
 
 async function handleExecute(socket: net.Socket, request: ExecuteRequest): Promise<void> {
-  await executeRequest(
-    request,
-    request.timeoutMs ?? DEFAULT_SCRIPT_TIMEOUT_MS,
-    {
-      isOpen: () => !socket.destroyed && socket.writable && !socket.writableEnded,
-      onDisconnect: (listener) => {
-        const onDisconnect = () => listener();
-        socket.once("close", onDisconnect);
-        socket.once("error", onDisconnect);
-        return () => {
-          socket.off("close", onDisconnect);
-          socket.off("error", onDisconnect);
-        };
+  idleReaper.requestStarted(request.browser);
+  try {
+    await executeRequest(
+      request,
+      request.timeoutMs ?? DEFAULT_SCRIPT_TIMEOUT_MS,
+      {
+        isOpen: () => !socket.destroyed && socket.writable && !socket.writableEnded,
+        onDisconnect: (listener) => {
+          const onDisconnect = () => listener();
+          socket.once("close", onDisconnect);
+          socket.once("error", onDisconnect);
+          return () => {
+            socket.off("close", onDisconnect);
+            socket.off("error", onDisconnect);
+          };
+        },
+        send: (message) => writeMessage(socket, message),
       },
-      send: (message) => writeMessage(socket, message),
-    },
-    {
-      withBrowserLock,
-      prepareBrowser: async (currentRequest, context) => {
-        const operation = { deadline: context.deadline, signal: context.signal };
-        if (currentRequest.connect === "auto") {
-          await manager.autoConnect(currentRequest.browser, operation);
-        } else if (currentRequest.connect) {
-          await manager.connectBrowser(currentRequest.browser, currentRequest.connect, operation);
-        } else {
-          await manager.ensureBrowser(currentRequest.browser, {
-            headless: currentRequest.headless,
-            ignoreHTTPSErrors: currentRequest.ignoreHTTPSErrors,
-            ...operation,
+      {
+        withBrowserLock,
+        prepareBrowser: async (currentRequest, context) => {
+          const operation = { deadline: context.deadline, signal: context.signal };
+          if (currentRequest.connect === "auto") {
+            await manager.autoConnect(currentRequest.browser, operation);
+          } else if (currentRequest.connect) {
+            await manager.connectBrowser(currentRequest.browser, currentRequest.connect, operation);
+          } else {
+            await manager.ensureBrowser(currentRequest.browser, {
+              headless: currentRequest.headless,
+              ignoreHTTPSErrors: currentRequest.ignoreHTTPSErrors,
+              ...operation,
+            });
+          }
+        },
+        runScript: async (currentRequest, output, context) => {
+          await runScript(currentRequest.script, manager, currentRequest.browser, output, {
+            signal: context.signal,
+            timeout: Math.max(1, context.deadline - Date.now()),
           });
-        }
-      },
-      runScript: async (currentRequest, output, context) => {
-        await runScript(currentRequest.script, manager, currentRequest.browser, output, {
-          signal: context.signal,
-          timeout: Math.max(1, context.deadline - Date.now()),
-        });
-      },
-    }
-  );
+        },
+      }
+    );
+  } finally {
+    idleReaper.requestFinished(request.browser);
+  }
 }
 
 async function handleInstall(socket: net.Socket, request: { id: string }): Promise<void> {
@@ -274,6 +285,10 @@ async function handleRequest(socket: net.Socket, line: string): Promise<void> {
 
   const { request } = parsed;
 
+  if (request.idleTimeoutMs !== undefined) {
+    idleReaper.configure(request.idleTimeoutMs);
+  }
+
   if (shuttingDown && request.type !== "stop") {
     await writeMessage(socket, {
       id: request.id,
@@ -289,10 +304,11 @@ async function handleRequest(socket: net.Socket, line: string): Promise<void> {
       return;
 
     case "browsers":
+      const browsers = manager.listBrowsers();
       await writeMessage(socket, {
         id: request.id,
         type: "result",
-        data: manager.listBrowsers(),
+        data: browsers.map((browser) => ({ ...browser, ...idleReaper.idleInfo(browser) })),
       });
       await writeMessage(socket, {
         id: request.id,
@@ -303,6 +319,7 @@ async function handleRequest(socket: net.Socket, line: string): Promise<void> {
 
     case "browser-stop":
       await withBrowserLock(request.browser, () => manager.stopBrowser(request.browser));
+      idleReaper.browserStopped(request.browser);
       await writeMessage(socket, {
         id: request.id,
         type: "result",
@@ -316,6 +333,7 @@ async function handleRequest(socket: net.Socket, line: string): Promise<void> {
       return;
 
     case "status":
+      const statusBrowsers = manager.listBrowsers();
       await writeMessage(socket, {
         id: request.id,
         type: "result",
@@ -323,8 +341,12 @@ async function handleRequest(socket: net.Socket, line: string): Promise<void> {
           pid: process.pid,
           uptimeMs: Date.now() - startedAt,
           browserCount: manager.browserCount(),
-          browsers: manager.listBrowsers(),
+          browsers: statusBrowsers.map((browser) => ({
+            ...browser,
+            ...idleReaper.idleInfo(browser),
+          })),
           socketPath: SOCKET_PATH,
+          idleTimeoutMs: idleReaper.idleTimeoutMs,
         },
       });
       await writeMessage(socket, {
@@ -365,6 +387,7 @@ async function shutdown(exitCode = 0): Promise<void> {
     const serverClosed = serverToClose ? closeServerInstance(serverToClose) : Promise.resolve();
 
     await manager.stopAll();
+    idleReaper.dispose();
     await Promise.allSettled(Array.from(clients, (socket) => closeClientSocket(socket)));
     await serverClosed;
     // Only remove the pid file and socket path if this process successfully

--- a/daemon/src/idle-browser-reaper.test.ts
+++ b/daemon/src/idle-browser-reaper.test.ts
@@ -1,0 +1,175 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { IdleBrowserReaper, type IdleBrowserSummary } from "./idle-browser-reaper.js";
+import { createKeyedLock } from "./lock.js";
+
+function deferred() {
+  let resolve!: () => void;
+  const promise = new Promise<void>((innerResolve) => {
+    resolve = innerResolve;
+  });
+  return { promise, resolve };
+}
+
+function createHarness(initialBrowsers: IdleBrowserSummary[]) {
+  const browsers = new Map(initialBrowsers.map((browser) => [browser.name, browser]));
+  const stopped: string[] = [];
+  const withBrowserLock = createKeyedLock<string>();
+  const reaper = new IdleBrowserReaper({
+    listBrowsers: () => [...browsers.values()],
+    stopBrowser: async (name) => {
+      stopped.push(name);
+      browsers.delete(name);
+    },
+    withBrowserLock,
+  });
+  return { browsers, reaper, stopped, withBrowserLock };
+}
+
+describe("IdleBrowserReaper", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("fires at the pinned idle deadline despite recurring background work", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    const { reaper, stopped } = createHarness([{ name: "managed", type: "launched" }]);
+    reaper.configure(1_000);
+    reaper.requestStarted("managed");
+    reaper.requestFinished("managed");
+
+    let backgroundTicks = 0;
+    const backgroundWork = setInterval(() => {
+      backgroundTicks += 1;
+    }, 100);
+
+    await vi.advanceTimersByTimeAsync(999);
+    expect(backgroundTicks).toBeGreaterThan(0);
+    expect(stopped).toEqual([]);
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(stopped).toEqual(["managed"]);
+
+    clearInterval(backgroundWork);
+    reaper.dispose();
+  });
+
+  it("does not close an active request and starts its idle window at completion", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    const { reaper, stopped } = createHarness([{ name: "active", type: "launched" }]);
+    reaper.configure(100);
+    reaper.requestStarted("active");
+
+    await vi.advanceTimersByTimeAsync(500);
+    expect(stopped).toEqual([]);
+    expect(reaper.idleInfo({ name: "active", type: "launched" }).activeRequests).toBe(1);
+
+    reaper.requestFinished("active");
+    await vi.advanceTimersByTimeAsync(99);
+    expect(stopped).toEqual([]);
+    await vi.advanceTimersByTimeAsync(1);
+    expect(stopped).toEqual(["active"]);
+    reaper.dispose();
+  });
+
+  it("tracks idle deadlines independently for each named browser", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    const { reaper, stopped } = createHarness([
+      { name: "first", type: "launched" },
+      { name: "second", type: "launched" },
+    ]);
+    reaper.configure(100);
+    reaper.requestStarted("first");
+    reaper.requestFinished("first");
+    reaper.requestStarted("second");
+    reaper.requestFinished("second");
+
+    await vi.advanceTimersByTimeAsync(50);
+    reaper.requestStarted("second");
+    reaper.requestFinished("second");
+
+    await vi.advanceTimersByTimeAsync(50);
+    expect(stopped).toEqual(["first"]);
+    await vi.advanceTimersByTimeAsync(50);
+    expect(stopped).toEqual(["first", "second"]);
+    reaper.dispose();
+  });
+
+  it("acquires the browser lock and rechecks activity before closing", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    const { reaper, stopped, withBrowserLock } = createHarness([
+      { name: "racing", type: "launched" },
+    ]);
+    reaper.configure(100);
+    reaper.requestStarted("racing");
+    reaper.requestFinished("racing");
+
+    const releaseLock = deferred();
+    const lockAcquired = deferred();
+    const heldLock = withBrowserLock("racing", async () => {
+      lockAcquired.resolve();
+      await releaseLock.promise;
+    });
+    await lockAcquired.promise;
+
+    await vi.advanceTimersByTimeAsync(100);
+    reaper.requestStarted("racing");
+    releaseLock.resolve();
+    await heldLock;
+    await vi.advanceTimersByTimeAsync(0);
+    expect(stopped).toEqual([]);
+
+    reaper.requestFinished("racing");
+    await vi.advanceTimersByTimeAsync(100);
+    expect(stopped).toEqual(["racing"]);
+    reaper.dispose();
+  });
+
+  it("never closes externally connected Chrome", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    const { reaper, stopped } = createHarness([{ name: "external", type: "connected" }]);
+    reaper.configure(100);
+    reaper.requestStarted("external");
+    reaper.requestFinished("external");
+
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(stopped).toEqual([]);
+    reaper.dispose();
+  });
+
+  it("disables cleanup when configured to zero", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    const { reaper, stopped } = createHarness([{ name: "disabled", type: "launched" }]);
+    reaper.configure(100);
+    reaper.requestStarted("disabled");
+    reaper.requestFinished("disabled");
+    reaper.configure(0);
+
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(stopped).toEqual([]);
+    reaper.dispose();
+  });
+
+  it("applies timeout changes without restarting the daemon", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    const { reaper, stopped } = createHarness([{ name: "managed", type: "launched" }]);
+    reaper.configure(1_000);
+    reaper.requestStarted("managed");
+    reaper.requestFinished("managed");
+    await vi.advanceTimersByTimeAsync(200);
+
+    reaper.configure(300);
+    await vi.advanceTimersByTimeAsync(99);
+    expect(stopped).toEqual([]);
+    await vi.advanceTimersByTimeAsync(1);
+    expect(stopped).toEqual(["managed"]);
+    reaper.dispose();
+  });
+});

--- a/daemon/src/idle-browser-reaper.ts
+++ b/daemon/src/idle-browser-reaper.ts
@@ -1,0 +1,198 @@
+export interface IdleBrowserSummary {
+  name: string;
+  type: "launched" | "connected";
+}
+
+export interface BrowserIdleInfo {
+  activeRequests: number;
+  idleForMs?: number;
+  idleRemainingMs?: number;
+}
+
+interface ActivityState {
+  activeRequests: number;
+  lastActivityAt: number;
+}
+
+interface IdleBrowserReaperDependencies {
+  listBrowsers(): IdleBrowserSummary[];
+  stopBrowser(name: string): Promise<void>;
+  withBrowserLock<T>(name: string, action: () => Promise<T>): Promise<T>;
+  now?: () => number;
+}
+
+const MAX_TIMER_DELAY_MS = 2_147_483_647;
+
+export class IdleBrowserReaper {
+  readonly #activity = new Map<string, ActivityState>();
+  readonly #dependencies: IdleBrowserReaperDependencies;
+  readonly #now: () => number;
+
+  #idleTimeoutMs = 0;
+  #timer: ReturnType<typeof setTimeout> | null = null;
+
+  constructor(dependencies: IdleBrowserReaperDependencies) {
+    this.#dependencies = dependencies;
+    this.#now = dependencies.now ?? Date.now;
+  }
+
+  configure(idleTimeoutMs: number): void {
+    if (idleTimeoutMs === this.#idleTimeoutMs) {
+      return;
+    }
+
+    this.#idleTimeoutMs = idleTimeoutMs;
+    this.#scheduleNextDeadline();
+  }
+
+  get idleTimeoutMs(): number {
+    return this.#idleTimeoutMs;
+  }
+
+  requestStarted(browserName: string): void {
+    const state = this.#getOrCreateActivity(browserName);
+    state.activeRequests += 1;
+    state.lastActivityAt = this.#now();
+    this.#scheduleNextDeadline();
+  }
+
+  requestFinished(browserName: string): void {
+    const state = this.#getOrCreateActivity(browserName);
+    state.activeRequests = Math.max(0, state.activeRequests - 1);
+    state.lastActivityAt = this.#now();
+    this.#scheduleNextDeadline();
+  }
+
+  browserStopped(browserName: string): void {
+    this.#activity.delete(browserName);
+    this.#scheduleNextDeadline();
+  }
+
+  idleInfo(browser: IdleBrowserSummary): BrowserIdleInfo {
+    const state = this.#activity.get(browser.name);
+    if (!state) {
+      return { activeRequests: 0 };
+    }
+
+    const now = this.#now();
+    const idleForMs = Math.max(0, now - state.lastActivityAt);
+    const info: BrowserIdleInfo = {
+      activeRequests: state.activeRequests,
+      idleForMs,
+    };
+
+    if (browser.type === "launched" && this.#idleTimeoutMs > 0 && state.activeRequests === 0) {
+      info.idleRemainingMs = Math.max(0, this.#idleTimeoutMs - idleForMs);
+    }
+
+    return info;
+  }
+
+  dispose(): void {
+    if (this.#timer) {
+      clearTimeout(this.#timer);
+      this.#timer = null;
+    }
+  }
+
+  #getOrCreateActivity(browserName: string): ActivityState {
+    let state = this.#activity.get(browserName);
+    if (!state) {
+      state = { activeRequests: 0, lastActivityAt: this.#now() };
+      this.#activity.set(browserName, state);
+    }
+    return state;
+  }
+
+  #scheduleNextDeadline(): void {
+    if (this.#timer) {
+      clearTimeout(this.#timer);
+      this.#timer = null;
+    }
+
+    if (this.#idleTimeoutMs === 0) {
+      return;
+    }
+
+    const now = this.#now();
+    let earliestDeadline: number | undefined;
+
+    for (const browser of this.#dependencies.listBrowsers()) {
+      if (browser.type !== "launched") {
+        continue;
+      }
+
+      const state = this.#getOrCreateActivity(browser.name);
+      if (state.activeRequests > 0) {
+        continue;
+      }
+
+      const deadline = state.lastActivityAt + this.#idleTimeoutMs;
+      earliestDeadline =
+        earliestDeadline === undefined ? deadline : Math.min(earliestDeadline, deadline);
+    }
+
+    if (earliestDeadline === undefined) {
+      return;
+    }
+
+    const delay = Math.min(MAX_TIMER_DELAY_MS, Math.max(0, earliestDeadline - now));
+    this.#timer = setTimeout(() => {
+      this.#timer = null;
+      void this.#reapDueBrowsers().finally(() => this.#scheduleNextDeadline());
+    }, delay);
+    this.#timer.unref?.();
+  }
+
+  async #reapDueBrowsers(): Promise<void> {
+    if (this.#idleTimeoutMs === 0) {
+      return;
+    }
+
+    const now = this.#now();
+    const candidates = this.#dependencies
+      .listBrowsers()
+      .filter((browser) => {
+        const state = this.#activity.get(browser.name);
+        return (
+          browser.type === "launched" &&
+          state !== undefined &&
+          state.activeRequests === 0 &&
+          now - state.lastActivityAt >= this.#idleTimeoutMs
+        );
+      })
+      .map((browser) => browser.name);
+
+    await Promise.allSettled(
+      candidates.map(async (browserName) => {
+        await this.#dependencies.withBrowserLock(browserName, async () => {
+          const browser = this.#dependencies
+            .listBrowsers()
+            .find((candidate) => candidate.name === browserName);
+          const state = this.#activity.get(browserName);
+
+          // Recheck after acquiring the same lock used by scripts and explicit stops.
+          // A request that started or completed while the reaper waited gets a fresh deadline.
+          if (
+            !browser ||
+            browser.type !== "launched" ||
+            !state ||
+            state.activeRequests > 0 ||
+            this.#idleTimeoutMs === 0 ||
+            this.#now() - state.lastActivityAt < this.#idleTimeoutMs
+          ) {
+            return;
+          }
+
+          try {
+            await this.#dependencies.stopBrowser(browserName);
+            this.#activity.delete(browserName);
+          } catch {
+            // Avoid a tight retry loop if a close fails unexpectedly.
+            state.lastActivityAt = this.#now();
+          }
+        });
+      })
+    );
+  }
+}

--- a/daemon/src/protocol.test.ts
+++ b/daemon/src/protocol.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+
+import { parseRequest } from "./protocol.js";
+
+describe("idle timeout protocol configuration", () => {
+  it("accepts a non-negative safe integer on requests", () => {
+    expect(
+      parseRequest(
+        JSON.stringify({
+          id: "status-1",
+          type: "status",
+          idleTimeoutMs: 300_000,
+        })
+      )
+    ).toEqual({
+      success: true,
+      request: {
+        id: "status-1",
+        type: "status",
+        idleTimeoutMs: 300_000,
+      },
+    });
+
+    expect(
+      parseRequest(JSON.stringify({ id: "status-2", type: "status", idleTimeoutMs: 0 }))
+    ).toEqual({
+      success: true,
+      request: { id: "status-2", type: "status", idleTimeoutMs: 0 },
+    });
+  });
+
+  it("rejects negative or unsafe timeout values", () => {
+    expect(
+      parseRequest(JSON.stringify({ id: "negative", type: "status", idleTimeoutMs: -1 })).success
+    ).toBe(false);
+    expect(
+      parseRequest(
+        JSON.stringify({
+          id: "unsafe",
+          type: "status",
+          idleTimeoutMs: Number.MAX_SAFE_INTEGER + 1,
+        })
+      ).success
+    ).toBe(false);
+  });
+});

--- a/daemon/src/protocol.ts
+++ b/daemon/src/protocol.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 
 const RequestBaseSchema = z.object({
   id: z.string().min(1),
+  idleTimeoutMs: z.number().int().min(0).max(Number.MAX_SAFE_INTEGER).optional(),
 });
 
 const ExecuteRequestSchema = RequestBaseSchema.extend({

--- a/daemon/src/sandbox/__tests__/auto-connect.test.ts
+++ b/daemon/src/sandbox/__tests__/auto-connect.test.ts
@@ -164,7 +164,7 @@ function createManager(
     options.fetch ??
     (vi.fn(async () => {
       throw new Error("unexpected fetch");
-    }) as typeof globalThis.fetch);
+    }) as unknown as typeof globalThis.fetch);
   const readFile =
     options.readFile ??
     (vi.fn(async (filePath: string) => {
@@ -406,7 +406,7 @@ describe("BrowserManager auto-connect", () => {
 
       throw createEnoentError(filePath);
     });
-    const fetch = vi.fn() as typeof globalThis.fetch;
+    const fetch = vi.fn() as unknown as typeof globalThis.fetch;
     const { manager } = createManager({ fetch, homedir: () => homeDir, readFile });
 
     await expect(getInternals(manager).discoverChrome()).resolves.toBe(websocketUrl);
@@ -482,7 +482,7 @@ describe("BrowserManager auto-connect", () => {
           },
         }
       );
-    }) as typeof globalThis.fetch;
+    }) as unknown as typeof globalThis.fetch;
     const { manager } = createManager({
       connectOverCDP,
       fetch,
@@ -580,7 +580,7 @@ describe("BrowserManager auto-connect", () => {
     const fetch = vi.fn(async (input: RequestInfo | URL) => {
       expect(String(input)).toBe("http://127.0.0.1:9222/json/version");
       return new Response("not found", { status: 404 });
-    }) as typeof globalThis.fetch;
+    }) as unknown as typeof globalThis.fetch;
     const readFile = vi.fn(async (filePath: string) => {
       if (filePath === devToolsPath) {
         return "9222\n/devtools/browser/from-active-port\n";
@@ -613,7 +613,7 @@ describe("BrowserManager auto-connect", () => {
     });
     const fetch = vi.fn(
       async () => new Response("not found", { status: 404 })
-    ) as typeof globalThis.fetch;
+    ) as unknown as typeof globalThis.fetch;
     const { manager } = createManager({
       fetch,
       homedir: () => homeDir,
@@ -674,7 +674,7 @@ describe("BrowserManager auto-connect", () => {
       }
 
       throw new Error("connection refused");
-    }) as typeof globalThis.fetch;
+    }) as unknown as typeof globalThis.fetch;
     const readFile = vi.fn(async (filePath: string) => {
       throw createEnoentError(filePath);
     });
@@ -745,7 +745,7 @@ describe("BrowserManager auto-connect", () => {
       }
 
       throw new Error("connection refused");
-    }) as typeof globalThis.fetch;
+    }) as unknown as typeof globalThis.fetch;
     const readFile = vi.fn(async (filePath: string) => {
       if (filePath === devToolsPath) {
         return "9222\n/devtools/browser/from-active-port\n";
@@ -777,7 +777,7 @@ describe("BrowserManager auto-connect", () => {
     });
     const fetch = vi.fn(async () => {
       throw new Error("connection refused");
-    }) as typeof globalThis.fetch;
+    }) as unknown as typeof globalThis.fetch;
     const { manager } = createManager({
       fetch,
       readFile,
@@ -794,7 +794,7 @@ describe("BrowserManager auto-connect", () => {
     });
     const fetch = vi.fn(async () => {
       throw new Error("connection refused");
-    }) as typeof globalThis.fetch;
+    }) as unknown as typeof globalThis.fetch;
     const { manager } = createManager({
       fetch,
       platform: "win32",

--- a/skills/dev-browser/SKILL.md
+++ b/skills/dev-browser/SKILL.md
@@ -17,3 +17,5 @@ dev-browser install
 ## Usage
 
 Run `dev-browser --help` to learn more.
+
+Named daemon-launched browsers persist by default. For unattended work, `--idle-timeout 5m` closes each launched browser after inactivity while preserving its profile and login state. The setting never closes Chrome attached with `--connect`; use `--idle-timeout 0` to disable configured cleanup.


### PR DESCRIPTION
## Summary

- add human-friendly idle timeout configuration with CLI, environment, and user-config precedence
- apply idle cleanup independently to daemon-launched named browsers while preserving profiles and exempting external Chrome
- track request activity, recheck under the per-browser lock, and report effective timeout and idle details in status
- document the behavior and add focused timer, race, protocol, and configuration regressions

## Validation

- cd daemon && npx tsc --noEmit
- cd daemon && pnpm vitest run (154 tests)
- cd daemon && pnpm bundle
- cd daemon && pnpm bundle:sandbox-client
- cd cli && cargo test (12 tests)
- cd cli && cargo build
- isolated daemon status/stop smoke test