### PR TITLE
docs: fix release verification command

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -87,7 +87,6 @@ channels:
 gh run list --workflow release.yml --limit 1
 npm info dev-browser version
 npm install -g dev-browser
-dev-browser --version
 dev-browser --help
 ```
 


### PR DESCRIPTION
## Summary

- remove the unsupported `dev-browser --version` check from the release instructions
- retain npm metadata and CLI help as consumer-facing verification

## Validation

- `npx --yes dev-browser@0.2.9 --help`