### PR TITLE
fix: avoid CDP attachment when listing connected pages

### DIFF
--- a/daemon/src/browser-manager-pages.test.ts
+++ b/daemon/src/browser-manager-pages.test.ts
@@ -2,7 +2,7 @@ import { mkdtemp } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 
-import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 
 import { BrowserManager } from "./browser-manager.js";
 import { removeDirectoryWithRetries } from "./test-cleanup.js";
@@ -102,6 +102,39 @@ describe.sequential("BrowserManager page discovery", () => {
     expect(
       (await manager.listPages(browserName)).filter((page) => page.title === "Target Tab")
     ).toHaveLength(1);
+  }, 120_000);
+
+  it("uses stable page ids without CDP target attachment for connected browsers", async () => {
+    await ensureBrowser();
+
+    const entry = manager.getBrowser(browserName)!;
+    entry.type = "connected";
+    const existingPage = await manager.newPage(browserName);
+    await existingPage.goto(createDataUrl("Restricted CDP", "<p>existing tab</p>"));
+    const newCDPSession = vi.spyOn(existingPage.context(), "newCDPSession");
+
+    const firstSummary = (await manager.listPages(browserName)).find(
+      (page) => page.title === "Restricted CDP"
+    );
+    const secondSummary = (await manager.listPages(browserName)).find(
+      (page) => page.title === "Restricted CDP"
+    );
+
+    expect(firstSummary).toBeDefined();
+    expect(secondSummary?.id).toBe(firstSummary?.id);
+    await expect(manager.getPage(browserName, firstSummary!.id)).resolves.toBe(existingPage);
+    expect(newCDPSession).not.toHaveBeenCalled();
+
+    const otherBrowserName = `${browserName}-other`;
+    try {
+      await manager.ensureBrowser(otherBrowserName, { headless: true });
+      manager.getBrowser(otherBrowserName)!.type = "connected";
+      await expect(manager.getPage(otherBrowserName, firstSummary!.id)).resolves.not.toBe(
+        existingPage
+      );
+    } finally {
+      await manager.stopBrowser(otherBrowserName);
+    }
   }, 120_000);
 
   it("getPage with a name still returns the existing named page", async () => {

--- a/daemon/src/browser-manager.ts
+++ b/daemon/src/browser-manager.ts
@@ -1,3 +1,4 @@
+import { randomBytes } from "node:crypto";
 import { mkdir, readFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -70,6 +71,8 @@ function isHttpEndpoint(endpoint: string): boolean {
 
 export class BrowserManager {
   private readonly browsers = new Map<string, BrowserEntry>();
+  private readonly fallbackTargetIds = new WeakMap<Page, string>();
+  private readonly pagesByFallbackTargetId = new Map<string, Page>();
   private readonly baseDir: string;
   private readonly dependencies: BrowserManagerDependencies;
 
@@ -259,7 +262,7 @@ export class BrowserManager {
     const summaries = await Promise.all(
       this.getContextPages(entry).map(
         async ({ context, page }): Promise<BrowserPageSummary | null> => {
-          const id = await this.getPageTargetId(context, page);
+          const id = await this.getPageTargetId(context, page, entry.type === "connected");
           if (!id) {
             return null;
           }
@@ -895,7 +898,21 @@ export class BrowserManager {
   }
 
   private async findPageByTargetId(entry: BrowserEntry, targetId: string): Promise<Page | null> {
-    for (const { context, page } of this.getContextPages(entry)) {
+    const contextPages = this.getContextPages(entry);
+    const fallbackPage = this.pagesByFallbackTargetId.get(targetId);
+    if (fallbackPage) {
+      if (!fallbackPage.isClosed() && contextPages.some(({ page }) => page === fallbackPage)) {
+        return fallbackPage;
+      }
+      if (fallbackPage.isClosed()) {
+        this.pagesByFallbackTargetId.delete(targetId);
+      }
+    }
+    if (entry.type === "connected") {
+      return null;
+    }
+
+    for (const { context, page } of contextPages) {
       const pageTargetId = await this.getPageTargetId(context, page);
       if (pageTargetId === targetId) {
         return page;
@@ -905,7 +922,15 @@ export class BrowserManager {
     return null;
   }
 
-  private async getPageTargetId(context: BrowserContext, page: Page): Promise<string | null> {
+  private async getPageTargetId(
+    context: BrowserContext,
+    page: Page,
+    useFallback = false
+  ): Promise<string | null> {
+    if (useFallback) {
+      return this.getFallbackTargetId(page);
+    }
+
     let session: Awaited<ReturnType<BrowserContext["newCDPSession"]>> | undefined;
 
     try {
@@ -935,5 +960,20 @@ export class BrowserManager {
     } finally {
       await session?.detach().catch(() => undefined);
     }
+  }
+
+  private getFallbackTargetId(page: Page): string {
+    let targetId = this.fallbackTargetIds.get(page);
+    if (!targetId) {
+      const generatedTargetId = randomBytes(16).toString("hex");
+      this.fallbackTargetIds.set(page, generatedTargetId);
+      this.pagesByFallbackTargetId.set(generatedTargetId, page);
+      if (typeof page.once === "function") {
+        page.once("close", () => this.pagesByFallbackTargetId.delete(generatedTargetId));
+      }
+      targetId = generatedTargetId;
+    }
+
+    return targetId;
   }
 }

--- a/daemon/src/sandbox/__tests__/auto-connect.test.ts
+++ b/daemon/src/sandbox/__tests__/auto-connect.test.ts
@@ -498,13 +498,13 @@ describe("BrowserManager auto-connect", () => {
     expect(context.newPageCalls).toBe(1);
     await expect(manager.listPages("attached")).resolves.toEqual([
       {
-        id: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        id: expect.stringMatching(/^[a-f0-9]{32}$/i),
         name: null,
         title: "Existing tab",
         url: "https://example.com/existing",
       },
       {
-        id: "00000000000000000000000000000001",
+        id: expect.stringMatching(/^[a-f0-9]{32}$/i),
         name: "dashboard",
         title: "",
         url: "about:blank",


### PR DESCRIPTION
Chromium's remote debugging setting can allow page control while rejecting `Target.attachToTarget`. `browser.listPages()` currently opens a page-level CDP session for every attached tab, so one rejected attachment makes the whole call fail.

This change uses stable, daemon-local page IDs for connected browsers. IDs returned by `listPages()` still work with `getPage(id)`, stay scoped to the browser that produced them, and are removed when the page closes. Browsers launched by dev-browser continue to return their native CDP target IDs.

Tested with:

- `pnpm exec vitest run` (155 tests)
- `pnpm run build`
- `pnpm run format:check`
