### PR TITLE
fix(cli): detach Windows daemon from parent Job Object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- On Windows, daemon spawn now breaks out of the parent Job Object (`CREATE_BREAKAWAY_FROM_JOB`, with a WMI `Win32_Process.Create` fallback when breakaway is denied) so the daemon survives agent-harness command teardown.
+
 ## [0.2.9] - 2026-07-14
 
 - Added configurable per-browser idle cleanup with `--idle-timeout`, `DEV_BROWSER_IDLE_TIMEOUT_MS`, and `~/.dev-browser/config.json` support. Idle cleanup preserves persistent profiles, excludes externally connected Chrome, and safely rechecks activity under the per-browser lock before closing.

--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ dev-browser --connect
 
 Windows npm installs download the native `dev-browser-windows-x64.exe` release asset during `postinstall`, and the generated npm shims invoke that executable directly.
 
+The background daemon is started so it outlives the CLI process. On Windows that includes leaving a parent Job Object (agent harnesses such as Claude Code and Grok Build kill the job when the command ends). If `CREATE_BREAKAWAY_FROM_JOB` is denied, spawn falls back to WMI `Win32_Process.Create`.
+
 ### Using with AI agents
 
 After installing, tell your agent to run `dev-browser --help` — the help output includes the current LLM usage guide and API reference.

--- a/cli/src/daemon.rs
+++ b/cli/src/daemon.rs
@@ -158,8 +158,102 @@ fn spawn_daemon(command: &DaemonCommand) -> io::Result<()> {
         });
     }
 
-    let _child = process.spawn()?;
-    Ok(())
+    #[cfg(windows)]
+    {
+        use std::os::windows::process::CommandExt;
+        const CREATE_BREAKAWAY_FROM_JOB: u32 = 0x01000000;
+        const CREATE_NEW_PROCESS_GROUP: u32 = 0x00000200;
+        const DETACHED_PROCESS: u32 = 0x00000008;
+        const CREATE_NO_WINDOW: u32 = 0x08000000;
+        process.creation_flags(
+            CREATE_BREAKAWAY_FROM_JOB
+                | CREATE_NEW_PROCESS_GROUP
+                | DETACHED_PROCESS
+                | CREATE_NO_WINDOW,
+        );
+    }
+
+    match process.spawn() {
+        Ok(_) => Ok(()),
+        #[cfg(windows)]
+        Err(err) if err.raw_os_error() == Some(5) => spawn_daemon_via_wmi(command),
+        Err(err) => Err(err),
+    }
+}
+
+/// Quote one Windows process argument the way CommandLineToArgvW expects.
+fn quote_windows_arg(arg: &str) -> String {
+    if arg.is_empty() {
+        return "\"\"".to_string();
+    }
+    let needs_quotes = arg.bytes().any(|b| matches!(b, b' ' | b'\t' | b'"'));
+    if !needs_quotes {
+        return arg.to_string();
+    }
+    let mut out = String::from("\"");
+    let mut backslashes = 0usize;
+    for ch in arg.chars() {
+        if ch == '\\' {
+            backslashes += 1;
+            continue;
+        }
+        if ch == '"' {
+            out.push_str(&"\\".repeat(backslashes * 2 + 1));
+            out.push('"');
+            backslashes = 0;
+            continue;
+        }
+        out.push_str(&"\\".repeat(backslashes));
+        out.push(ch);
+        backslashes = 0;
+    }
+    out.push_str(&"\\".repeat(backslashes * 2));
+    out.push('"');
+    out
+}
+
+#[cfg(windows)]
+fn windows_cmdline(command: &DaemonCommand) -> String {
+    std::iter::once(command.program.as_str())
+        .chain(command.args.iter().map(String::as_str))
+        .map(quote_windows_arg)
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+#[cfg(windows)]
+fn spawn_daemon_via_wmi(command: &DaemonCommand) -> io::Result<()> {
+    // Agent harnesses (Claude Code, Grok Build) put the CLI in a Job Object
+    // with KILL_ON_JOB_CLOSE and without JOB_OBJECT_LIMIT_BREAKAWAY_OK.
+    // CREATE_BREAKAWAY_FROM_JOB then returns Access Denied (5). WMI
+    // Win32_Process.Create is parented by WmiPrvSE, outside that job, so
+    // the daemon survives when the agent command ends.
+    let cmdline = windows_cmdline(command).replace('\'', "''");
+    let cwd = command
+        .current_dir
+        .to_string_lossy()
+        .replace('\'', "''");
+    let script = format!(
+        "$s = ([wmiclass]'Win32_ProcessStartup'); $s.ShowWindow = 0; $r = ([wmiclass]'Win32_Process').Create('{cmdline}', '{cwd}', $s); if ($null -eq $r -or $r.ReturnValue -ne 0) {{ exit $(if ($r) {{ [int]$r.ReturnValue }} else {{ 1 }}) }}"
+    );
+    let status = Command::new("powershell")
+        .args([
+            "-NoProfile",
+            "-NonInteractive",
+            "-ExecutionPolicy",
+            "Bypass",
+            "-Command",
+            &script,
+        ])
+        .status()?;
+    if status.success() {
+        Ok(())
+    } else {
+        Err(io::Error::new(
+            io::ErrorKind::Other,
+            format!("WMI daemon spawn failed with {status}"),
+        ))
+    }
 }
 
 fn daemon_pid() -> Option<i32> {
@@ -321,4 +415,24 @@ fn run_install_command(
     };
 
     Err(reason.into())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::quote_windows_arg;
+
+    #[test]
+    fn quote_windows_arg_leaves_simple_tokens_alone() {
+        assert_eq!(quote_windows_arg("node"), "node");
+        assert_eq!(
+            quote_windows_arg(r"C:\dev-browser\daemon.mjs"),
+            r"C:\dev-browser\daemon.mjs"
+        );
+    }
+
+    #[test]
+    fn quote_windows_arg_quotes_spaces_and_escapes_quotes() {
+        assert_eq!(quote_windows_arg("Program Files"), "\"Program Files\"");
+        assert_eq!(quote_windows_arg(r#"say "hi""#), r#""say \"hi\"""#);
+    }
 }


### PR DESCRIPTION
## Summary

On Windows, `spawn_daemon` currently `Command::spawn`s `node` as a child of the CLI process. Agent harnesses (Claude Code, Grok Build) wrap that CLI in a Job Object with `KILL_ON_JOB_CLOSE`. When the tool command ends, Windows kills the daemon and every managed Chromium. Named-page login cookies stay on disk under `~/.dev-browser/browsers/`, but the window is gone.

Unix already called `setsid()`. This PR does the Windows equivalent:

1. `CREATE_BREAKAWAY_FROM_JOB | CREATE_NEW_PROCESS_GROUP | DETACHED_PROCESS | CREATE_NO_WINDOW`
2. If breakaway is denied (`ERROR_ACCESS_DENIED` / 5) — some harness jobs omit `JOB_OBJECT_LIMIT_BREAKAWAY_OK` — fall back to WMI `Win32_Process.Create` so the parent is `WmiPrvSE`, outside the job.

Idle-timeout (`#124`) is unrelated and already on main. This is only daemon lifetime.

## Test plan

- [x] `cargo test quote_windows` (quoting helper)
- [ ] Windows: from a Job Object that allows breakaway, `dev-browser status` twice — same daemon pid / growing uptime
- [ ] Windows: from a Job Object that denies breakaway (Grok Build / Claude Code tool shell), same check — daemon still alive after the command returns
- [ ] `--connect` / idle-timeout behavior unchanged