### PR TITLE
release: v1.0.0-rc.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -24,6 +24,6 @@
   ],
   "metadata": {
     "description": "Marketplace for the dev-browser skill",
-    "version": "1.0.0"
+    "version": "1.0.0-rc.1"
   }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.0.0] - 2026-09-03
+## [1.0.0-rc.1] - 2026-09-04
 
 - Replaced the Playwright/QuickJS runtime with the faster Puppeteer implementation developed as doobie.
 - Added persistent named pages, ARIA snapshot refs, tracked snapshot diffs, screenshots, deterministic request deadlines, concurrent scripts, Chrome attachment, and a stdio MCP server.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dev-browser",
-  "version": "1.0.0",
+  "version": "1.0.0-rc.1",
   "description": "Browser automation CLI for coding agents: Puppeteer scripts, named pages, snapshot refs, one warm daemon.",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
## Summary

- set the npm package and Claude marketplace metadata to `1.0.0-rc.1`
- mark the 1.0 changelog entry as the first release candidate
- prepare the matching `v1.0.0-rc.1` tag, which will publish npm under the `next` dist-tag

The stale historical `v1.0.0` tag was preserved as `archive/browser-skill-v1.0.0` and removed before this release.

## Validation

- `bun install --frozen-lockfile`
- `bun x tsc --noEmit`
- `bun run build`
- `bun run test` — 339 passing
- `npm pack --dry-run` — 8 expected files
- `dist/dev-browser --version` — `dev-browser 1.0.0-rc.1`
