### PR TITLE
Fix npm pack compatibility in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,7 +54,9 @@ jobs:
         run: |
           npm pack --dry-run --json > /tmp/pack.json
           node -e '
-            const [p] = require("/tmp/pack.json");
+            const packed = JSON.parse(require("node:fs").readFileSync("/tmp/pack.json", "utf8"));
+            const p = Array.isArray(packed) ? packed[0] : packed;
+            if (!p || !Array.isArray(p.files)) { console.error("unexpected npm pack JSON output"); process.exit(1); }
             const files = p.files.map((f) => f.path).sort();
             console.log(files.join("\n"));
             const need = ["bin/dev-browser.cjs", "scripts/postinstall.cjs", "scripts/download-binary.cjs", "package.json"];


### PR DESCRIPTION
## Summary

- accept both array and single-object JSON output from `npm pack --dry-run --json`
- fail clearly if npm returns a package record without a file list
- unblock the unpublished `v1.0.0-rc.1` release after all platform builds and smoke tests passed

## Validation

- exercised the package check against both array and object JSON shapes
- `git diff --check`

