### PR TITLE
Release v1.0.0-rc.2

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -24,6 +24,6 @@
   ],
   "metadata": {
     "description": "Marketplace for the dev-browser skill",
-    "version": "1.0.0-rc.1"
+    "version": "1.0.0-rc.2"
   }
 }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,7 +74,7 @@ jobs:
           node -e '
             const pkg = require("./package.json");
             if (pkg.name !== "dev-browser") { console.error("wrong package name " + pkg.name); process.exit(1); }
-            if (pkg.bin?.["dev-browser"] !== "./bin/dev-browser.cjs") { console.error("wrong dev-browser bin mapping"); process.exit(1); }
+            if (pkg.bin?.["dev-browser"] !== "bin/dev-browser.cjs") { console.error("wrong dev-browser bin mapping"); process.exit(1); }
             if (pkg.dependencies && Object.keys(pkg.dependencies).length) { console.error("package must not have runtime dependencies"); process.exit(1); }
           '
       - name: GitHub release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-rc.2] - 2026-09-04
+
+- Fixed the npm executable mapping for npm 12, which removed the `dev-browser` command from RC.1 while normalizing its published manifest.
+
 ## [1.0.0-rc.1] - 2026-09-04
 
 - Replaced the Playwright/QuickJS runtime with the faster Puppeteer implementation developed as doobie.

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
   "name": "dev-browser",
-  "version": "1.0.0-rc.1",
+  "version": "1.0.0-rc.2",
   "description": "Browser automation CLI for coding agents: Puppeteer scripts, named pages, snapshot refs, one warm daemon.",
   "license": "MIT",
   "type": "module",
   "bin": {
-    "dev-browser": "./bin/dev-browser.cjs"
+    "dev-browser": "bin/dev-browser.cjs"
   },
   "repository": {
     "type": "git",

--- a/test/unit/packaging.test.ts
+++ b/test/unit/packaging.test.ts
@@ -397,7 +397,7 @@ describe("package.json", () => {
       "docs/help.md",
       "skills/",
     ]);
-    expect(pkg.bin).toEqual({ "dev-browser": "./bin/dev-browser.cjs" });
+    expect(pkg.bin).toEqual({ "dev-browser": "bin/dev-browser.cjs" });
     expect(pkg.scripts.postinstall).toBe("node scripts/postinstall.cjs");
   });
 


### PR DESCRIPTION
## Summary

- release `dev-browser@1.0.0-rc.2`
- normalize the npm executable path for npm 12 so installs expose the `dev-browser` command
- update the release guard and packaging contract to require the publish-safe mapping
- document why RC.2 supersedes RC.1

## Validation

- `bun install --frozen-lockfile`
- `bun x tsc --noEmit`
- `bun run build`
- `bun run test` (338 passed; one stale path assertion identified and updated)
- `bun test test/unit/packaging.test.ts --timeout 120000` (27 passed)
- `npm pack --dry-run` (8 expected files)
- `npm@12.0.2 publish --dry-run --ignore-scripts --access public --tag next` (no manifest auto-correction warning)
- `dist/dev-browser --version` → `dev-browser 1.0.0-rc.2`

