### PR TITLE
Release v1.0.0-rc.3

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -24,6 +24,6 @@
   ],
   "metadata": {
     "description": "Marketplace for the dev-browser skill",
-    "version": "1.0.0-rc.2"
+    "version": "1.0.0-rc.3"
   }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-rc.3] - 2026-09-05
+
+- Added cross-origin iframe contents to snapshots, with document-scoped frame refs that stay valid across same-document navigation and safely expire after reloads, full navigation, renderer swaps, or frame removal.
+
 ## [1.0.0-rc.2] - 2026-09-04
 
 - Normalized the npm executable mapping for npm 12, avoiding a misleading publish-time manifest-correction warning. RC.1 remained installable.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dev-browser",
-  "version": "1.0.0-rc.2",
+  "version": "1.0.0-rc.3",
   "description": "Browser automation CLI for coding agents: Puppeteer scripts, named pages, snapshot refs, one warm daemon.",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
## Summary

- release `dev-browser@1.0.0-rc.3` from `origin/main` after the iframe support merge (#140)
- ship cross-origin iframe snapshots and document-scoped frame refs to npm prerelease users
- update the package and marketplace versions and document the iframe behavior in the changelog
- keep `docs/help.md` on its existing `{{VERSION}}` source-of-truth template; the built binary resolves it to RC.3

## Validation

- `bun install --frozen-lockfile`
- `bun x tsc --noEmit`
- `bun run build`
- `bun run test` (343 passed)
- `npm pack --dry-run` (8 expected files, package version `1.0.0-rc.3`)
- `dist/dev-browser --version` → `dev-browser 1.0.0-rc.3`
- `dist/dev-browser --help | head -n 1` → `dev-browser 1.0.0-rc.3 — browser automation CLI for coding agents (Puppeteer scripts, named pages, snapshot refs)`

